### PR TITLE
Prevent opening a DB with NoArchive option if there is an archive

### DIFF
--- a/go/state/gostate/configurations_test.go
+++ b/go/state/gostate/configurations_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package gostate
+
+import (
+	"os"
+	"testing"
+
+	"github.com/0xsoniclabs/carmen/go/state"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenArchive_FailsForNoArchiveIfThereIsAnArchive(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+
+	params := state.Parameters{
+		Directory: dir,
+		Archive:   state.S5Archive,
+	}
+
+	// Create an archive in the directory.
+	archive, cleanup, err := openArchive(params)
+	require.NoError(err)
+	require.Nil(cleanup)
+	require.NoError(archive.Close())
+
+	// Reopening the archive with the NoArchive option should fail.
+	params.Archive = state.NoArchive
+	_, _, err = openArchive(params)
+	require.Error(err)
+}
+
+func TestOpenArchive_FailsForNoArchiveIfTheArchiveDirectoryCanNotBeAccessed(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+
+	params := state.Parameters{
+		Directory: dir,
+	}
+
+	path, err := prepareArchiveDirectory(params)
+	require.NoError(err)
+
+	// An empty archive can be opened as a No-Archive.
+	archive, cleanup, err := openArchive(params)
+	require.NoError(err)
+	require.Nil(archive)
+	require.Nil(cleanup)
+
+	// If the empty archive can not be accessed, an error should be returned.
+	os.Chmod(path, 0000)
+	defer os.Chmod(path, 0755)
+
+	_, _, err = openArchive(params)
+	require.Error(err)
+}

--- a/go/state/gostate/go_schema5.go
+++ b/go/state/gostate/go_schema5.go
@@ -43,7 +43,7 @@ func newS5State(params state.Parameters, mptState *mpt.MptState) (state.State, e
 
 	if params.Archive == state.S5Archive {
 		// We can ignore archiveCleanup because it is not used for S5Archive,
-		// it is used for leveldb only
+		// it is used for LevelDB only
 		archiveBlockHeight, empty, err := arch.GetBlockHeight()
 		if err != nil {
 			return nil, errors.Join(err, arch.Close(), mptState.Close())


### PR DESCRIPTION
This is a proposed usability improvement prevents a DB with an archive to be opened using the `NoArchive` option.