### PR TITLE
Partially implement HasEmptyStorage for S3

### DIFF
--- a/go/state/cppstate/cpp_state.go
+++ b/go/state/cppstate/cpp_state.go
@@ -290,7 +290,8 @@ func (cs *CppState) CreateWitnessProof(address common.Address, keys ...common.Ke
 
 func (cs *CppState) HasEmptyStorage(addr common.Address) (bool, error) {
 	// S3 schema is based on directly indexed files without ability to iterate
-	// over a dataset. For this reason, this method is implemented as purely returning a constant value all the time.
+	// over a dataset. For this reason, this method is implemented as purely
+	// returning a constant value all the time.
 	return true, nil
 }
 

--- a/go/state/cppstate/cpp_state.go
+++ b/go/state/cppstate/cpp_state.go
@@ -289,7 +289,9 @@ func (cs *CppState) CreateWitnessProof(address common.Address, keys ...common.Ke
 }
 
 func (cs *CppState) HasEmptyStorage(addr common.Address) (bool, error) {
-	panic("CppState does not support HasEmptyStorage operation")
+	// S3 schema is based on directly indexed files without ability to iterate
+	// over a dataset. For this reason, this method is implemented as purely returning a constant value all the time.
+	return true, nil
 }
 
 func (cs *CppState) Export(context.Context, io.Writer) (common.Hash, error) {

--- a/go/state/gostate/go_schema3.go
+++ b/go/state/gostate/go_schema3.go
@@ -253,7 +253,8 @@ func (s *GoSchema3) GetCodeHash(address common.Address) (hash common.Hash, err e
 
 func (s *GoSchema3) HasEmptyStorage(addr common.Address) (bool, error) {
 	// S3 schema is based on directly indexed files without ability to iterate
-	// over a dataset. For this reason, this method is implemented as purely returning a constant value all the time.
+	// over a dataset. For this reason, this method is implemented as purely
+	// returning a constant value all the time.
 	return true, nil
 }
 

--- a/go/state/gostate/go_schema3.go
+++ b/go/state/gostate/go_schema3.go
@@ -252,7 +252,9 @@ func (s *GoSchema3) GetCodeHash(address common.Address) (hash common.Hash, err e
 }
 
 func (s *GoSchema3) HasEmptyStorage(addr common.Address) (bool, error) {
-	panic("HasEmptyStorage is not implemented for Scheme3")
+	// S3 schema is based on directly indexed files without ability to iterate
+	// over a dataset. For this reason, this method is implemented as purely returning a constant value all the time.
+	return true, nil
 }
 
 func (s *GoSchema3) GetHash() (hash common.Hash, err error) {

--- a/go/state/state_test.go
+++ b/go/state/state_test.go
@@ -1085,8 +1085,8 @@ func TestS3_HasEmptyStorage(t *testing.T) {
 			}
 		})
 	}
-
 }
