### PR TITLE
introduces read access visitors

### DIFF
--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -2239,7 +2239,7 @@ func TestArchiveTrie_FailingOperation_InvalidatesOtherArchiveOperations(t *testi
 	// rotate getters to start the experiment from all existing getters.
 	for i := 0; i < len(archiveOps); i++ {
 		i := i
-		t.Run(fmt.Sprintf("rotation_%d", i), func(t *testing.T) {
+		t.Run(fmt.Sprintf("rotation_%s", names[i]), func(t *testing.T) {
 			t.Parallel()
 
 			ctrl := gomock.NewController(t)

--- a/go/database/mpt/nodes.go
+++ b/go/database/mpt/nodes.go
@@ -487,7 +487,7 @@ func visitNodesWithReadAccess(source NodeSource, root *NodeReference, visitor No
 // If no more nodes are available, the execution ends.
 // The function returns an error if the tree cannot be
 // iterated due to error propagated from the node source.
-// The function accesses nodes using the Read access provided by the source.
+// The function accesses nodes using the Hash access provided by the source.
 func visitNodesWithHashAccess(source NodeManager, root *NodeReference, visitor NodeVisitor) error {
 	return visitNodes(root,
 		source.getHashAccess,

--- a/go/database/mpt/nodes_test.go
+++ b/go/database/mpt/nodes_test.go
@@ -7379,6 +7379,12 @@ func TestVisitStorage_Visits_All_Slots(t *testing.T) {
 		t.Errorf("expected at least one node, but got none")
 	}
 
+	slices.SortFunc(expected, func(a, b common.Key) int {
+		return a.Compare(&b)
+	})
+	slices.SortFunc(actual, func(a, b common.Key) int {
+		return a.Compare(&b)
+	})
 	if !slices.Equal(expected, actual) {
 		t.Errorf("unexpected visit result, wanted %v, got %v", expected, actual)
 	}

--- a/go/database/mpt/nodes_test.go
+++ b/go/database/mpt/nodes_test.go
@@ -7043,7 +7043,7 @@ func TestVisitNodes_Visits_All_Nodes(t *testing.T) {
 
 	testMethods := map[string]func(source *nodeContext, root *NodeReference, visitor NodeVisitor) error{
 		"view": func(source *nodeContext, root *NodeReference, visitor NodeVisitor) error {
-			return visitNodesWithReadAccess(source, root, visitor)
+			return visitNodesWithViewAccess(source, root, visitor)
 		},
 		"hash": func(source *nodeContext, root *NodeReference, visitor NodeVisitor) error {
 			return visitNodesWithHashAccess(source, root, visitor)
@@ -7121,7 +7121,7 @@ func TestVisitNodes_Visits_Nodes_Prune_Account(t *testing.T) {
 
 	testMethods := map[string]func(source *nodeContext, root *NodeReference, visitor NodeVisitor) error{
 		"view": func(source *nodeContext, root *NodeReference, visitor NodeVisitor) error {
-			return visitNodesWithReadAccess(source, root, visitor)
+			return visitNodesWithViewAccess(source, root, visitor)
 		},
 		"hash": func(source *nodeContext, root *NodeReference, visitor NodeVisitor) error {
 			return visitNodesWithHashAccess(source, root, visitor)
@@ -7176,7 +7176,7 @@ func TestVisitNodes_Abort_Visitor(t *testing.T) {
 
 	testMethods := map[string]func(source *nodeContext, root *NodeReference, visitor NodeVisitor) error{
 		"view": func(source *nodeContext, root *NodeReference, visitor NodeVisitor) error {
-			return visitNodesWithReadAccess(source, root, visitor)
+			return visitNodesWithViewAccess(source, root, visitor)
 		},
 		"hash": func(source *nodeContext, root *NodeReference, visitor NodeVisitor) error {
 			return visitNodesWithHashAccess(source, root, visitor)

--- a/go/database/mpt/visitor.go
+++ b/go/database/mpt/visitor.go
@@ -51,6 +51,13 @@ type AccountVisitor interface {
 	VisitAccount(address common.Address, info AccountInfo) VisitResponse
 }
 
+// StorageVisitor defines an interface for consumers interested in visiting storage slots in a tree.
+type StorageVisitor interface {
+	// VisitStorage is called for each storage slot, providing its value.
+	// It returns a VisitResponse to control the visiting process.
+	VisitStorage(key common.Key, value common.Value) VisitResponse
+}
+
 type VisitResponse int
 
 const (
@@ -101,6 +108,19 @@ type lambdaAccountVisitor struct {
 
 func (v *lambdaAccountVisitor) VisitAccount(address common.Address, info AccountInfo) VisitResponse {
 	return v.visit(address, info)
+}
+
+// MakeStorageVisitor wraps a function into the node visitor interface.
+func MakeStorageVisitor(visit func(key common.Key, value common.Value) VisitResponse) StorageVisitor {
+	return &lambdaStorageVisitor{visit}
+}
+
+type lambdaStorageVisitor struct {
+	visit func(key common.Key, value common.Value) VisitResponse
+}
+
+func (v *lambdaStorageVisitor) VisitStorage(key common.Key, value common.Value) VisitResponse {
+	return v.visit(key, value)
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
this PR introduces a new private method `visitNodes` that iterates trie nodes using configured node access rights. 

It furthermore introduces two visitors `VisitAccounts` and `VisitStorages` that provides accounts and storages using the `read` access right. 

 