### PR TITLE
Add total-supply calculation tool

### DIFF
--- a/go/database/mpt/io/total_supply.go
+++ b/go/database/mpt/io/total_supply.go
@@ -1,0 +1,122 @@
+package io
+
+import (
+	"context"
+	"fmt"
+	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/0xsoniclabs/carmen/go/common/interrupt"
+	"github.com/0xsoniclabs/carmen/go/database/mpt"
+	"github.com/holiman/uint256"
+)
+
+func CalculateLiveTotalSupply(ctx context.Context, logger *Log, directory string) error {
+	info, err := CheckMptDirectoryAndGetInfo(directory)
+	if err != nil {
+		return fmt.Errorf("error in input directory: %v", err)
+	}
+
+	if info.Config.Name != mpt.S5LiveConfig.Name {
+		return fmt.Errorf("can only support export of LiveDB instances, found %v in directory", info.Mode)
+	}
+
+	mptState, err := mpt.OpenGoFileState(directory, info.Config, mpt.NodeCacheConfig{Capacity: exportCacheCapacitySize})
+	if err != nil {
+		return fmt.Errorf("failed to open LiveDB: %v", err)
+	}
+	defer mptState.Close()
+
+	hash, err := mptState.GetHash()
+	if err != nil {
+		return fmt.Errorf("failed to get state root: %v", err)
+	}
+
+	zeroBalanceAmount, err := mptState.GetBalance(common.Address{})
+	if err != nil {
+		return fmt.Errorf("failed to get balance of zero address: %w", err)
+	}
+	zeroBalance := zeroBalanceAmount.Uint256()
+
+	logger.Printf("Calculating total supply...")
+	progress := logger.NewProgressTracker("visited %d accounts, %.2f accounts/s", 1_000_000)
+	db := &exportableLiveTrie{db: mptState, directory: directory}
+	visitor := totalSupplyCalculatingVisitor{ctx: ctx, progress: progress}
+	if err := db.Visit(&visitor, true); err != nil {
+		return fmt.Errorf("failed visiting content: %v", err)
+	}
+
+	logger.Printf("Calculated for: %s", directory)
+	logger.Printf("State Root:     %x", hash)
+	logger.Printf("Accounts count: %d", visitor.accounts)
+	logger.Printf("Total supply:   %s", visitor.totalSupply.Dec())
+	logger.Printf("Zero address:   %s", zeroBalance.Dec())
+	diff := new(uint256.Int).Sub(&visitor.totalSupply, &zeroBalance)
+	logger.Printf("Total - Zero:   %s", diff.Dec())
+	return nil
+}
+
+func CalculateArchiveTotalSupply(ctx context.Context, logger *Log, directory string, block uint64) error {
+	info, err := CheckMptDirectoryAndGetInfo(directory)
+	if err != nil {
+		return fmt.Errorf("error in input directory: %v", err)
+	}
+
+	if info.Config.Name != mpt.S5ArchiveConfig.Name {
+		return fmt.Errorf("can only support export of S5 Archive instances, found %v in directory", info.Config.Name)
+	}
+
+	archive, err := mpt.OpenArchiveTrie(directory, info.Config, mpt.NodeCacheConfig{Capacity: exportCacheCapacitySize}, mpt.ArchiveConfig{})
+	if err != nil {
+		return err
+	}
+	defer archive.Close()
+
+	hash, err := archive.GetHash(block)
+	if err != nil {
+		return fmt.Errorf("failed to get state root: %w", err)
+	}
+
+	zeroBalanceAmount, err := archive.GetBalance(block, common.Address{})
+	if err != nil {
+		return fmt.Errorf("failed to get balance of zero address: %w", err)
+	}
+	zeroBalance := zeroBalanceAmount.Uint256()
+
+	logger.Printf("Calculating total supply...")
+	progress := logger.NewProgressTracker("visited %d accounts, %.2f accounts/s", 1_000_000)
+	db := exportableArchiveTrie{trie: archive, block: block}
+	visitor := totalSupplyCalculatingVisitor{ctx: ctx, progress: progress}
+	if err := db.Visit(&visitor, false); err != nil {
+		return fmt.Errorf("failed visiting content: %v", err)
+	}
+
+	logger.Printf("Calculated for: %s", directory)
+	logger.Printf("Block Number:   %d", block)
+	logger.Printf("State Root:     %x", hash)
+	logger.Printf("Accounts count: %d", visitor.accounts)
+	logger.Printf("Total supply:   %s", visitor.totalSupply.Dec())
+	logger.Printf("Zero address:   %s", zeroBalance.Dec())
+	diff := new(uint256.Int).Sub(&visitor.totalSupply, &zeroBalance)
+	logger.Printf("Total - Zero:   %s", diff.Dec())
+	return err
+}
+
+type totalSupplyCalculatingVisitor struct {
+	ctx         context.Context
+	progress    *ProgressLogger
+	totalSupply uint256.Int
+	accounts    uint64
+}
+
+func (e *totalSupplyCalculatingVisitor) Visit(node mpt.Node, _ mpt.NodeInfo) error {
+	// outside call to interrupt
+	if interrupt.IsCancelled(e.ctx) {
+		return interrupt.ErrCanceled
+	}
+	if n, ok := node.(*mpt.AccountNode); ok {
+		balance := n.Info().Balance.Uint256()
+		e.totalSupply.Add(&e.totalSupply, &balance)
+		e.accounts++
+		e.progress.Step(1)
+	}
+	return nil
+}

