### PR TITLE
Add explicit permission parameter to visit functions

### DIFF
--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -453,21 +453,26 @@ func (a *ArchiveTrie) Flush() error {
 	return a.addError(err)
 }
 
-func (a *ArchiveTrie) VisitTrie(block uint64, visitor NodeVisitor) error {
+func (a *ArchiveTrie) VisitTrie(block uint64, mode AccessMode, visitor NodeVisitor) error {
 	view, err := a.getView(block)
 	if err != nil {
 		return err
 	}
-	return a.addError(view.VisitTrie(visitor))
+	return a.addError(view.VisitTrie(mode, visitor))
 }
 
-func (a *ArchiveTrie) VisitAccountStorage(block uint64, address common.Address, visitor NodeVisitor) error {
+func (a *ArchiveTrie) VisitAccountStorage(
+	block uint64,
+	address common.Address,
+	mode AccessMode,
+	visitor NodeVisitor,
+) error {
 	view, err := a.getView(block)
 	if err != nil {
 		return err
 	}
 
-	return a.addError(view.VisitAccountStorage(address, visitor))
+	return a.addError(view.VisitAccountStorage(address, mode, visitor))
 }
 
 func (a *ArchiveTrie) Close() error {

--- a/go/database/mpt/forest.go
+++ b/go/database/mpt/forest.go
@@ -422,7 +422,7 @@ func (s *Forest) HasEmptyStorage(rootRef *NodeReference, addr common.Address) (i
 		}
 		return VisitResponseContinue
 	})
-	exists, err := VisitPathToAccount(s, rootRef, addr, v)
+	exists, err := VisitPathToAccount(s, rootRef, addr, ReadAccess{}, v)
 	if err != nil {
 		err = fmt.Errorf("failed to check storage for account %v: %w", addr, err)
 		s.errors = append(s.errors, err)
@@ -448,15 +448,15 @@ func (s *Forest) ClearStorage(rootRef *NodeReference, addr common.Address) (Node
 	return newRoot, err
 }
 
-func (s *Forest) VisitTrie(rootRef *NodeReference, visitor NodeVisitor) error {
-	root, err := s.getViewAccess(rootRef)
+func (s *Forest) VisitTrie(rootRef *NodeReference, mode AccessMode, visitor NodeVisitor) error {
+	root, err := mode.Access(s, rootRef)
 	if err != nil {
 		err = fmt.Errorf("failed to obtain view access to node %v: %w", rootRef.Id(), err)
 		s.errors = append(s.errors, err)
 		return err
 	}
 	defer root.Release()
-	_, err = root.Get().Visit(s, rootRef, 0, visitor)
+	_, err = root.Get().Visit(s, rootRef, 0, mode, visitor)
 	if err != nil {
 		err = fmt.Errorf("error during trie visit: %w", err)
 		s.errors = append(s.errors, err)

--- a/go/database/mpt/forest_test.go
+++ b/go/database/mpt/forest_test.go
@@ -240,7 +240,7 @@ func TestForest_GettingAccountInfo_Fails(t *testing.T) {
 						t.Errorf("getting account should fail")
 					}
 					nodeVisitor := NewMockNodeVisitor(ctrl)
-					if err := forest.VisitTrie(&root, nodeVisitor); !errors.Is(err, injectedErr) {
+					if err := forest.VisitTrie(&root, ReadAccess{}, nodeVisitor); !errors.Is(err, injectedErr) {
 						t.Errorf("getting account should fail")
 					}
 				})
@@ -1965,13 +1965,13 @@ func TestForest_ErrorsAreForwardedAndCollected(t *testing.T) {
 		"VisitTrie-Failed-RootLookup": {
 			prepareRootLookupFailure,
 			func(f *Forest) error {
-				return f.VisitTrie(&rootRef, nil)
+				return f.VisitTrie(&rootRef, ReadAccess{}, nil)
 			},
 		},
 		"VisitTrie-Failed-TreeNavigation": {
 			prepareTreeNavigationFailure,
 			func(f *Forest) error {
-				return f.VisitTrie(&rootRef, MakeVisitor(func(Node, NodeInfo) VisitResponse { return VisitResponseContinue }))
+				return f.VisitTrie(&rootRef, ReadAccess{}, MakeVisitor(func(Node, NodeInfo) VisitResponse { return VisitResponseContinue }))
 			},
 		},
 		"updateHashesFor-Failed-RootLookup": {
@@ -2385,7 +2385,7 @@ func TestForest_VisitPathToAccount(t *testing.T) {
 
 					for i, addr := range addresses {
 						lastNode = nil
-						if found, err := VisitPathToAccount(forest, &rootRef, addr, nodeVisitor); err != nil || !found {
+						if found, err := VisitPathToAccount(forest, &rootRef, addr, ReadAccess{}, nodeVisitor); err != nil || !found {
 							t.Errorf("failed to iterate nodes by address: %v", err)
 						}
 						switch account := lastNode.(type) {
@@ -2456,7 +2456,7 @@ func TestForest_VisitPathToStorage(t *testing.T) {
 
 					for _, address := range addresses {
 						// find out account node to start storage search from it.
-						if found, err := VisitPathToAccount(forest, &rootRef, address, nodeVisitor); err != nil || !found {
+						if found, err := VisitPathToAccount(forest, &rootRef, address, ReadAccess{}, nodeVisitor); err != nil || !found {
 							t.Errorf("failed to iterate nodes by address: %v", err)
 						}
 					}
@@ -2679,7 +2679,7 @@ func testVisitPathToStorage(t *testing.T, forest *Forest, keys []common.Key, sto
 
 	for i, key := range keys {
 		lastNode = nil
-		if found, err := VisitPathToStorage(forest, &storageRoot, key, nodeVisitor); err != nil || !found {
+		if found, err := VisitPathToStorage(forest, &storageRoot, key, ReadAccess{}, nodeVisitor); err != nil || !found {
 			t.Errorf("failed to iterate nodes by address: %v", err)
 		}
 		switch value := lastNode.(type) {

--- a/go/database/mpt/hasher_mocks.go
+++ b/go/database/mpt/hasher_mocks.go
@@ -30,6 +30,7 @@ import (
 type Mockhasher struct {
 	ctrl     *gomock.Controller
 	recorder *MockhasherMockRecorder
+	isgomock struct{}
 }
 
 // MockhasherMockRecorder is the mock recorder for Mockhasher.

--- a/go/database/mpt/io/parallel_visit_test.go
+++ b/go/database/mpt/io/parallel_visit_test.go
@@ -142,7 +142,7 @@ func TestNodeSource_CanRead_Nodes(t *testing.T) {
 
 				// iterate all nodes in the trie for all blocks
 				for i := uint64(0); i <= blocks; i++ {
-					if err := trie.VisitTrie(i, mpt.MakeVisitor(func(node mpt.Node, info mpt.NodeInfo) mpt.VisitResponse {
+					if err := trie.VisitTrie(i, mpt.ViewAccess{}, mpt.MakeVisitor(func(node mpt.Node, info mpt.NodeInfo) mpt.VisitResponse {
 						sourceNode, err := source.get(info.Id)
 						if err != nil {
 							t.Fatalf("failed to get node from source: %v", err)
@@ -197,7 +197,7 @@ func TestVisit_CanHandleSlowConsumer(t *testing.T) {
 	}
 
 	numNodes := 0
-	err = live.Visit(mpt.MakeVisitor(func(node mpt.Node, info mpt.NodeInfo) mpt.VisitResponse {
+	err = live.Visit(mpt.ReadAccess{}, mpt.MakeVisitor(func(node mpt.Node, info mpt.NodeInfo) mpt.VisitResponse {
 		numNodes++
 		return mpt.VisitResponseContinue
 	}))
@@ -434,7 +434,7 @@ func TestVisit_Nodes_Iterated_Deterministic(t *testing.T) {
 				// iterate all nodes in the trie for all blocks
 				for block := uint64(0); block <= blocks; block++ {
 					var nodes []mpt.NodeId
-					if err := trie.VisitTrie(block, mpt.MakeVisitor(
+					if err := trie.VisitTrie(block, mpt.ReadAccess{}, mpt.MakeVisitor(
 						func(node mpt.Node, info mpt.NodeInfo) mpt.VisitResponse {
 							nodes = append(nodes, info.Id)
 							return mpt.VisitResponseContinue
@@ -556,7 +556,7 @@ func TestNodeSourceFactoryForLiveDB_CanRead_Nodes(t *testing.T) {
 			// collect all nodes from the live db
 			nodes := make(map[mpt.NodeId]mpt.Node)
 			// collect all nodes from the live db
-			if err := live.Visit(mpt.MakeVisitor(func(node mpt.Node, info mpt.NodeInfo) mpt.VisitResponse {
+			if err := live.Visit(mpt.ReadAccess{}, mpt.MakeVisitor(func(node mpt.Node, info mpt.NodeInfo) mpt.VisitResponse {
 				nodes[info.Id] = node
 				return mpt.VisitResponseContinue
 			})); err != nil {

--- a/go/database/mpt/live_trie.go
+++ b/go/database/mpt/live_trie.go
@@ -168,13 +168,17 @@ func (s *LiveTrie) setHashes(hashes *NodeHashes) error {
 	return s.forest.setHashesFor(&s.root, hashes)
 }
 
-func (s *LiveTrie) VisitTrie(visitor NodeVisitor) error {
-	return s.forest.VisitTrie(&s.root, visitor)
+func (s *LiveTrie) VisitTrie(mode AccessMode, visitor NodeVisitor) error {
+	return s.forest.VisitTrie(&s.root, mode, visitor)
 }
 
 // VisitAccountStorage visits the storage nodes of an account with the given address.
 // The visited nodes do not contain the account node itself.
-func (s *LiveTrie) VisitAccountStorage(address common.Address, visitor NodeVisitor) error {
+func (s *LiveTrie) VisitAccountStorage(
+	address common.Address,
+	mode AccessMode,
+	visitor NodeVisitor,
+) error {
 	var innerError error
 	// this visitor finds the account node with the given address
 	accountVisitor := MakeVisitor(func(node Node, info NodeInfo) VisitResponse {
@@ -182,7 +186,7 @@ func (s *LiveTrie) VisitAccountStorage(address common.Address, visitor NodeVisit
 		case *AccountNode:
 			if n.Address() == address {
 				// and then it sends the storage node to the visitor
-				_, innerError = n.visitStorage(s.forest, 0, visitor)
+				_, innerError = n.visitStorage(s.forest, 0, mode, visitor)
 			}
 			return VisitResponseAbort
 		}
@@ -190,7 +194,7 @@ func (s *LiveTrie) VisitAccountStorage(address common.Address, visitor NodeVisit
 		return VisitResponseContinue
 	})
 
-	_, err := VisitPathToAccount(s.forest, &s.root, address, accountVisitor)
+	_, err := VisitPathToAccount(s.forest, &s.root, address, mode, accountVisitor)
 	return errors.Join(innerError, err)
 }
 

--- a/go/database/mpt/live_trie_test.go
+++ b/go/database/mpt/live_trie_test.go
@@ -189,7 +189,7 @@ func TestLiveTrie_Fail_Read_Data(t *testing.T) {
 	db.EXPECT().SetValue(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(NodeReference{}, injectedErr)
 	db.EXPECT().GetValue(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.Value{}, injectedErr)
 	db.EXPECT().ClearStorage(gomock.Any(), gomock.Any()).Return(NodeReference{}, injectedErr)
-	db.EXPECT().VisitTrie(gomock.Any(), gomock.Any()).Return(injectedErr)
+	db.EXPECT().VisitTrie(gomock.Any(), gomock.Any(), gomock.Any()).Return(injectedErr)
 	db.EXPECT().updateHashesFor(gomock.Any()).Return(common.Hash{}, nil, injectedErr)
 	db.EXPECT().Close()
 
@@ -216,7 +216,7 @@ func TestLiveTrie_Fail_Read_Data(t *testing.T) {
 		t.Errorf("getting account should fail")
 	}
 	nodeVisitor := NewMockNodeVisitor(ctrl)
-	if err := mpt.VisitTrie(nodeVisitor); !errors.Is(err, injectedErr) {
+	if err := mpt.VisitTrie(ReadAccess{}, nodeVisitor); !errors.Is(err, injectedErr) {
 		t.Errorf("getting account should fail")
 	}
 }
@@ -241,7 +241,7 @@ func TestLiveTrie_VisitAccount(t *testing.T) {
 			// there are no accounts at the beginning
 			for i := 0; i < Addresses; i++ {
 				addr := common.AddressFromNumber(i)
-				if err := trie.VisitAccountStorage(addr, MakeVisitor(func(node Node, _ NodeInfo) VisitResponse {
+				if err := trie.VisitAccountStorage(addr, ReadAccess{}, MakeVisitor(func(node Node, _ NodeInfo) VisitResponse {
 					t.Errorf("unexpected node: %v", node)
 					return VisitResponseContinue
 				})); err != nil {
@@ -259,7 +259,7 @@ func TestLiveTrie_VisitAccount(t *testing.T) {
 			// there are no nodes in the accounts
 			for i := 0; i < Addresses; i++ {
 				addr := common.AddressFromNumber(i)
-				if err := trie.VisitAccountStorage(addr, MakeVisitor(func(node Node, _ NodeInfo) VisitResponse {
+				if err := trie.VisitAccountStorage(addr, ReadAccess{}, MakeVisitor(func(node Node, _ NodeInfo) VisitResponse {
 					t.Errorf("unexpected node: %v", node)
 					return VisitResponseContinue
 				})); err != nil {
@@ -281,7 +281,7 @@ func TestLiveTrie_VisitAccount(t *testing.T) {
 			for i := 0; i < Addresses; i++ {
 				addr := common.AddressFromNumber(i)
 				visited := make(map[common.Key]common.Value)
-				if err := trie.VisitAccountStorage(addr, MakeVisitor(func(node Node, _ NodeInfo) VisitResponse {
+				if err := trie.VisitAccountStorage(addr, ReadAccess{}, MakeVisitor(func(node Node, _ NodeInfo) VisitResponse {
 					switch n := node.(type) {
 					case *ValueNode:
 						visited[n.Key()] = n.Value()

--- a/go/database/mpt/node_cache_mocks.go
+++ b/go/database/mpt/node_cache_mocks.go
@@ -15,6 +15,7 @@
 //
 //	mockgen -source node_cache.go -destination node_cache_mocks.go -package mpt
 //
+
 // Package mpt is a generated GoMock package.
 package mpt
 
@@ -30,6 +31,7 @@ import (
 type MockNodeCache struct {
 	ctrl     *gomock.Controller
 	recorder *MockNodeCacheMockRecorder
+	isgomock struct{}
 }
 
 // MockNodeCacheMockRecorder is the mock recorder for MockNodeCache.

--- a/go/database/mpt/nodes_mocks.go
+++ b/go/database/mpt/nodes_mocks.go
@@ -15,6 +15,7 @@
 //
 //	mockgen -source nodes.go -destination nodes_mocks.go -package mpt
 //
+
 // Package mpt is a generated GoMock package.
 package mpt
 
@@ -31,6 +32,7 @@ import (
 type MockNode struct {
 	ctrl     *gomock.Controller
 	recorder *MockNodeMockRecorder
+	isgomock struct{}
 }
 
 // MockNodeMockRecorder is the mock recorder for MockNode.
@@ -298,24 +300,25 @@ func (mr *MockNodeMockRecorder) SetValue(manager, thisRef, this, key, path, valu
 }
 
 // Visit mocks base method.
-func (m *MockNode) Visit(source NodeSource, thisRef *NodeReference, depth int, visitor NodeVisitor) (bool, error) {
+func (m *MockNode) Visit(manager NodeManager, thisRef *NodeReference, depth int, mode AccessMode, visitor NodeVisitor) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Visit", source, thisRef, depth, visitor)
+	ret := m.ctrl.Call(m, "Visit", manager, thisRef, depth, mode, visitor)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Visit indicates an expected call of Visit.
-func (mr *MockNodeMockRecorder) Visit(source, thisRef, depth, visitor any) *gomock.Call {
+func (mr *MockNodeMockRecorder) Visit(manager, thisRef, depth, mode, visitor any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Visit", reflect.TypeOf((*MockNode)(nil).Visit), source, thisRef, depth, visitor)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Visit", reflect.TypeOf((*MockNode)(nil).Visit), manager, thisRef, depth, mode, visitor)
 }
 
 // MockNodeSource is a mock of NodeSource interface.
 type MockNodeSource struct {
 	ctrl     *gomock.Controller
 	recorder *MockNodeSourceMockRecorder
+	isgomock struct{}
 }
 
 // MockNodeSourceMockRecorder is the mock recorder for MockNodeSource.
@@ -426,6 +429,7 @@ func (mr *MockNodeSourceMockRecorder) hashKey(arg0 any) *gomock.Call {
 type MockNodeManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockNodeManagerMockRecorder
+	isgomock struct{}
 }
 
 // MockNodeManagerMockRecorder is the mock recorder for MockNodeManager.
@@ -652,10 +656,128 @@ func (mr *MockNodeManagerMockRecorder) releaseTrieAsynchronous(arg0 any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "releaseTrieAsynchronous", reflect.TypeOf((*MockNodeManager)(nil).releaseTrieAsynchronous), arg0)
 }
 
+// MockHandle is a mock of Handle interface.
+type MockHandle struct {
+	ctrl     *gomock.Controller
+	recorder *MockHandleMockRecorder
+	isgomock struct{}
+}
+
+// MockHandleMockRecorder is the mock recorder for MockHandle.
+type MockHandleMockRecorder struct {
+	mock *MockHandle
+}
+
+// NewMockHandle creates a new mock instance.
+func NewMockHandle(ctrl *gomock.Controller) *MockHandle {
+	mock := &MockHandle{ctrl: ctrl}
+	mock.recorder = &MockHandleMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockHandle) EXPECT() *MockHandleMockRecorder {
+	return m.recorder
+}
+
+// Get mocks base method.
+func (m *MockHandle) Get() Node {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get")
+	ret0, _ := ret[0].(Node)
+	return ret0
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockHandleMockRecorder) Get() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockHandle)(nil).Get))
+}
+
+// Release mocks base method.
+func (m *MockHandle) Release() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Release")
+}
+
+// Release indicates an expected call of Release.
+func (mr *MockHandleMockRecorder) Release() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Release", reflect.TypeOf((*MockHandle)(nil).Release))
+}
+
+// Valid mocks base method.
+func (m *MockHandle) Valid() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Valid")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Valid indicates an expected call of Valid.
+func (mr *MockHandleMockRecorder) Valid() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Valid", reflect.TypeOf((*MockHandle)(nil).Valid))
+}
+
+// MockAccessMode is a mock of AccessMode interface.
+type MockAccessMode struct {
+	ctrl     *gomock.Controller
+	recorder *MockAccessModeMockRecorder
+	isgomock struct{}
+}
+
+// MockAccessModeMockRecorder is the mock recorder for MockAccessMode.
+type MockAccessModeMockRecorder struct {
+	mock *MockAccessMode
+}
+
+// NewMockAccessMode creates a new mock instance.
+func NewMockAccessMode(ctrl *gomock.Controller) *MockAccessMode {
+	mock := &MockAccessMode{ctrl: ctrl}
+	mock.recorder = &MockAccessModeMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockAccessMode) EXPECT() *MockAccessModeMockRecorder {
+	return m.recorder
+}
+
+// Access mocks base method.
+func (m *MockAccessMode) Access(arg0 NodeManager, arg1 *NodeReference) (Handle, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Access", arg0, arg1)
+	ret0, _ := ret[0].(Handle)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Access indicates an expected call of Access.
+func (mr *MockAccessModeMockRecorder) Access(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Access", reflect.TypeOf((*MockAccessMode)(nil).Access), arg0, arg1)
+}
+
+// String mocks base method.
+func (m *MockAccessMode) String() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "String")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// String indicates an expected call of String.
+func (mr *MockAccessModeMockRecorder) String() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MockAccessMode)(nil).String))
+}
+
 // MockleafNode is a mock of leafNode interface.
 type MockleafNode struct {
 	ctrl     *gomock.Controller
 	recorder *MockleafNodeMockRecorder
+	isgomock struct{}
 }
 
 // MockleafNodeMockRecorder is the mock recorder for MockleafNode.
@@ -923,18 +1045,18 @@ func (mr *MockleafNodeMockRecorder) SetValue(manager, thisRef, this, key, path, 
 }
 
 // Visit mocks base method.
-func (m *MockleafNode) Visit(source NodeSource, thisRef *NodeReference, depth int, visitor NodeVisitor) (bool, error) {
+func (m *MockleafNode) Visit(manager NodeManager, thisRef *NodeReference, depth int, mode AccessMode, visitor NodeVisitor) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Visit", source, thisRef, depth, visitor)
+	ret := m.ctrl.Call(m, "Visit", manager, thisRef, depth, mode, visitor)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Visit indicates an expected call of Visit.
-func (mr *MockleafNodeMockRecorder) Visit(source, thisRef, depth, visitor any) *gomock.Call {
+func (mr *MockleafNodeMockRecorder) Visit(manager, thisRef, depth, mode, visitor any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Visit", reflect.TypeOf((*MockleafNode)(nil).Visit), source, thisRef, depth, visitor)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Visit", reflect.TypeOf((*MockleafNode)(nil).Visit), manager, thisRef, depth, mode, visitor)
 }
 
 // setPathLength mocks base method.

--- a/go/database/mpt/proof/verification_mocks.go
+++ b/go/database/mpt/proof/verification_mocks.go
@@ -15,6 +15,7 @@
 //
 //	mockgen -source verification.go -destination verification_mocks.go -package proof
 //
+
 // Package proof is a generated GoMock package.
 package proof
 
@@ -31,6 +32,7 @@ import (
 type MockverifiableTrie struct {
 	ctrl     *gomock.Controller
 	recorder *MockverifiableTrieMockRecorder
+	isgomock struct{}
 }
 
 // MockverifiableTrieMockRecorder is the mock recorder for MockverifiableTrie.
@@ -118,37 +120,38 @@ func (mr *MockverifiableTrieMockRecorder) UpdateHashes() *gomock.Call {
 }
 
 // VisitAccountStorage mocks base method.
-func (m *MockverifiableTrie) VisitAccountStorage(address common.Address, visitor mpt.NodeVisitor) error {
+func (m *MockverifiableTrie) VisitAccountStorage(address common.Address, mode mpt.AccessMode, visitor mpt.NodeVisitor) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VisitAccountStorage", address, visitor)
+	ret := m.ctrl.Call(m, "VisitAccountStorage", address, mode, visitor)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // VisitAccountStorage indicates an expected call of VisitAccountStorage.
-func (mr *MockverifiableTrieMockRecorder) VisitAccountStorage(address, visitor any) *gomock.Call {
+func (mr *MockverifiableTrieMockRecorder) VisitAccountStorage(address, mode, visitor any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VisitAccountStorage", reflect.TypeOf((*MockverifiableTrie)(nil).VisitAccountStorage), address, visitor)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VisitAccountStorage", reflect.TypeOf((*MockverifiableTrie)(nil).VisitAccountStorage), address, mode, visitor)
 }
 
 // VisitTrie mocks base method.
-func (m *MockverifiableTrie) VisitTrie(visitor mpt.NodeVisitor) error {
+func (m *MockverifiableTrie) VisitTrie(mode mpt.AccessMode, visitor mpt.NodeVisitor) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VisitTrie", visitor)
+	ret := m.ctrl.Call(m, "VisitTrie", mode, visitor)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // VisitTrie indicates an expected call of VisitTrie.
-func (mr *MockverifiableTrieMockRecorder) VisitTrie(visitor any) *gomock.Call {
+func (mr *MockverifiableTrieMockRecorder) VisitTrie(mode, visitor any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VisitTrie", reflect.TypeOf((*MockverifiableTrie)(nil).VisitTrie), visitor)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VisitTrie", reflect.TypeOf((*MockverifiableTrie)(nil).VisitTrie), mode, visitor)
 }
 
 // MockverifiableArchiveTrie is a mock of verifiableArchiveTrie interface.
 type MockverifiableArchiveTrie struct {
 	ctrl     *gomock.Controller
 	recorder *MockverifiableArchiveTrieMockRecorder
+	isgomock struct{}
 }
 
 // MockverifiableArchiveTrieMockRecorder is the mock recorder for MockverifiableArchiveTrie.
@@ -251,29 +254,29 @@ func (mr *MockverifiableArchiveTrieMockRecorder) GetStorage(block, addr, key any
 }
 
 // VisitAccountStorage mocks base method.
-func (m *MockverifiableArchiveTrie) VisitAccountStorage(block uint64, address common.Address, visitor mpt.NodeVisitor) error {
+func (m *MockverifiableArchiveTrie) VisitAccountStorage(block uint64, address common.Address, mode mpt.AccessMode, visitor mpt.NodeVisitor) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VisitAccountStorage", block, address, visitor)
+	ret := m.ctrl.Call(m, "VisitAccountStorage", block, address, mode, visitor)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // VisitAccountStorage indicates an expected call of VisitAccountStorage.
-func (mr *MockverifiableArchiveTrieMockRecorder) VisitAccountStorage(block, address, visitor any) *gomock.Call {
+func (mr *MockverifiableArchiveTrieMockRecorder) VisitAccountStorage(block, address, mode, visitor any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VisitAccountStorage", reflect.TypeOf((*MockverifiableArchiveTrie)(nil).VisitAccountStorage), block, address, visitor)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VisitAccountStorage", reflect.TypeOf((*MockverifiableArchiveTrie)(nil).VisitAccountStorage), block, address, mode, visitor)
 }
 
 // VisitTrie mocks base method.
-func (m *MockverifiableArchiveTrie) VisitTrie(block uint64, visitor mpt.NodeVisitor) error {
+func (m *MockverifiableArchiveTrie) VisitTrie(block uint64, mode mpt.AccessMode, visitor mpt.NodeVisitor) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VisitTrie", block, visitor)
+	ret := m.ctrl.Call(m, "VisitTrie", block, mode, visitor)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // VisitTrie indicates an expected call of VisitTrie.
-func (mr *MockverifiableArchiveTrieMockRecorder) VisitTrie(block, visitor any) *gomock.Call {
+func (mr *MockverifiableArchiveTrieMockRecorder) VisitTrie(block, mode, visitor any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VisitTrie", reflect.TypeOf((*MockverifiableArchiveTrie)(nil).VisitTrie), block, visitor)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VisitTrie", reflect.TypeOf((*MockverifiableArchiveTrie)(nil).VisitTrie), block, mode, visitor)
 }

--- a/go/database/mpt/proof_mocks.go
+++ b/go/database/mpt/proof_mocks.go
@@ -15,6 +15,7 @@
 //
 //	mockgen -source proof.go -destination proof_mocks.go -package mpt
 //
+
 // Package mpt is a generated GoMock package.
 package mpt
 
@@ -29,6 +30,7 @@ import (
 type MockwitnessProofVisitor struct {
 	ctrl     *gomock.Controller
 	recorder *MockwitnessProofVisitorMockRecorder
+	isgomock struct{}
 }
 
 // MockwitnessProofVisitorMockRecorder is the mock recorder for MockwitnessProofVisitor.

--- a/go/database/mpt/proof_test.go
+++ b/go/database/mpt/proof_test.go
@@ -235,11 +235,11 @@ func TestCreateWitnessProof_CannotCreateProof_FailingNodeSources(t *testing.T) {
 
 	tests := []struct {
 		name string
-		mock func(*MockNodeSource)
+		mock func(*MockNodeManager)
 	}{
 		{
 			name: "call in account proof fails",
-			mock: func(mock *MockNodeSource) {
+			mock: func(mock *MockNodeManager) {
 				childId := NewNodeReference(ValueId(123))
 				branchNode := BranchNode{}
 				branchNode.setEmbedded(0xA, true)
@@ -250,7 +250,7 @@ func TestCreateWitnessProof_CannotCreateProof_FailingNodeSources(t *testing.T) {
 		},
 		{
 			name: "call in storage proof fails",
-			mock: func(mock *MockNodeSource) {
+			mock: func(mock *MockNodeManager) {
 				var account Node = &AccountNode{address: common.Address{0xA}}
 				gomock.InOrder(
 					mock.EXPECT().getViewAccess(gomock.Any()).Return(shared.MakeShared(account).GetViewHandle(), nil),
@@ -263,14 +263,14 @@ func TestCreateWitnessProof_CannotCreateProof_FailingNodeSources(t *testing.T) {
 	hash := common.Hash{0xA}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			nodeSource := NewMockNodeSource(ctrl)
-			nodeSource.EXPECT().getConfig().AnyTimes().Return(S5LiveConfig)
-			nodeSource.EXPECT().hashKey(gomock.Any()).AnyTimes().Return(hash)
-			nodeSource.EXPECT().hashAddress(gomock.Any()).AnyTimes().Return(hash)
-			test.mock(nodeSource)
+			nodeManager := NewMockNodeManager(ctrl)
+			nodeManager.EXPECT().getConfig().AnyTimes().Return(S5LiveConfig)
+			nodeManager.EXPECT().hashKey(gomock.Any()).AnyTimes().Return(hash)
+			nodeManager.EXPECT().hashAddress(gomock.Any()).AnyTimes().Return(hash)
+			test.mock(nodeManager)
 			root := NewNodeReference(EmptyId())
 
-			if _, err := CreateWitnessProof(nodeSource, &root, common.Address{0xA}, common.Key{0x1}); !errors.Is(err, injectedErr) {
+			if _, err := CreateWitnessProof(nodeManager, &root, common.Address{0xA}, common.Key{0x1}); !errors.Is(err, injectedErr) {
 				t.Errorf("getting proof should fail")
 			}
 		})
@@ -937,7 +937,7 @@ func TestCreateWitnessProof_Elements_Path_Sorted_By_Trie_Navigation(t *testing.T
 		mptNodes = append(mptNodes, immutable.NewBytes(rlp))
 		if account, ok := node.(*AccountNode); ok {
 			expectedStorageRootHash = account.storageHash
-			if _, err := VisitPathToStorage(ctxt, &account.storage, key, visitor); err != nil {
+			if _, err := VisitPathToStorage(ctxt, &account.storage, key, ReadAccess{}, visitor); err != nil {
 				t.Fatalf("failed to visit path: %v", err)
 			}
 		}
@@ -945,7 +945,7 @@ func TestCreateWitnessProof_Elements_Path_Sorted_By_Trie_Navigation(t *testing.T
 	}).AnyTimes()
 
 	// iterate over the path to get all nodes in order of the trie navigation
-	found, err := VisitPathToAccount(ctxt, &root, address, visitor)
+	found, err := VisitPathToAccount(ctxt, &root, address, ReadAccess{}, visitor)
 	if err != nil {
 		t.Fatalf("failed to visit path: %v", err)
 	}
@@ -1725,7 +1725,7 @@ func createReferenceProof(t *testing.T, ctxt *nodeContext, root *NodeReference, 
 	t.Helper()
 	proof := proofDb{}
 	handle := node.GetViewHandle()
-	_, err := handle.Get().Visit(ctxt, root, 0, MakeVisitor(func(node Node, info NodeInfo) VisitResponse {
+	_, err := handle.Get().Visit(ctxt, root, 0, ViewAccess{}, MakeVisitor(func(node Node, info NodeInfo) VisitResponse {
 		if _, ok := node.(EmptyNode); ok {
 			// nodes that are not correct terminal values are not present in the proof
 			return VisitResponseContinue

--- a/go/database/mpt/state.go
+++ b/go/database/mpt/state.go
@@ -65,8 +65,8 @@ type Database interface {
 	// Freeze seals current trie, preventing further updates to it.
 	Freeze(ref *NodeReference) error
 
-	// VisitTrie allows for travertines the whole trie under the input root
-	VisitTrie(rootRef *NodeReference, visitor NodeVisitor) error
+	// VisitTrie allows for traversing the whole trie under the input root
+	VisitTrie(rootRef *NodeReference, mode AccessMode, visitor NodeVisitor) error
 
 	// Dump provides a debug print of the whole trie under the input root
 	Dump(rootRef *NodeReference)
@@ -346,8 +346,8 @@ func (s *MptState) Apply(block uint64, update common.Update) (archiveUpdateHints
 	return hints, err
 }
 
-func (s *MptState) Visit(visitor NodeVisitor) error {
-	return s.trie.VisitTrie(visitor)
+func (s *MptState) Visit(mode AccessMode, visitor NodeVisitor) error {
+	return s.trie.VisitTrie(mode, visitor)
 }
 
 func (s *MptState) GetCodes() map[common.Hash][]byte {

--- a/go/database/mpt/state_mocks.go
+++ b/go/database/mpt/state_mocks.go
@@ -15,6 +15,7 @@
 //
 //	mockgen -source state.go -destination state_mocks.go -package mpt
 //
+
 // Package mpt is a generated GoMock package.
 package mpt
 
@@ -32,6 +33,7 @@ import (
 type MockDatabase struct {
 	ctrl     *gomock.Controller
 	recorder *MockDatabaseMockRecorder
+	isgomock struct{}
 }
 
 // MockDatabaseMockRecorder is the mock recorder for MockDatabase.
@@ -253,17 +255,17 @@ func (mr *MockDatabaseMockRecorder) SetValue(rootRef, addr, key, value any) *gom
 }
 
 // VisitTrie mocks base method.
-func (m *MockDatabase) VisitTrie(rootRef *NodeReference, visitor NodeVisitor) error {
+func (m *MockDatabase) VisitTrie(rootRef *NodeReference, mode AccessMode, visitor NodeVisitor) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VisitTrie", rootRef, visitor)
+	ret := m.ctrl.Call(m, "VisitTrie", rootRef, mode, visitor)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // VisitTrie indicates an expected call of VisitTrie.
-func (mr *MockDatabaseMockRecorder) VisitTrie(rootRef, visitor any) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) VisitTrie(rootRef, mode, visitor any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VisitTrie", reflect.TypeOf((*MockDatabase)(nil).VisitTrie), rootRef, visitor)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VisitTrie", reflect.TypeOf((*MockDatabase)(nil).VisitTrie), rootRef, mode, visitor)
 }
 
 // createAccount mocks base method.
@@ -507,6 +509,7 @@ func (mr *MockDatabaseMockRecorder) updateHashesFor(ref any) *gomock.Call {
 type MockLiveState struct {
 	ctrl     *gomock.Controller
 	recorder *MockLiveStateMockRecorder
+	isgomock struct{}
 }
 
 // MockLiveStateMockRecorder is the mock recorder for MockLiveState.

--- a/go/database/mpt/state_test.go
+++ b/go/database/mpt/state_test.go
@@ -296,7 +296,7 @@ func TestState_StateModifications_Failing(t *testing.T) {
 	db.EXPECT().SetAccountInfo(gomock.Any(), gomock.Any(), gomock.Any()).Return(NodeReference{}, injectedErr).AnyTimes()
 	db.EXPECT().GetValue(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.Value{}, injectedErr).AnyTimes()
 	db.EXPECT().SetValue(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(NodeReference{}, injectedErr).AnyTimes()
-	db.EXPECT().VisitTrie(gomock.Any(), gomock.Any()).Return(injectedErr)
+	db.EXPECT().VisitTrie(gomock.Any(), gomock.Any(), gomock.Any()).Return(injectedErr)
 	db.EXPECT().CheckErrors()
 	db.EXPECT().Close()
 
@@ -357,7 +357,7 @@ func TestState_StateModifications_Failing(t *testing.T) {
 		t.Errorf("accessing data should fail")
 	}
 	nodeVisitor := NewMockNodeVisitor(ctrl)
-	if err := state.Visit(nodeVisitor); !errors.Is(err, injectedErr) {
+	if err := state.Visit(ReadAccess{}, nodeVisitor); !errors.Is(err, injectedErr) {
 		t.Errorf("accessing data should fail")
 	}
 }

--- a/go/database/mpt/verification_mocks.go
+++ b/go/database/mpt/verification_mocks.go
@@ -29,6 +29,7 @@ import (
 type MockVerificationObserver struct {
 	ctrl     *gomock.Controller
 	recorder *MockVerificationObserverMockRecorder
+	isgomock struct{}
 }
 
 // MockVerificationObserverMockRecorder is the mock recorder for MockVerificationObserver.

--- a/go/database/mpt/visitor.go
+++ b/go/database/mpt/visitor.go
@@ -14,8 +14,9 @@ package mpt
 
 import (
 	"fmt"
-	"github.com/0xsoniclabs/carmen/go/common/tribool"
 	"strings"
+
+	"github.com/0xsoniclabs/carmen/go/common/tribool"
 )
 
 // ----------------------------------------------------------------------------
@@ -89,7 +90,7 @@ func (v *lambdaVisitor) Visit(n Node, i NodeInfo) VisitResponse {
 // GetTrieNodeStatistics computes node statistics for the given Trie.
 func GetTrieNodeStatistics(trie *LiveTrie) (NodeStatistic, error) {
 	collector := &nodeStatisticsCollector{}
-	if err := trie.VisitTrie(collector); err != nil {
+	if err := trie.VisitTrie(ReadAccess{}, collector); err != nil {
 		return NodeStatistic{}, err
 	}
 	return collector.stats, nil

--- a/go/database/mpt/visitor_mocks.go
+++ b/go/database/mpt/visitor_mocks.go
@@ -29,6 +29,7 @@ import (
 type MockNodeVisitor struct {
 	ctrl     *gomock.Controller
 	recorder *MockNodeVisitorMockRecorder
+	isgomock struct{}
 }
 
 // MockNodeVisitorMockRecorder is the mock recorder for MockNodeVisitor.

--- a/go/database/mpt/write_buffer_mocks.go
+++ b/go/database/mpt/write_buffer_mocks.go
@@ -30,6 +30,7 @@ import (
 type MockWriteBuffer struct {
 	ctrl     *gomock.Controller
 	recorder *MockWriteBufferMockRecorder
+	isgomock struct{}
 }
 
 // MockWriteBufferMockRecorder is the mock recorder for MockWriteBuffer.
@@ -108,6 +109,7 @@ func (mr *MockWriteBufferMockRecorder) Flush() *gomock.Call {
 type MockNodeSink struct {
 	ctrl     *gomock.Controller
 	recorder *MockNodeSinkMockRecorder
+	isgomock struct{}
 }
 
 // MockNodeSinkMockRecorder is the mock recorder for MockNodeSink.


### PR DESCRIPTION
This PR adds an additional parameter to core `Visit` functions facilitating the specification of the access permissions that should be used while performing the iteration through a trie. The supported options are analog to the modes of the locking [schema](https://github.com/0xsoniclabs/carmen/blob/5b29ffd54847c45ac59be6f5afde3e4c0d6032b9/go/database/mpt/shared/shared.go#L24-L41):
  - read access: grants users to read content fields of the object
  - view access: grants users to read content and hash fields
  - hash access: grants users to read content and write hash fields
  - write access: grants write permission to content and hash fields

This extension facilitates the more accurate specification of node access permissions, enabling more elaborate concurrent access patterns.