### PR TITLE
Limit the size of StateDB's reincarnation cache

### DIFF
--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -1398,7 +1398,7 @@ func (s *stateDB) ResetBlockContext() {
 // When the size reached the limit, this structure is emptied,
 // and the stored data cache is cleared as well.
 func (s *stateDB) resetReincarnationWhenExceeds(limit int) {
-	if len(s.reincarnation) >= limit {
+	if len(s.reincarnation) > limit {
 		// Reset reincarnation map and stored data cache.
 		s.reincarnation = make(map[common.Address]uint64, defaultStoredDataCacheSize)
 		s.storedDataCache.Clear()

--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -1391,9 +1391,9 @@ func (s *stateDB) ResetBlockContext() {
 	s.resetTransactionContext()
 
 	// limit the reincarnation map size not to grow indefinitely
-	// we cap the map roughly to the size of the cache, which it is used in connection with
-	// when the size reached; both structures are emptied
-	if len(s.reincarnation) > defaultStoredDataCacheSize {
+	// we cap the map to 100M items, which was experimentally assessed,
+	// when the size reached both structures are emptied
+	if len(s.reincarnation) > 100_000_000 {
 		s.reincarnation = make(map[common.Address]uint64, defaultStoredDataCacheSize)
 		s.storedDataCache.Clear()
 	}

--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -1400,7 +1400,7 @@ func (s *stateDB) ResetBlockContext() {
 func (s *stateDB) resetReincarnationWhenExceeds(limit int) {
 	if len(s.reincarnation) > limit {
 		// Reset reincarnation map and stored data cache.
-		s.reincarnation = make(map[common.Address]uint64, defaultStoredDataCacheSize)
+		s.reincarnation = make(map[common.Address]uint64)
 		s.storedDataCache.Clear()
 	}
 }

--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -1389,6 +1389,14 @@ func (s *stateDB) ResetBlockContext() {
 	s.codes = make(map[common.Address]*codeValue)
 	s.logsInBlock = 0
 	s.resetTransactionContext()
+
+	// limit the reincarnation map size not to grow indefinitely
+	// we cap the map roughly to the size of the cache, which it is used in connection with
+	// when the size reached; both structures are emptied
+	if len(s.reincarnation) > defaultStoredDataCacheSize {
+		s.reincarnation = make(map[common.Address]uint64, defaultStoredDataCacheSize)
+		s.storedDataCache.Clear()
+	}
 }
 
 func (s *stateDB) resetState(state State) {

--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -1389,11 +1389,17 @@ func (s *stateDB) ResetBlockContext() {
 	s.codes = make(map[common.Address]*codeValue)
 	s.logsInBlock = 0
 	s.resetTransactionContext()
+	s.resetReincarnationWhenExceeds(100_000_000)
+}
 
-	// limit the reincarnation map size not to grow indefinitely
-	// we cap the map to 100M items, which was experimentally assessed,
-	// when the size reached both structures are emptied
-	if len(s.reincarnation) > 100_000_000 {
+// resetReincarnationWhenExceeds limits the reincarnation map size
+// not to grow indefinitely; we cap the map to 100M items, which was
+// experimentally assessed.
+// When the size reached the limit, this structure is emptied,
+// and the stored data cache is cleared as well.
+func (s *stateDB) resetReincarnationWhenExceeds(limit int) {
+	if len(s.reincarnation) >= limit {
+		// Reset reincarnation map and stored data cache.
 		s.reincarnation = make(map[common.Address]uint64, defaultStoredDataCacheSize)
 		s.storedDataCache.Clear()
 	}

--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -1393,7 +1393,7 @@ func (s *stateDB) ResetBlockContext() {
 }
 
 // resetReincarnationWhenExceeds limits the reincarnation map size
-// not to grow indefinitely; we cap the map to 100M items, which was
+// not to grow indefinitely. We cap the map to 100M items, which was
 // experimentally assessed.
 // When the size reached the limit, this structure is emptied,
 // and the stored data cache is cleared as well.

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -4504,6 +4504,85 @@ func TestStateDB_HasEmptyStorage_DestructedContract_ReportEmpty(t *testing.T) {
 	}
 }
 
+// mockStoredDataCache implements only Clear for testing.
+type mockStoredDataCache struct {
+	cleared bool
+}
+
+func (m *mockStoredDataCache) Clear() { m.cleared = true }
+
+func TestStateDB_resetReincarnationWhenExceeds_DoesNotResetBelowLimit(t *testing.T) {
+	const limit = 5
+	s := &stateDB{
+		reincarnation:   make(map[common.Address]uint64),
+		storedDataCache: common.NewLruCache[slotId, storedDataCacheValue](limit),
+	}
+
+	for i := 0; i < limit; i++ {
+		s.reincarnation[common.Address{byte(i)}] = uint64(i)
+		s.storedDataCache.Set(
+			slotId{common.Address{byte(i)}, common.Key{byte(i)}},
+			storedDataCacheValue{common.Value{byte(i)}, 1})
+	}
+
+	s.resetReincarnationWhenExceeds(limit + 1)
+
+	if got, want := len(s.reincarnation), limit; got != want {
+		t.Errorf("reincarnation size is %d, want %d", got, want)
+	}
+	isEmpty := true
+	s.storedDataCache.Iterate(func(id slotId, value storedDataCacheValue) bool {
+		isEmpty = false
+		return false
+	})
+
+	if isEmpty {
+		t.Errorf("storedDataCache should not be empty")
+	}
+}
+
+func TestStateDB_resetReincarnationWhenExceeds_ResetAboveLimit(t *testing.T) {
+	const limit = 5
+	tests := map[string]struct {
+		limit func() int
+	}{
+		"at limit":    {limit: func() int { return limit }},
+		"above limit": {limit: func() int { return limit - 1 }},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			s := &stateDB{
+				reincarnation:   make(map[common.Address]uint64),
+				storedDataCache: common.NewLruCache[slotId, storedDataCacheValue](limit),
+			}
+
+			for i := 0; i < limit; i++ {
+				s.reincarnation[common.Address{byte(i)}] = uint64(i)
+				s.storedDataCache.Set(
+					slotId{common.Address{byte(i)}, common.Key{byte(i)}},
+					storedDataCacheValue{common.Value{byte(i)}, 1})
+			}
+
+			s.resetReincarnationWhenExceeds(test.limit())
+
+			if len(s.reincarnation) != 0 {
+				t.Errorf("reincarnation size is %d, want 0", len(s.reincarnation))
+			}
+
+			isEmpty := true
+			s.storedDataCache.Iterate(func(id slotId, value storedDataCacheValue) bool {
+				isEmpty = false
+				return false
+			})
+
+			if !isEmpty {
+				t.Errorf("storedDataCache should not be empty")
+			}
+		})
+	}
+}
+
 type sameEffectAs struct {
 	want common.Update
 }

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -4537,10 +4537,10 @@ func TestStateDB_resetReincarnationWhenExceeds_DoesNotResetBelowLimit(t *testing
 func TestStateDB_resetReincarnationWhenExceeds_ResetAboveLimit(t *testing.T) {
 	const limit = 5
 	tests := map[string]struct {
-		limit func() int
+		limit int
 	}{
-		"at limit":    {limit: func() int { return limit - 1 }},
-		"above limit": {limit: func() int { return 1 }},
+		"at limit":    {limit: limit - 1},
+		"above limit": {limit: 1},
 	}
 
 	for name, test := range tests {
@@ -4557,7 +4557,7 @@ func TestStateDB_resetReincarnationWhenExceeds_ResetAboveLimit(t *testing.T) {
 					storedDataCacheValue{common.Value{byte(i)}, 1})
 			}
 
-			s.resetReincarnationWhenExceeds(test.limit())
+			s.resetReincarnationWhenExceeds(test.limit)
 
 			if len(s.reincarnation) != 0 {
 				t.Errorf("reincarnation size is %d, want 0", len(s.reincarnation))

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -4504,13 +4504,6 @@ func TestStateDB_HasEmptyStorage_DestructedContract_ReportEmpty(t *testing.T) {
 	}
 }
 
-// mockStoredDataCache implements only Clear for testing.
-type mockStoredDataCache struct {
-	cleared bool
-}
-
-func (m *mockStoredDataCache) Clear() { m.cleared = true }
-
 func TestStateDB_resetReincarnationWhenExceeds_DoesNotResetBelowLimit(t *testing.T) {
 	const limit = 5
 	s := &stateDB{

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -4546,8 +4546,8 @@ func TestStateDB_resetReincarnationWhenExceeds_ResetAboveLimit(t *testing.T) {
 	tests := map[string]struct {
 		limit func() int
 	}{
-		"at limit":    {limit: func() int { return limit }},
-		"above limit": {limit: func() int { return limit - 1 }},
+		"at limit":    {limit: func() int { return limit - 1 }},
+		"above limit": {limit: func() int { return 1 }},
 	}
 
 	for name, test := range tests {

--- a/go/state/stress_test.go
+++ b/go/state/stress_test.go
@@ -14,11 +14,8 @@
 package state_test
 
 import (
-	"fmt"
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/state"
-	"os"
-	"runtime/pprof"
 	"testing"
 )
 
@@ -131,30 +128,5 @@ func TestStress_CanHandleDeleteOfLargeAccount(t *testing.T) {
 				t.Errorf("failed to close DB: %v", err)
 			}
 		})
-	}
-}
-
-func TestStateDB_Reincarnation_Capture_Memory_Size(t *testing.T) {
-	const size = 100_000_000
-	reincarnation := make(map[common.Address]uint64, size)
-
-	for i := 0; i < size; i++ {
-		addr := common.Address{byte(i), byte(i >> 8), byte(i >> 16), byte(i >> 24)}
-		reincarnation[addr] = uint64(i)
-	}
-
-	if got, want := len(reincarnation), size; got != want {
-		t.Errorf("reincarnation size is %d, want %d", got, want)
-	}
-
-	f, err := os.Create(fmt.Sprintf("reincarnation_memory_%d.prof", size))
-	if err != nil {
-		t.Fatalf("could not create memory profile: %v", err)
-	}
-	if err := pprof.WriteHeapProfile(f); err != nil {
-		t.Errorf("could not write memory profile: %v", err)
-	}
-	if err := f.Close(); err != nil {
-		t.Fatalf("could not close memory profile file: %v", err)
 	}
 }

--- a/go/state/stress_test.go
+++ b/go/state/stress_test.go
@@ -14,8 +14,11 @@
 package state_test
 
 import (
+	"fmt"
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/state"
+	"os"
+	"runtime/pprof"
 	"testing"
 )
 
@@ -128,5 +131,30 @@ func TestStress_CanHandleDeleteOfLargeAccount(t *testing.T) {
 				t.Errorf("failed to close DB: %v", err)
 			}
 		})
+	}
+}
+
+func TestStateDB_Reincarnation_Capture_Memory_Size(t *testing.T) {
+	const size = 100_000_000
+	reincarnation := make(map[common.Address]uint64, size)
+
+	for i := 0; i < size; i++ {
+		addr := common.Address{byte(i), byte(i >> 8), byte(i >> 16), byte(i >> 24)}
+		reincarnation[addr] = uint64(i)
+	}
+
+	if got, want := len(reincarnation), size; got != want {
+		t.Errorf("reincarnation size is %d, want %d", got, want)
+	}
+
+	f, err := os.Create(fmt.Sprintf("reincarnation_memory_%d.prof", size))
+	if err != nil {
+		t.Fatalf("could not create memory profile: %v", err)
+	}
+	if err := pprof.WriteHeapProfile(f); err != nil {
+		t.Errorf("could not write memory profile: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("could not close memory profile file: %v", err)
 	}
 }


### PR DESCRIPTION
This PR caps the size of the reincarnation map to 100M items. When this size is reached, the map is cleared together with the storage cache. 

The size of 100M was experimentally assessed to serve the same performance as it used to be, but the memory consumption is limited to 2.2GB for the whole legacy chain with 72M blocks.  

<img width="1092" alt="image" src="https://github.com/user-attachments/assets/ddca688f-d96e-457a-b2a5-337fa13fc4a6" />
