### PR TITLE
makes consistent zero hashes and hash of zeros for witness proof

### DIFF
--- a/go/carmen/proof.go
+++ b/go/carmen/proof.go
@@ -71,13 +71,13 @@ type WitnessProof interface {
 
 	// GetNonce extracts a nonce from the witness proof for the input root hash and the address.
 	// If the witness proof contains the account for the input address, it returns its nonce.
-	// If the proof does not contain the account, it returns false.
+	// If the proof cannot prove the account, it returns false.
 	// The method may return an error if the proof is invalid.
 	GetNonce(root Hash, address Address) (uint64, bool, error)
 
 	// GetCodeHash extracts a code hash from the witness proof for the input root hash and the address.
 	// If the witness proof contains the account for the input address, it returns its code hash.
-	// If the proof does not contain the account, it returns false.
+	// If the proof cannot prove the account, it returns false.
 	// The method may return an error if the proof is invalid.
 	GetCodeHash(root Hash, address Address) (Hash, bool, error)
 

--- a/go/common/witness/proof.go
+++ b/go/common/witness/proof.go
@@ -61,13 +61,13 @@ type Proof interface {
 
 	// GetNonce extracts a nonce from the witness proof for the input root hash and the address.
 	// If the witness proof contains the account for the input address, it returns its nonce.
-	// If the proof does not contain the account, it returns false.
+	// If the proof cannot prove the account, it returns false.
 	// The method may return an error if the proof is invalid.
 	GetNonce(root common.Hash, address common.Address) (common.Nonce, bool, error)
 
 	// GetCodeHash extracts a code hash from the witness proof for the input root hash and the address.
 	// If the witness proof contains the account for the input address, it returns its code hash.
-	// If the proof does not contain the account, it returns false.
+	// If the proof cannot prove the account, it returns false.
 	// The method may return an error if the proof is invalid.
 	GetCodeHash(root common.Hash, address common.Address) (common.Hash, bool, error)
 

--- a/go/database/mpt/hasher.go
+++ b/go/database/mpt/hasher.go
@@ -15,6 +15,7 @@ package mpt
 import (
 	"crypto/sha256"
 	"fmt"
+	"golang.org/x/crypto/sha3"
 	"reflect"
 	"sync"
 
@@ -247,7 +248,12 @@ func makeEthereumLikeHasher() hasher {
 type ethHasher struct{}
 
 var EmptyNodeEthereumEncoding = immutable.NewBytes(rlp.Encode(rlp.String{}))
+
+// EmptyNodeEthereumHash encodes an empty RLP node, it is a node with empty string
 var EmptyNodeEthereumHash = common.Keccak256(EmptyNodeEthereumEncoding.ToBytes())
+
+// EmptyEthereumHash is a hash of zeros
+var EmptyEthereumHash = common.GetHash(sha3.NewLegacyKeccak256(), []byte{})
 
 func (h ethHasher) updateHashes(
 	ref *NodeReference,

--- a/go/database/mpt/proof.go
+++ b/go/database/mpt/proof.go
@@ -275,7 +275,7 @@ func (p WitnessProof) GetAccountElements(root common.Hash, address common.Addres
 	if err != nil || !complete {
 		return []immutable.Bytes{}, common.Hash{}, false
 	}
-	storageHash := EmptyNodeEthereumHash
+	var storageHash common.Hash
 	if found {
 		storageHash = visitor.visitedAccount.storageHash
 	}


### PR DESCRIPTION
This PR makes consistent return values for hashes of non-empty and empty accounts in a witness proof.

It is made sure that following values are returned for `storageRoot` 
* a hash of a storage root sub-tree when the account exists, and the storage is non empty
* `Hash(Rlp(EmptyNode))` -- a hash of empty node when the account exists, and its storage is empty
* `0x00...000` -- zero values when account is empty, i.e. the proof could not find account address when creating the proof, the proof is still complete though

For `codeHash` following is assured:
* a hash of byte-code is returned when the account exists, and the code is present
* `Hash([]byte)` -- a hash of empty bytes when the account exist, and its code is not assigned. 
* `0x00..000` -- zero values when account is empty, i.e. the proof could not find account address when creating the proof, the proof is still complete though