### PR TITLE
Fix print-out of balances and nonces in updates

### DIFF
--- a/go/common/update.go
+++ b/go/common/update.go
@@ -187,13 +187,13 @@ func (u *Update) String() string {
 	if len(u.Balances) > 0 {
 		builder.WriteString("\tBalances:\n")
 		for _, change := range u.Balances {
-			builder.WriteString(fmt.Sprintf("\t\t%v: %x\n", change.Account, change.Balance))
+			builder.WriteString(fmt.Sprintf("\t\t%v: %v\n", change.Account, change.Balance))
 		}
 	}
 	if len(u.Nonces) > 0 {
 		builder.WriteString("\tNonces:\n")
 		for _, change := range u.Nonces {
-			builder.WriteString(fmt.Sprintf("\t\t%v: %x\n", change.Account, change.Nonce))
+			builder.WriteString(fmt.Sprintf("\t\t%v: %d\n", change.Account, change.Nonce.ToUint64()))
 		}
 	}
 	if len(u.Codes) > 0 {

--- a/go/common/update_test.go
+++ b/go/common/update_test.go
@@ -551,7 +551,7 @@ func TestUpdate_Print(t *testing.T) {
 	update.AppendDeleteAccount(Address{1})
 	update.AppendCreateAccount(Address{2})
 	update.AppendBalanceUpdate(Address{3}, amount.New(1))
-	update.AppendNonceUpdate(Address{4}, Nonce{2})
+	update.AppendNonceUpdate(Address{4}, ToNonce(2))
 	update.AppendCodeUpdate(Address{5}, []byte{1, 2, 3})
 	update.AppendSlotUpdate(Address{6}, Key{1}, Value{2})
 
@@ -563,6 +563,8 @@ func TestUpdate_Print(t *testing.T) {
 		"Balances:",
 		"Nonces:",
 		"Slots:",
+		"0300000000000000000000000000000000000000: 1", // decimal balance
+		"0400000000000000000000000000000000000000: 2", // decimal nonce
 	}
 
 	for _, expectation := range expectations {


### PR DESCRIPTION
This PR fixes a cosmetic issue encountered while debugging some other issues: in Updates, balances got printed as the hex-encoding of their decimal encoding. 

This PR fixes the output format for balances and nonces to use decimal values.