### PR TITLE
propagates Update as pointer to propagate changes upstream

### DIFF
--- a/go/database/mpt/io/archive.go
+++ b/go/database/mpt/io/archive.go
@@ -433,7 +433,7 @@ func (c *importContext) finishCurrentBlock(archive archive.Archive, live state.L
 	if !c.currentBlockHashFound {
 		return fmt.Errorf("input format error: no hash for block %d", c.currentBlock)
 	}
-	hints, err := live.Apply(c.currentBlock, c.currentUpdate)
+	hints, err := live.Apply(c.currentBlock, &c.currentUpdate)
 	if err != nil {
 		return err
 	}

--- a/go/database/mpt/state.go
+++ b/go/database/mpt/state.go
@@ -338,7 +338,7 @@ func (s *MptState) GetHash() (hash common.Hash, err error) {
 	return hash, err
 }
 
-func (s *MptState) Apply(block uint64, update common.Update) (archiveUpdateHints common.Releaser, err error) {
+func (s *MptState) Apply(block uint64, update *common.Update) (archiveUpdateHints common.Releaser, err error) {
 	if err := update.ApplyTo(s); err != nil {
 		return nil, err
 	}

--- a/go/database/mpt/state_mocks.go
+++ b/go/database/mpt/state_mocks.go
@@ -407,7 +407,7 @@ func (m *MockLiveState) EXPECT() *MockLiveStateMockRecorder {
 }
 
 // Apply mocks base method.
-func (m *MockLiveState) Apply(block uint64, update common.Update) (common.Releaser, error) {
+func (m *MockLiveState) Apply(block uint64, update *common.Update) (common.Releaser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Apply", block, update)
 	ret0, _ := ret[0].(common.Releaser)

--- a/go/state/gostate/go_schema1.go
+++ b/go/state/gostate/go_schema1.go
@@ -289,7 +289,7 @@ func (s *GoSchema1) GetHash() (hash common.Hash, err error) {
 	return hash, nil
 }
 
-func (s *GoSchema1) Apply(block uint64, update common.Update) (archiveUpdateHints common.Releaser, err error) {
+func (s *GoSchema1) Apply(block uint64, update *common.Update) (archiveUpdateHints common.Releaser, err error) {
 	if err := update.Normalize(); err != nil {
 		return nil, err
 	}

--- a/go/state/gostate/go_schema2.go
+++ b/go/state/gostate/go_schema2.go
@@ -275,7 +275,7 @@ func (s *GoSchema2) GetHash() (hash common.Hash, err error) {
 	return hash, nil
 }
 
-func (s *GoSchema2) Apply(block uint64, update common.Update) (archiveUpdateHints common.Releaser, err error) {
+func (s *GoSchema2) Apply(block uint64, update *common.Update) (archiveUpdateHints common.Releaser, err error) {
 	if err := update.Normalize(); err != nil {
 		return nil, err
 	}

--- a/go/state/gostate/go_schema3.go
+++ b/go/state/gostate/go_schema3.go
@@ -284,7 +284,7 @@ func (s *GoSchema3) GetHash() (hash common.Hash, err error) {
 	return hash, nil
 }
 
-func (s *GoSchema3) Apply(block uint64, update common.Update) (archiveUpdateHints common.Releaser, err error) {
+func (s *GoSchema3) Apply(block uint64, update *common.Update) (archiveUpdateHints common.Releaser, err error) {
 	if err := update.Normalize(); err != nil {
 		return nil, err
 	}

--- a/go/state/gostate/go_state.go
+++ b/go/state/gostate/go_state.go
@@ -215,7 +215,7 @@ func (s *GoState) Apply(block uint64, update common.Update) error {
 	}
 
 	// Apply the changes to the LiveDB.
-	archiveUpdateHints, err := s.live.Apply(block, update)
+	archiveUpdateHints, err := s.live.Apply(block, &update)
 	if err != nil {
 		s.stateError = errors.Join(s.stateError, err)
 		return s.stateError

--- a/go/state/state.go
+++ b/go/state/state.go
@@ -107,7 +107,7 @@ type LiveDB interface {
 	GetCodeHash(address common.Address) (hash common.Hash, err error)
 	HasEmptyStorage(addr common.Address) (bool, error)
 	GetHash() (hash common.Hash, err error)
-	Apply(block uint64, update common.Update) (archiveUpdateHints common.Releaser, err error)
+	Apply(block uint64, update *common.Update) (archiveUpdateHints common.Releaser, err error)
 	Flush() error
 	Close() error
 	common.MemoryFootprintProvider

--- a/go/state/state_mock.go
+++ b/go/state/state_mock.go
@@ -408,7 +408,7 @@ func (m *MockLiveDB) EXPECT() *MockLiveDBMockRecorder {
 }
 
 // Apply mocks base method.
-func (m *MockLiveDB) Apply(block uint64, update common.Update) (common.Releaser, error) {
+func (m *MockLiveDB) Apply(block uint64, update *common.Update) (common.Releaser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Apply", block, update)
 	ret0, _ := ret[0].(common.Releaser)


### PR DESCRIPTION
This PR changes the way the `Update` object is propagated to live database. It is now passed in as a pointer, which is consistent with how the object is propagated to Archive. 

Current approach had issue for some schemes:

1. The `Update` object is passed to the state
2. `Update` is normalised by some Live schemas not to contain duplicities
3. the updated object is supposed to be sent to the archive, but since the object was not a pointer, the archive got the original copy