### PR TITLE
Limit live and archive caches on import/export

### DIFF
--- a/go/carmen/database_test.go
+++ b/go/carmen/database_test.go
@@ -2359,7 +2359,7 @@ func TestDatabase_Export(t *testing.T) {
 	if err := os.MkdirAll(liveDbLocation, 0755); err != nil {
 		t.Fatalf("cannot create live db location: %v", err)
 	}
-	if err = io.ImportLiveDb(io.NewLog(), liveDbLocation, b); err != nil {
+	if err = io.ImportLiveDb(io.NewLog(), liveDbLocation, b, 0); err != nil {
 		t.Fatalf("cannot import live db: %v", err)
 	}
 

--- a/go/carmen/example_test.go
+++ b/go/carmen/example_test.go
@@ -574,7 +574,7 @@ func ExampleHistoricBlockContext_Export() {
 	}
 	liveDbLocation := filepath.Join(importedDbPath, "live")
 
-	err = io.ImportLiveDb(io.NewLog(), liveDbLocation, b)
+	err = io.ImportLiveDb(io.NewLog(), liveDbLocation, b, 0)
 	if err != nil {
 		log.Fatalf("cannot import live db")
 	}

--- a/go/database/mpt/io/archive.go
+++ b/go/database/mpt/io/archive.go
@@ -16,13 +16,14 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/0xsoniclabs/carmen/go/common/amount"
-	"github.com/0xsoniclabs/carmen/go/common/interrupt"
-	"github.com/0xsoniclabs/carmen/go/state"
 	"io"
 	"os"
 	"path"
 	"sort"
+
+	"github.com/0xsoniclabs/carmen/go/common/amount"
+	"github.com/0xsoniclabs/carmen/go/common/interrupt"
+	"github.com/0xsoniclabs/carmen/go/state"
 
 	"github.com/0xsoniclabs/carmen/go/backend/archive"
 	"github.com/0xsoniclabs/carmen/go/common"
@@ -67,7 +68,11 @@ func ExportArchive(ctx context.Context, logger *Log, directory string, out io.Wr
 	}
 
 	logger.Printf("opening archive: %s", directory)
-	archive, err := mpt.OpenArchiveTrie(directory, info.Config, mpt.NodeCacheConfig{}, mpt.ArchiveConfig{})
+	archive, err := mpt.OpenArchiveTrie(
+		directory,
+		info.Config,
+		mpt.NodeCacheConfig{Capacity: exportCacheCapacitySize},
+		mpt.ArchiveConfig{})
 	if err != nil {
 		return err
 	}
@@ -246,7 +251,8 @@ func importArchive(logger *Log, liveDbDir, archiveDbDir string, in io.Reader) (e
 	}
 
 	// Create a live-DB updated in parallel for faster hash computation.
-	live, err := mpt.OpenGoFileState(liveDbDir, mpt.S5LiveConfig, mpt.NodeCacheConfig{})
+	live, err := mpt.OpenGoFileState(liveDbDir, mpt.S5LiveConfig,
+		mpt.NodeCacheConfig{Capacity: importNodeCacheSize})
 	if err != nil {
 		return fmt.Errorf("failed to create auxiliary live DB: %w", err)
 	}
@@ -258,7 +264,11 @@ func importArchive(logger *Log, liveDbDir, archiveDbDir string, in io.Reader) (e
 	}()
 
 	// Create an empty archive.
-	archive, err := mpt.OpenArchiveTrie(archiveDbDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{}, mpt.ArchiveConfig{})
+	archive, err := mpt.OpenArchiveTrie(
+		archiveDbDir,
+		mpt.S5ArchiveConfig,
+		mpt.NodeCacheConfig{Capacity: importNodeCacheSize},
+		mpt.ArchiveConfig{})
 	if err != nil {
 		return fmt.Errorf("failed to create empty state: %w", err)
 	}

--- a/go/database/mpt/io/archive_test.go
+++ b/go/database/mpt/io/archive_test.go
@@ -13,12 +13,13 @@ package io
 import (
 	"bytes"
 	"context"
-	"github.com/0xsoniclabs/carmen/go/common"
-	"github.com/0xsoniclabs/carmen/go/common/amount"
-	"github.com/0xsoniclabs/carmen/go/database/mpt"
 	"path"
 	"strings"
 	"testing"
+
+	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/0xsoniclabs/carmen/go/common/amount"
+	"github.com/0xsoniclabs/carmen/go/database/mpt"
 )
 
 func TestIO_Archive_ExportAndImport(t *testing.T) {
@@ -54,7 +55,7 @@ func TestIO_Archive_ExportAndImport(t *testing.T) {
 	// Import the archive into a new directory.
 	targetDir := t.TempDir()
 	buffer = bytes.NewBuffer(genesis)
-	if err := ImportArchive(NewLog(), targetDir, buffer); err != nil {
+	if err := ImportArchive(NewLog(), targetDir, buffer, 0); err != nil {
 		t.Fatalf("failed to import Archive: %v", err)
 	}
 
@@ -120,7 +121,7 @@ func TestIO_ArchiveAndLive_ExportAndImport(t *testing.T) {
 	// Import the archive into a new directory.
 	targetDir := t.TempDir()
 	buffer = bytes.NewBuffer(genesis)
-	if err := ImportLiveAndArchive(NewLog(), targetDir, buffer); err != nil {
+	if err := ImportLiveAndArchive(NewLog(), targetDir, buffer, 0); err != nil {
 		t.Fatalf("failed to import Archive: %v", err)
 	}
 
@@ -178,7 +179,7 @@ func TestIO_LiveAndArchive_Import_IncorrectMagicNumberIsNoticed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot write magic number: %v", err)
 	}
-	err = importArchive(nil, t.TempDir(), t.TempDir(), b)
+	err = importArchive(nil, t.TempDir(), t.TempDir(), b, 0)
 	if err == nil {
 		t.Fatal("import must fail")
 	}

--- a/go/database/mpt/io/live.go
+++ b/go/database/mpt/io/live.go
@@ -254,7 +254,7 @@ func ExportLive(ctx context.Context, logger *Log, db mptStateVisitor, out io.Wri
 
 // ImportLiveDb creates a fresh StateDB in the given directory and fills it
 // with the content read from the given reader.
-func ImportLiveDb(logger *Log, directory string, in io.Reader) error {
+func ImportLiveDb(logger *Log, directory string, in io.Reader, _ int) error {
 	_, _, err := runImport(logger, directory, in, mpt.S5LiveConfig)
 	return err
 }

--- a/go/database/mpt/io/live_test.go
+++ b/go/database/mpt/io/live_test.go
@@ -28,7 +28,7 @@ func TestIO_ExportAndImportAsLiveDb(t *testing.T) {
 
 	buffer := bytes.NewBuffer(genesis)
 	targetDir := t.TempDir()
-	if err := ImportLiveDb(NewLog(), targetDir, buffer); err != nil {
+	if err := ImportLiveDb(NewLog(), targetDir, buffer, 0); err != nil {
 		t.Fatalf("failed to import DB: %v", err)
 	}
 
@@ -222,7 +222,7 @@ func TestImport_ImportIntoNonEmptyTargetDirectoryFails(t *testing.T) {
 		t.Fatalf("failed to create file: %v", err)
 	}
 
-	if err := ImportLiveDb(NewLog(), dir, nil); err == nil || !strings.Contains(err.Error(), "is not empty") {
+	if err := ImportLiveDb(NewLog(), dir, nil, 0); err == nil || !strings.Contains(err.Error(), "is not empty") {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
@@ -336,7 +336,7 @@ func TestIO_ExportBlockFromArchive(t *testing.T) {
 
 		// Import live database.
 		targetDir := t.TempDir()
-		if err := ImportLiveDb(NewLog(), targetDir, buffer); err != nil {
+		if err := ImportLiveDb(NewLog(), targetDir, buffer, 0); err != nil {
 			t.Fatalf("failed to import DB: %v", err)
 		}
 
@@ -412,7 +412,7 @@ func TestIO_ExportBlockFromOnlineArchive(t *testing.T) {
 
 		// Import live database.
 		targetDir := t.TempDir()
-		if err := ImportLiveDb(nil, targetDir, buffer); err != nil {
+		if err := ImportLiveDb(nil, targetDir, buffer, 0); err != nil {
 			t.Fatalf("failed to import DB: %v", err)
 		}
 

--- a/go/database/mpt/tool/import.go
+++ b/go/database/mpt/tool/import.go
@@ -55,7 +55,7 @@ func doLiveAndArchiveImport(context *cli.Context) error {
 	return doImport(context, mptIo.ImportLiveAndArchive)
 }
 
-func doImport(context *cli.Context, runImport func(logger *mptIo.Log, directory string, in io.Reader) error) error {
+func doImport(context *cli.Context, runImport func(logger *mptIo.Log, directory string, in io.Reader, nodeCacheCapacity int) error) error {
 	if context.Args().Len() != 2 {
 		return fmt.Errorf("missing source file and/or target directory parameter")
 	}
@@ -80,7 +80,7 @@ func doImport(context *cli.Context, runImport func(logger *mptIo.Log, directory 
 		logger.Printf("import done")
 	}()
 	return errors.Join(
-		runImport(logger, dir, in),
+		runImport(logger, dir, in, 0),
 		file.Close(),
 	)
 }


### PR DESCRIPTION
This PR uses the already declared [mpt/io/live.go](https://github.com/0xsoniclabs/carmen/blob/main/go/database/mpt/io/live.go#L50) import/export cache sizes, when they are called from the archive exported methods. 

This PR is part of https://github.com/0xsoniclabs/sonic-admin/issues/244