### PR TITLE
Ignore *_mocks.go from coverage report

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -23,5 +23,6 @@ coverage:
 ignore:
   - "tests/"
   - "**/*_mock.go"
+  - "**/*_mocks.go"
   - "**/*_test.go"
   - "**/*.pb.go"


### PR DESCRIPTION
This PR modifies coverage configuration file. Some mock files ending with `mocks.go` are ignored from coverage report.