### PR TITLE
includes stateDB in memory footprint calculation

### DIFF
--- a/go/carmen/database.go
+++ b/go/carmen/database.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"sync"
 	"time"
+	"unsafe"
 
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/state"
@@ -174,7 +175,10 @@ func (db *database) QueryBlock(block uint64, run func(HistoricBlockContext) erro
 }
 
 func (db *database) GetMemoryFootprint() MemoryFootprint {
-	return newMemoryFootprint(db.db.GetMemoryFootprint())
+	fp := common.NewMemoryFootprint(unsafe.Sizeof(*db))
+	fp.AddChild("liveState", db.state.GetMemoryFootprint())
+	fp.AddChild("database", db.db.GetMemoryFootprint())
+	return newMemoryFootprint(fp)
 }
 
 func (db *database) GetArchiveBlockHeight() (int64, error) {

--- a/go/carmen/database_test.go
+++ b/go/carmen/database_test.go
@@ -2294,12 +2294,14 @@ func TestDatabase_ArchiveCanBeAccessedAsync(t *testing.T) {
 
 func TestDatabase_GetMemoryFootprint(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	state := state.NewMockState(ctrl)
+	store := state.NewMockState(ctrl)
 
-	state.EXPECT().GetMemoryFootprint()
+	store.EXPECT().GetMemoryFootprint()
+	st := state.CreateStateDBUsing(store)
 
 	db := &database{
-		db: state,
+		db:    store,
+		state: st,
 	}
 
 	db.GetMemoryFootprint()

--- a/go/carmen/memory_footprint_test.go
+++ b/go/carmen/memory_footprint_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 )
 
-func TestMemoryFootprint(t *testing.T) {
+func TestMemoryFootprint_Contains_Data(t *testing.T) {
 	db, err := openTestDatabase(t)
 	if err != nil {
 		t.Fatalf("cannot open test database: %v", err)
@@ -36,4 +36,9 @@ func TestMemoryFootprint(t *testing.T) {
 	if !strings.Contains(s, "archive") {
 		t.Error("memory-footprint breakdown does not contain 'archive' keyword even though database contains Archive")
 	}
+
+	if !strings.Contains(s, "liveState") {
+		t.Error("memory-footprint breakdown does not contain 'liveState' keyword for live database")
+	}
+
 }

--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -1325,10 +1325,10 @@ func (s *stateDB) GetMemoryFootprint() *common.MemoryFootprint {
 	const addressSize = 20
 	const keySize = 32
 	const hashSize = 32
+	const valueSize = 32
 	const slotIdSize = addressSize + keySize
 
 	mf := common.NewMemoryFootprint(unsafe.Sizeof(*s))
-	mf.AddChild("state", s.state.GetMemoryFootprint())
 
 	// For account-states, balances, and nonces an over-approximation should be sufficient.
 	mf.AddChild("accounts", common.NewMemoryFootprint(uintptr(len(s.accounts))*(addressSize+unsafe.Sizeof(accountState{})+unsafe.Sizeof(common.AccountState(0)))))
@@ -1336,7 +1336,7 @@ func (s *stateDB) GetMemoryFootprint() *common.MemoryFootprint {
 	mf.AddChild("nonces", common.NewMemoryFootprint(uintptr(len(s.nonces))*(addressSize+unsafe.Sizeof(nonceValue{})+8)))
 	mf.AddChild("slots", common.NewMemoryFootprint(uintptr(s.data.Size())*(slotIdSize+unsafe.Sizeof(slotValue{}))))
 
-	var sum uintptr = 0
+	var sum uintptr
 	for _, value := range s.codes {
 		sum += addressSize
 		if value.hash != nil {
@@ -1354,6 +1354,23 @@ func (s *stateDB) GetMemoryFootprint() *common.MemoryFootprint {
 	mf.AddChild("storedDataCache", s.storedDataCache.GetMemoryFootprint(0))
 	mf.AddChild("reincarnation", common.NewMemoryFootprint(uintptr(len(s.reincarnation))*(addressSize+unsafe.Sizeof(uint64(0)))))
 	mf.AddChild("emptyCandidates", common.NewMemoryFootprint(uintptr(len(s.emptyCandidates))*(addressSize)))
+
+	mf.AddChild("transientStorage", common.NewMemoryFootprint(uintptr(s.transientStorage.Size())*(slotIdSize+valueSize)))
+	mf.AddChild("accountsToDelete", common.NewMemoryFootprint(uintptr(len(s.accountsToDelete))*(addressSize)))
+	mf.AddChild("clearedAccounts", common.NewMemoryFootprint(uintptr(len(s.clearedAccounts))*(addressSize+unsafe.Sizeof(accountClearingState(0)))))
+	mf.AddChild("createdContracts", common.NewMemoryFootprint(uintptr(len(s.createdContracts))*(addressSize)))
+
+	var logSize uintptr
+	for _, log := range s.logs {
+		logSize += unsafe.Sizeof(log) + uintptr(len(log.Topics))*hashSize + uintptr(len(log.Data))
+	}
+	mf.AddChild("logs", common.NewMemoryFootprint(logSize))
+
+	var errsSize uintptr
+	for _, err := range s.errors {
+		errsSize += unsafe.Sizeof(err) + uintptr(len(err.Error())) // Approximate size of the error message
+	}
+	mf.AddChild("errors", common.NewMemoryFootprint(errsSize))
 
 	return mf
 }

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -14,12 +14,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"reflect"
-	"testing"
-
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/common/amount"
 	"go.uber.org/mock/gomock"
+	"reflect"
+	"testing"
 )
 
 var (
@@ -4070,7 +4069,6 @@ func TestStateDB_GetMemoryFootprintIsReturnedAndNotZero(t *testing.T) {
 	mock.EXPECT().GetBalance(address1).Return(amount.New(10), nil)
 	mock.EXPECT().GetCode(address1).Return([]byte{1, 2, 3}, nil)
 	mock.EXPECT().GetCodeHash(address1).Return(common.Hash{3, 2, 1}, nil)
-	mock.EXPECT().GetMemoryFootprint().Return(common.NewMemoryFootprint(12))
 
 	// Make sure that there is some data in the caches.
 	db.AddBalance(address1, amount.New(12))
@@ -4090,7 +4088,6 @@ func TestStateDB_GetMemoryFootprintIsReturnedAndNotZero(t *testing.T) {
 		name       string
 		mayBeEmpty bool
 	}{
-		{"state", false},
 		{"accounts", false},
 		{"balances", false},
 		{"nonces", false},
@@ -4102,6 +4099,12 @@ func TestStateDB_GetMemoryFootprintIsReturnedAndNotZero(t *testing.T) {
 		{"storedDataCache", false},
 		{"reincarnation", true},
 		{"emptyCandidates", false},
+		{"transientStorage", true},
+		{"accountsToDelete", true},
+		{"clearedAccounts", true},
+		{"createdContracts", true},
+		{"logs", true},
+		{"errors", true},
 	}
 
 	for _, component := range components {


### PR DESCRIPTION
this PR updates implementation of memory footprint of the top-level API to include `stateDB` object.

Previously it produced only `state`  (underlaying database layer) footprint as it was ment that the `stateDB` contains only temporal data. It turns out that some objects are long living, and there may be potentially bugs causing some of the elements to grow.

For this reason, it was extended to include this data in the memory footprint. 

Furthermore, `stateDB` was extended to include all its fields in the memory footprint. Although most of the fields do not live only for the duration of one block, a possible bug can cause them to grow, and this needs to be captured as well.  