### PR TITLE
reduces reincarnation map size to 10M

### DIFF
--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -1389,7 +1389,7 @@ func (s *stateDB) ResetBlockContext() {
 	s.codes = make(map[common.Address]*codeValue)
 	s.logsInBlock = 0
 	s.resetTransactionContext()
-	s.resetReincarnationWhenExceeds(25_000_000)
+	s.resetReincarnationWhenExceeds(10_000_000)
 }
 
 // resetReincarnationWhenExceeds limits the reincarnation map size


### PR DESCRIPTION
This PR reduces reincarnation map size limit to 10M. It saves even more memory, while featuring the same performance.

<img width="1098" alt="image" src="https://github.com/user-attachments/assets/0aaa77c4-f8e6-409e-8d8f-bb293046dba9" />
