### PR TITLE
exposes BackgroundFlushPeriod to public state.Parameters

### DIFF
--- a/go/carmen/database.go
+++ b/go/carmen/database.go
@@ -49,16 +49,21 @@ func openDatabase(
 	if err != nil {
 		return nil, err
 	}
+	backgroundFlushPeriod, err := properties.GetInteger(BackgroundFlushPeriod, 0)
+	if err != nil {
+		return nil, err
+	}
 
 	params := state.Parameters{
-		Directory:          directory,
-		Variant:            state.Variant(configuration.Variant),
-		Schema:             state.Schema(configuration.Schema),
-		Archive:            state.ArchiveType(configuration.Archive),
-		LiveCache:          int64(liveCache),
-		ArchiveCache:       int64(archiveCache),
-		CheckpointInterval: checkpointInterval,
-		CheckpointPeriod:   time.Duration(checkpointPeriod) * time.Minute,
+		Directory:             directory,
+		Variant:               state.Variant(configuration.Variant),
+		Schema:                state.Schema(configuration.Schema),
+		Archive:               state.ArchiveType(configuration.Archive),
+		LiveCache:             int64(liveCache),
+		ArchiveCache:          int64(archiveCache),
+		CheckpointInterval:    checkpointInterval,
+		CheckpointPeriod:      time.Duration(checkpointPeriod) * time.Minute,
+		BackgroundFlushPeriod: time.Duration(backgroundFlushPeriod) * time.Second,
 	}
 	db, err := state.NewState(params)
 	if err != nil {

--- a/go/carmen/property.go
+++ b/go/carmen/property.go
@@ -41,6 +41,8 @@ const (
 	CheckpointInterval = Property("CheckpointInterval")
 	// CheckpointPeriod determines how often (in minutes) an Archive creates checkpoints.
 	CheckpointPeriod = Property("CheckpointPeriod")
+	// BackgroundFlushPeriod sets the time in seconds between background flushes; a default is chosen if zero, disabled if negative
+	BackgroundFlushPeriod = Property("BackgroundFlushPeriod")
 )
 
 // Properties are optional settings which may influence the

--- a/go/state/configurations.go
+++ b/go/state/configurations.go
@@ -24,14 +24,15 @@ import (
 
 // Parameters struct defining configuration parameters for state instances.
 type Parameters struct {
-	Variant            Variant
-	Schema             Schema
-	Archive            ArchiveType
-	Directory          string
-	LiveCache          int64 // bytes, approximate, supported only by S5 now
-	ArchiveCache       int64 // bytes, approximate, supported only by S5 now
-	CheckpointInterval int   // in blocks
-	CheckpointPeriod   time.Duration
+	Variant               Variant
+	Schema                Schema
+	Archive               ArchiveType
+	Directory             string
+	LiveCache             int64 // bytes, approximate, supported only by S5 now
+	ArchiveCache          int64 // bytes, approximate, supported only by S5 now
+	CheckpointInterval    int   // in blocks
+	CheckpointPeriod      time.Duration
+	BackgroundFlushPeriod time.Duration // the time between background flushes; a default is chosen if zero, disabled if negative
 }
 
 const (

--- a/go/state/flush_benchmark_test.go
+++ b/go/state/flush_benchmark_test.go
@@ -13,6 +13,7 @@ package state
 import (
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/common/amount"
+	"time"
 
 	"testing"
 )
@@ -54,5 +55,57 @@ func BenchmarkFlushGoState(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
+	}
+}
+
+// Run, for example, with:
+// go test . -cpuprofile=cpu.prof -run none -bench Benchmark_Long_vs_Short_Flush_Period/short  --benchtime 10s
+// go test . -cpuprofile=cpu.prof -run none -bench Benchmark_Long_vs_Short_Flush_Period/long  --benchtime 10s
+// and observe CPU time consumed by 'tryFlushDirtyNodes'
+func Benchmark_Long_vs_Short_Flush_Period(b *testing.B) {
+	tests := map[string]struct {
+		period time.Duration
+	}{
+		"short": {time.Millisecond},
+		"long":  {time.Second},
+	}
+
+	for name, config := range tests {
+		b.Run(name, func(b *testing.B) {
+
+			parameters := Parameters{
+				Variant:               "go-file",
+				Schema:                5,
+				Archive:               NoArchive,
+				BackgroundFlushPeriod: config.period,
+			}
+
+			s, err := NewState(parameters)
+			if err != nil {
+				b.Fatalf("failed to initialize state %s; %s", name, err)
+			}
+			db := CreateStateDBUsing(s)
+
+			db.BeginBlock()
+			db.BeginTransaction()
+
+			// Create accounts.
+			for i := 0; i < b.N; i++ {
+				addr := common.Address{byte(i), byte(i >> 8), byte(i >> 16), byte(i >> 24)}
+				db.CreateAccount(addr)
+				db.SetNonce(addr, 12)
+			}
+
+			db.EndTransaction()
+			db.EndBlock(12)
+
+			if err := db.Check(); err != nil {
+				b.Errorf("update failed with unexpected error: %v", err)
+			}
+
+			if err := db.Close(); err != nil {
+				b.Errorf("failed to close DB: %v", err)
+			}
+		})
 	}
 }

--- a/go/state/flush_benchmark_test.go
+++ b/go/state/flush_benchmark_test.go
@@ -77,6 +77,7 @@ func Benchmark_Long_vs_Short_Flush_Period(b *testing.B) {
 				Variant:               "go-file",
 				Schema:                5,
 				Archive:               NoArchive,
+				LiveCache:             1 << 29, // 0.5 GB
 				BackgroundFlushPeriod: config.period,
 			}
 

--- a/go/state/gostate/configurations.go
+++ b/go/state/gostate/configurations.go
@@ -938,7 +938,7 @@ func openArchive(params state.Parameters) (archive archive.Archive, cleanup func
 		if err != nil {
 			return nil, nil, err
 		}
-		arch, err := mpt.OpenArchiveTrie(path, mpt.S4ArchiveConfig, getNodeCacheConfig(params.ArchiveCache), mpt.ArchiveConfig{
+		arch, err := mpt.OpenArchiveTrie(path, mpt.S4ArchiveConfig, getNodeCacheConfig(params.ArchiveCache, params.BackgroundFlushPeriod), mpt.ArchiveConfig{
 			CheckpointInterval: params.CheckpointInterval,
 			CheckpointPeriod:   params.CheckpointPeriod,
 		})
@@ -949,7 +949,7 @@ func openArchive(params state.Parameters) (archive archive.Archive, cleanup func
 		if err != nil {
 			return nil, nil, err
 		}
-		arch, err := mpt.OpenArchiveTrie(path, mpt.S5ArchiveConfig, getNodeCacheConfig(params.ArchiveCache), mpt.ArchiveConfig{
+		arch, err := mpt.OpenArchiveTrie(path, mpt.S5ArchiveConfig, getNodeCacheConfig(params.ArchiveCache, params.BackgroundFlushPeriod), mpt.ArchiveConfig{
 			CheckpointInterval: params.CheckpointInterval,
 			CheckpointPeriod:   params.CheckpointPeriod,
 		})

--- a/go/state/gostate/go_schema5_test.go
+++ b/go/state/gostate/go_schema5_test.go
@@ -12,6 +12,7 @@ package gostate
 
 import (
 	"testing"
+	"time"
 
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/common/amount"
@@ -164,10 +165,18 @@ func TestGetNodeCacheConfig(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			cfg := getNodeCacheConfig(test.cacheSize)
+			cfg := getNodeCacheConfig(test.cacheSize, 0)
 			if cfg.Capacity != test.capacity {
 				t.Errorf("unexpected capacity: %d != %d", cfg.Capacity, test.capacity)
 			}
 		})
+	}
+}
+
+func TestGetNodeCacheConfig_BackgroundFlushPeriod(t *testing.T) {
+	const expected = 123 * time.Second
+
+	if got, want := getNodeCacheConfig(0, expected).BackgroundFlushPeriod, expected; got != want {
+		t.Errorf("unexpected background flush period: %v != %v", got, want)
 	}
 }

--- a/go/state/stress_test.go
+++ b/go/state/stress_test.go
@@ -14,11 +14,9 @@
 package state_test
 
 import (
-	"testing"
-	"time"
-
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/state"
+	"testing"
 )
 
 func TestStress_CanHandleLargeBlock(t *testing.T) {
@@ -121,56 +119,6 @@ func TestStress_CanHandleDeleteOfLargeAccount(t *testing.T) {
 			db.EndTransaction()
 			db.EndBlock(block)
 			block++
-
-			if err := db.Check(); err != nil {
-				t.Errorf("update failed with unexpected error: %v", err)
-			}
-
-			if err := db.Close(); err != nil {
-				t.Errorf("failed to close DB: %v", err)
-			}
-		})
-	}
-}
-
-func TestStress_Long_vs_Short_Flush_Period(t *testing.T) {
-	const N = 1_000_000 // the number of changes in a single block
-
-	tests := map[string]struct {
-		period time.Duration
-	}{
-		"short": {time.Millisecond},
-		"long":  {time.Second},
-	}
-
-	for name, config := range tests {
-		t.Run(name, func(t *testing.T) {
-
-			parameters := state.Parameters{
-				Variant:               "go-file",
-				Schema:                5,
-				Archive:               state.NoArchive,
-				BackgroundFlushPeriod: config.period,
-			}
-
-			s, err := state.NewState(parameters)
-			if err != nil {
-				t.Fatalf("failed to initialize state %s; %s", name, err)
-			}
-			db := state.CreateStateDBUsing(s)
-
-			db.BeginBlock()
-			db.BeginTransaction()
-
-			// Create a lot of accounts.
-			for i := 0; i < N; i++ {
-				addr := common.Address{byte(i), byte(i >> 8), byte(i >> 16), byte(i >> 24)}
-				db.CreateAccount(addr)
-				db.SetNonce(addr, 12)
-			}
-
-			db.EndTransaction()
-			db.EndBlock(12)
 
 			if err := db.Check(); err != nil {
 				t.Errorf("update failed with unexpected error: %v", err)


### PR DESCRIPTION
This PR exposes `BackgroundFlushPeriod` to public `state.Properties`. It allows for configuring frequency of flushing cached data to disk from clients. 

Experiment was conducted with two flush periods configured:
* short - nodes flushed every millisecond 
* long - nodes flushed every second

A stress test was added into the source code.

Results:

* **Short** period:
```
 go test . -cpuprofile=cpu.prof  -v  -tags stress_test -run TestStress_Long_vs_Short_Flush_Period/short
```

<img width="2560" alt="image" src="https://github.com/user-attachments/assets/3e3e22bb-fbb3-4341-8b57-c6ca6711f3be" />


* **Long** period:
```
 go test . -cpuprofile=cpu.prof  -v  -tags stress_test -run TestStress_Long_vs_Short_Flush_Period/long
```
 
<img width="2560" alt="image" src="https://github.com/user-attachments/assets/a28f3b21-30b4-4e96-9817-d838ac5665f7" />