--- a/go/database/mpt/tool/main.go
+++ b/go/database/mpt/tool/main.go
@@ -68,6 +68,7 @@ func main() {
 			&Block,
 			&StressTestCmd,
 			&Reset,
+			&TotalSupplyCmd,
 		},
 	}
 

--- a/go/database/mpt/tool/total_supply.go
+++ b/go/database/mpt/tool/total_supply.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"github.com/0xsoniclabs/carmen/go/common/interrupt"
+	"github.com/0xsoniclabs/carmen/go/database/mpt"
+	"github.com/0xsoniclabs/carmen/go/database/mpt/io"
+	"github.com/urfave/cli/v2"
+)
+
+var TotalSupplyCmd = cli.Command{
+	Action:    doTotalSupplyCalc,
+	Name:      "total-supply",
+	Usage:     "calculate total supply of native tokens in the state",
+	ArgsUsage: "<db director>",
+	Flags: []cli.Flag{
+		&targetBlockFlag,
+	},
+}
+
+func doTotalSupplyCalc(context *cli.Context) error {
+	if context.Args().Len() != 1 {
+		return fmt.Errorf("missing state directory parameter")
+	}
+	dir := context.Args().Get(0)
+
+	// check the type of target database
+	mptInfo, err := io.CheckMptDirectoryAndGetInfo(dir)
+	if err != nil {
+		return err
+	}
+
+	logger := io.NewLog()
+
+	ctx := interrupt.CancelOnInterrupt(context.Context)
+
+	if mptInfo.Mode == mpt.Immutable {
+		if !context.IsSet(targetBlockFlag.Name) {
+			return fmt.Errorf("you need to specify --%s for archive", targetBlockFlag.Name)
+		}
+		// Passed Archive and chosen block
+		blkNumber := context.Uint64(targetBlockFlag.Name)
+		return io.CalculateArchiveTotalSupply(ctx, logger, dir, blkNumber)
+	} else {
+		// Passed LiveDB
+		return io.CalculateLiveTotalSupply(ctx, logger, dir)
+	}
+}


### PR DESCRIPTION
Add tool which allows to analyze total supply of native tokens in the state.

```
./tool total-supply --block 14238489 /var/sonic/carmen/archive
2025/03/20 11:53:13 [t=   0:00] - Calculating total supply...
2025/03/20 11:54:01 [t=   0:48] - visited 1000000 accounts, 20792.95 accounts/s
2025/03/20 11:54:13 [t=   1:00] - Calculated for: /var/sonic/carmen/archive
2025/03/20 11:54:13 [t=   1:00] - Block Number:   14238489
2025/03/20 11:54:13 [t=   1:00] - State Root:     8484e6b2700d93039ea95d8f9c80648359946cc4f11ff1c503b3b9ff9405af2e
2025/03/20 11:54:13 [t=   1:00] - Accounts count: 1278336
2025/03/20 11:54:13 [t=   1:00] - Total supply:   3763730783169283929813104651
2025/03/20 11:54:13 [t=   1:00] - Zero address:   400011344505743181610968087
2025/03/20 11:54:13 [t=   1:00] - Total - Zero:   3363719438663540748202136564
```