### PR TITLE
adds diagnostic port to benchmark

### DIFF
--- a/go/database/mpt/tool/benchmark.go
+++ b/go/database/mpt/tool/benchmark.go
@@ -41,6 +41,7 @@ var Benchmark = cli.Command{
 		&tmpDirFlag,
 		&keepStateFlag,
 		&cpuProfileFlag,
+		&diagnosticsFlag,
 	},
 }
 


### PR DESCRIPTION
This PR adds diagnostic server to the benchmark tool. 