### PR TITLE
reduces reincarnation limit to 25M

### DIFF
--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -1389,7 +1389,7 @@ func (s *stateDB) ResetBlockContext() {
 	s.codes = make(map[common.Address]*codeValue)
 	s.logsInBlock = 0
 	s.resetTransactionContext()
-	s.resetReincarnationWhenExceeds(100_000_000)
+	s.resetReincarnationWhenExceeds(25_000_000)
 }
 
 // resetReincarnationWhenExceeds limits the reincarnation map size


### PR DESCRIPTION
This PR reduces max size of the reincarnation map to 25 million items. It turns out, that this size performs the same as previous 100M, while it needs 4x less memory. 


<img width="1111" alt="image" src="https://github.com/user-attachments/assets/caf31e21-a7f2-4a83-8cad-d6153e4d93c9" />
