### PR TITLE
cleans up  CreateWitnessProof called on live view from archive

### DIFF
--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -363,16 +363,11 @@ func (a *ArchiveTrie) CreateWitnessProof(block uint64, address common.Address, k
 	if !a.nodeSource.getConfig().UseHashedPaths {
 		return nil, archive.ErrWitnessProofNotSupported
 	}
-	a.rootsMutex.Lock()
-	length := uint64(a.roots.length())
-	if block >= length {
-		a.rootsMutex.Unlock()
-		return nil, fmt.Errorf("invalid block: %d >= %d", block, length)
+	view, err := a.getView(block)
+	if err != nil {
+		return nil, err
 	}
-	ref := a.roots.get(block).NodeRef
-	a.rootsMutex.Unlock()
-
-	proof, err := CreateWitnessProof(a.nodeSource, &ref, address, keys...)
+	proof, err := view.CreateWitnessProof(address, keys...)
 	return proof, a.addError(err)
 }
 


### PR DESCRIPTION
This PR cleans-up call to `CreateWitnessProof` in the archive to be consistent with other methods. This furthermore makes sure that possible errors are checked transitively in the method `getView`. This was missing in the original code. 