+
 func execSubProcessTest(t *testing.T, dir string, stateImpl string, execTestName string) {
 	path, err := os.Executable()
 	if err != nil {
@@ -1107,7 +1107,6 @@ func execSubProcessTest(t *testing.T, dir string, stateImpl string, execTestName
 // createState creates a state with the given name and directory
 func createState(t *testing.T, name, dir string) state.State {
 	for _, config := range initStates() {
-		fmt.Println(config.name())
 		if config.name() == name {
 			state, err := config.createState(dir)
 			if err != nil {

--- a/go/state/state_test.go
+++ b/go/state/state_test.go
@@ -965,17 +965,17 @@ func TestStateRead(t *testing.T) {
 }
 
 func TestHasEmptyStorage_S3_Always_Returns_True(t *testing.T) {
-	updates := map[string]common.Update{
-		"fresh-account": {
+	updates := []common.Update{
+		{
 			CreatedAccounts: []common.Address{address1},
 		},
-		"account-with-empty-storage": {
+		{
 			Slots: []common.SlotUpdate{{Account: address1, Key: key1, Value: val0}},
 		},
-		"account-with-non_empty-storage": {
+		{
 			Slots: []common.SlotUpdate{{Account: address1, Key: key1, Value: val1}},
 		},
-		"deleted-account": {
+		{
 			DeletedAccounts: []common.Address{address1},
 		},
 	}
@@ -986,25 +986,22 @@ func TestHasEmptyStorage_S3_Always_Returns_True(t *testing.T) {
 		}
 		dir := t.TempDir()
 		st, err := config.createState(dir)
-
+		if err != nil {
+			t.Fatalf("unable to create state: %v", err)
+		}
 		var idx uint64
-		for updateName, update := range updates {
-			testName := fmt.Sprintf("%s_%s", config.name(), updateName)
-			err = st.Apply(idx, update)
-			if err != nil {
+		for _, update := range updates {
+			if err = st.Apply(idx, update); err != nil {
 				t.Fatalf("failed to apply state: %v", err)
 			}
-			t.Run(testName, func(t *testing.T) {
-				isEmpty, err := st.HasEmptyStorage(address1)
-				if err != nil {
-					t.Fatalf("failed to check state: %v", err)
-				}
-				if !isEmpty {
-					t.Errorf("HasEmptyStorage should always return true")
-				}
-
-				idx++
-			})
+			isEmpty, err := st.HasEmptyStorage(address1)
+			if err != nil {
+				t.Fatalf("failed to check state: %v", err)
+			}
+			if !isEmpty {
+				t.Errorf("HasEmptyStorage should always return true")
+			}
+			idx++
 		}
 	}
 }

--- a/go/state/state_test.go
+++ b/go/state/state_test.go
@@ -965,118 +965,128 @@ func TestStateRead(t *testing.T) {
 }
 
 func TestS3_HasEmptyStorage(t *testing.T) {
-	dir := t.TempDir()
-	st := createState(t, "go-file_s3_none", dir)
+	for _, config := range initStates() {
+		name := config.name()
+		if !strings.Contains(name, "s3") {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			st, err := config.createState(dir)
+			if err != nil {
+				t.Fatalf("Cannot init state: %s, err: %v", name, err)
+			}
+			// check non-existent addr
+			isEmpty, err := st.HasEmptyStorage(address1)
+			if err != nil {
+				t.Fatalf("failed to check state: %v", err)
+			}
+			if !isEmpty {
+				t.Errorf("isEmpty should always be true")
+			}
 
-	// check non-existent addr
-	isEmpty, err := st.HasEmptyStorage(address1)
-	if err != nil {
-		t.Fatalf("failed to check state: %v", err)
-	}
-	if !isEmpty {
-		t.Errorf("isEmpty should always be true")
+			// create account with no storage set
+			err = st.Apply(1, common.Update{
+				CreatedAccounts: []common.Address{address1},
+			})
+			if err != nil {
+				t.Fatalf("failed to apply state: %v", err)
+			}
+
+			exists, err := st.Exists(address1)
+			if err != nil {
+				t.Fatalf("failed to check account: %v", err)
+			}
+			if !exists {
+				t.Fatal("account does not exist")
+			}
+
+			// check existing addr with empty storage
+			isEmpty, err = st.HasEmptyStorage(address1)
+			if err != nil {
+				t.Fatalf("failed to check state: %v", err)
+			}
+			if !isEmpty {
+				t.Errorf("isEmpty should always be true")
+			}
+
+			// add zero value storage to the account
+			err = st.Apply(2, common.Update{
+				Slots: []common.SlotUpdate{{Account: address1, Key: key1, Value: val0}},
+			})
+			if err != nil {
+				t.Fatalf("failed to apply state: %v", err)
+			}
+			val, err := st.GetStorage(address1, key1)
+			if err != nil {
+				t.Fatalf("failed to get storage: %v", err)
+			}
+			if val != val0 {
+				t.Fatalf("storage value does not match: %v != %v", val, val0)
+			}
+
+			// check existing acc with zero value storage
+			isEmpty, err = st.HasEmptyStorage(address1)
+			if err != nil {
+				t.Fatalf("failed to check state: %v", err)
+			}
+			if !isEmpty {
+				t.Errorf("isEmpty should always be true")
+			}
+
+			// overwrite the storage key with an existing value
+			err = st.Apply(3, common.Update{
+				Slots: []common.SlotUpdate{{Account: address1, Key: key1, Value: val1}},
+			})
+			if err != nil {
+				t.Fatalf("failed to apply state: %v", err)
+			}
+			val, err = st.GetStorage(address1, key1)
+			if err != nil {
+				t.Fatalf("failed to get storage: %v", err)
+			}
+			if val != val1 {
+				t.Fatalf("storage value does not match: %v != %v", val, val1)
+			}
+
+			// check existing acc with non-empty storage
+			isEmpty, err = st.HasEmptyStorage(address1)
+			if err != nil {
+				t.Fatalf("failed to check state: %v", err)
+			}
+			if !isEmpty {
+				t.Errorf("isEmpty should always be true")
+			}
+
+			// delete the acc
+			err = st.Apply(4, common.Update{
+				DeletedAccounts: []common.Address{address1},
+			})
+			if err != nil {
+				t.Fatalf("failed to apply state: %v", err)
+			}
+
+			// check deleted acc
+			exists, err = st.Exists(address1)
+			if err != nil {
+				t.Fatalf("failed to check account: %v", err)
+			}
+			if exists {
+				t.Fatal("account should not exist")
+			}
+
+			// check deleted acc
+			isEmpty, err = st.HasEmptyStorage(address1)
+			if err != nil {
+				t.Fatalf("failed to check state: %v", err)
+			}
+			if !isEmpty {
+				t.Errorf("isEmpty should always be true")
+			}
+		})
 	}
 
-	// create account with no storage set
-	err = st.Apply(1, common.Update{
-		CreatedAccounts: []common.Address{address1},
-	})
-	if err != nil {
-		t.Fatalf("failed to apply state: %v", err)
-	}
-
-	exists, err := st.Exists(address1)
-	if err != nil {
-		t.Fatalf("failed to check account: %v", err)
-	}
-	if !exists {
-		t.Fatal("account does not exist")
-	}
-
-	// check existing addr with empty storage
-	isEmpty, err = st.HasEmptyStorage(address1)
-	if err != nil {
-		t.Fatalf("failed to check state: %v", err)
-	}
-	if !isEmpty {
-		t.Errorf("isEmpty should always be true")
-	}
-
-	// add zero value storage to the account
-	err = st.Apply(1, common.Update{
-		Slots: []common.SlotUpdate{{Account: address1, Key: key1, Value: val0}},
-	})
-	if err != nil {
-		t.Fatalf("failed to apply state: %v", err)
-	}
-	val, err := st.GetStorage(address1, key1)
-	if err != nil {
-		t.Fatalf("failed to get storage: %v", err)
-	}
-	if val != val0 {
-		t.Fatalf("storage value does not match: %v != %v", val, val0)
-	}
-
-	// check existing acc with zero value storage
-	isEmpty, err = st.HasEmptyStorage(address1)
-	if err != nil {
-		t.Fatalf("failed to check state: %v", err)
-	}
-	if !isEmpty {
-		t.Errorf("isEmpty should always be true")
-	}
-
-	// overwrite the storage key with an existing value
-	err = st.Apply(2, common.Update{
-		Slots: []common.SlotUpdate{{Account: address1, Key: key1, Value: val1}},
-	})
-	if err != nil {
-		t.Fatalf("failed to apply state: %v", err)
-	}
-	val, err = st.GetStorage(address1, key1)
-	if err != nil {
-		t.Fatalf("failed to get storage: %v", err)
-	}
-	if val != val1 {
-		t.Fatalf("storage value does not match: %v != %v", val, val1)
-	}
-
-	// check existing acc with non-empty storage
-	isEmpty, err = st.HasEmptyStorage(address1)
-	if err != nil {
-		t.Fatalf("failed to check state: %v", err)
-	}
-	if !isEmpty {
-		t.Errorf("isEmpty should always be true")
-	}
-
-	// delete the acc
-	err = st.Apply(2, common.Update{
-		DeletedAccounts: []common.Address{address1},
-	})
-	if err != nil {
-		t.Fatalf("failed to apply state: %v", err)
-	}
-
-	// check deleted acc
-	exists, err = st.Exists(address1)
-	if err != nil {
-		t.Fatalf("failed to check account: %v", err)
-	}
-	if exists {
-		t.Fatal("account should not exist")
-	}
-
-	// check deleted acc
-	isEmpty, err = st.HasEmptyStorage(address1)
-	if err != nil {
-		t.Fatalf("failed to check state: %v", err)
-	}
-	if !isEmpty {
-		t.Errorf("isEmpty should always be true")
-	}
 }
-
 func execSubProcessTest(t *testing.T, dir string, stateImpl string, execTestName string) {
 	path, err := os.Executable()
 	if err != nil {
@@ -1097,6 +1107,7 @@ func execSubProcessTest(t *testing.T, dir string, stateImpl string, execTestName
 // createState creates a state with the given name and directory
 func createState(t *testing.T, name, dir string) state.State {
 	for _, config := range initStates() {
+		fmt.Println(config.name())
 		if config.name() == name {
 			state, err := config.createState(dir)
 			if err != nil {

--- a/go/state/state_test.go
+++ b/go/state/state_test.go
@@ -964,17 +964,16 @@ func TestStateRead(t *testing.T) {
 	}
 }
 
-func TestS3_HasEmptyStorage(t *testing.T) {
+func TestHasEmptyStorage_Always_Returns_True(t *testing.T) {
 	for _, config := range initStates() {
-		name := config.name()
-		if !strings.Contains(name, "s3") {
+		if config.config.Schema != 3 {
 			continue
 		}
-		t.Run(name, func(t *testing.T) {
+		t.Run(config.name(), func(t *testing.T) {
 			dir := t.TempDir()
 			st, err := config.createState(dir)
 			if err != nil {
-				t.Fatalf("Cannot init state: %s, err: %v", name, err)
+				t.Fatalf("cannot init state: %s, err: %v", config.name(), err)
 			}
 			// check non-existent addr
 			isEmpty, err := st.HasEmptyStorage(address1)
@@ -982,7 +981,7 @@ func TestS3_HasEmptyStorage(t *testing.T) {
 				t.Fatalf("failed to check state: %v", err)
 			}
 			if !isEmpty {
-				t.Errorf("isEmpty should always be true")
+				t.Errorf("HasEmptyStorage should always return true")
 			}
 
 			// create account with no storage set
@@ -1007,7 +1006,7 @@ func TestS3_HasEmptyStorage(t *testing.T) {
 				t.Fatalf("failed to check state: %v", err)
 			}
 			if !isEmpty {
-				t.Errorf("isEmpty should always be true")
+				t.Errorf("HasEmptyStorage should always return true")
 			}
 
 			// add zero value storage to the account
@@ -1031,7 +1030,7 @@ func TestS3_HasEmptyStorage(t *testing.T) {
 				t.Fatalf("failed to check state: %v", err)
 			}
 			if !isEmpty {
-				t.Errorf("isEmpty should always be true")
+				t.Errorf("HasEmptyStorage should always return true")
 			}
 
 			// overwrite the storage key with an existing value
@@ -1055,7 +1054,7 @@ func TestS3_HasEmptyStorage(t *testing.T) {
 				t.Fatalf("failed to check state: %v", err)
 			}
 			if !isEmpty {
-				t.Errorf("isEmpty should always be true")
+				t.Errorf("HasEmptyStorage should always return true")
 			}
 
 			// delete the acc
@@ -1081,7 +1080,7 @@ func TestS3_HasEmptyStorage(t *testing.T) {
 				t.Fatalf("failed to check state: %v", err)
 			}
 			if !isEmpty {
-				t.Errorf("isEmpty should always be true")
+				t.Errorf("HasEmptyStorage should always return true")
 			}
 		})
 	}

--- a/go/state/state_test.go
+++ b/go/state/state_test.go
@@ -989,9 +989,8 @@ func TestHasEmptyStorage_S3_Always_Returns_True(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unable to create state: %v", err)
 		}
-		var idx uint64
-		for _, update := range updates {
-			if err = st.Apply(idx, update); err != nil {
+		for i, update := range updates {
+			if err = st.Apply(uint64(i), update); err != nil {
 				t.Fatalf("failed to apply state: %v", err)
 			}
 			isEmpty, err := st.HasEmptyStorage(address1)
@@ -1001,7 +1000,6 @@ func TestHasEmptyStorage_S3_Always_Returns_True(t *testing.T) {
 			if !isEmpty {
 				t.Errorf("HasEmptyStorage should always return true")
 			}
-			idx++
 		}
 	}
 }

--- a/go/state/state_test.go
+++ b/go/state/state_test.go
@@ -964,7 +964,7 @@ func TestStateRead(t *testing.T) {
 	}
 }
 
-func TestHasEmptyStorage_Always_Returns_True(t *testing.T) {
+func TestHasEmptyStorage_S3_Always_Returns_True(t *testing.T) {
 	updates := map[string]common.Update{
 		"fresh-account": {
 			CreatedAccounts: []common.Address{address1},


### PR DESCRIPTION
This PR partially implements `HasEmptyStorage` method for `GoStateS3` and `CppState`.

S3 schema does not allow for iterating over a dataset. This makes it hard to correctly assess if the storage is really empty. For this reason, this PR makes the method always return `true`. 

This method was implemented for compatibility with Ethereum to prevent creation of accounts under certain conditions. These conditions are not effective in Sonic/Fantom chain, and for this reason, the method always pretends the storage is empty. 