### PR TITLE
Adapts VerkleTrie from go-ethereum

### DIFF
--- a/go/database/vt/geth/memory_source.go
+++ b/go/database/vt/geth/memory_source.go
@@ -32,10 +32,7 @@ func NewMemorySource() NodeSource {
 
 func (s *memorySource) Node(owner common.Hash, path []byte, hash common.Hash) ([]byte, error) {
 	key := immutable.NewBytes(path)
-	if node, exists := s.nodes[key]; exists {
-		return node, nil
-	}
-	return nil, nil
+	return s.nodes[key], nil
 }
 
 func (s *memorySource) Set(path []byte, value []byte) error {

--- a/go/database/vt/geth/memory_source.go
+++ b/go/database/vt/geth/memory_source.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package geth
+
+import (
+	"github.com/0xsoniclabs/carmen/go/common/immutable"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// NodeSource is an interface for retrieving and storing nodes in memory.
+// It serves as a base for different node storage implementations, such as
+// in-memory storage, cached storage, or persistent storage.
+// It is itself not intended for real-life usage, as the amount of memory
+// would quickly grow to an unmanageable size.
+type memorySource struct {
+	nodes map[immutable.Bytes][]byte
+}
+
+func NewMemorySource() NodeSource {
+	return &memorySource{
+		nodes: make(map[immutable.Bytes][]byte),
+	}
+}
+
+func (s *memorySource) Node(owner common.Hash, path []byte, hash common.Hash) ([]byte, error) {
+	key := immutable.NewBytes(path)
+	if node, exists := s.nodes[key]; exists {
+		return node, nil
+	}
+	return nil, nil
+}
+
+func (s *memorySource) Set(path []byte, value []byte) error {
+	s.nodes[immutable.NewBytes(path)] = value
+
+	return nil
+}
+
+func (s *memorySource) Flush() error {
+	return nil
+}
+
+func (s *memorySource) Close() error {
+	return s.Flush()
+}

--- a/go/database/vt/geth/memory_source.go
+++ b/go/database/vt/geth/memory_source.go
@@ -21,22 +21,26 @@ import (
 // It is itself not intended for real-life usage, as the amount of memory
 // would quickly grow to an unmanageable size.
 type memorySource struct {
-	nodes map[immutable.Bytes][]byte
+	nodes map[immutable.Bytes]immutable.Bytes
 }
 
-func NewMemorySource() NodeSource {
+func newMemorySource() nodeSource {
 	return &memorySource{
-		nodes: make(map[immutable.Bytes][]byte),
+		nodes: make(map[immutable.Bytes]immutable.Bytes),
 	}
 }
 
 func (s *memorySource) Node(owner common.Hash, path []byte, hash common.Hash) ([]byte, error) {
 	key := immutable.NewBytes(path)
-	return s.nodes[key], nil
+	bytes, exists := s.nodes[key]
+	if !exists {
+		return nil, nil
+	}
+	return bytes.ToBytes(), nil
 }
 
-func (s *memorySource) Set(path []byte, value []byte) error {
-	s.nodes[immutable.NewBytes(path)] = value
+func (s *memorySource) set(path []byte, value []byte) error {
+	s.nodes[immutable.NewBytes(path)] = immutable.NewBytes(value)
 
 	return nil
 }

--- a/go/database/vt/geth/memory_source_test.go
+++ b/go/database/vt/geth/memory_source_test.go
@@ -7,11 +7,14 @@
 //
 // On the date above, in accordance with the Business Source License, use of
 // this software will be governed by the GNU Lesser General Public License v3.
+
 package geth
 
 import (
-	"github.com/ethereum/go-ethereum/common"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMemorySource_SetAndGetNode(t *testing.T) {
@@ -23,32 +26,18 @@ func TestMemorySource_SetAndGetNode(t *testing.T) {
 
 	// Initially, Node should return nil
 	got, err := src.Node(owner, path, hash)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got != nil {
-		t.Errorf("expected nil, got %v", got)
-	}
+	require.NoError(t, err, "unexpected error")
+	require.Nil(t, got, "expected nil")
 
 	// Set value and retrieve
-	if err := src.set(path, value); err != nil {
-		t.Fatalf("set failed: %v", err)
-	}
+	require.NoError(t, src.set(path, value), "set failed")
 	got, err = src.Node(owner, path, hash)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if string(got) != string(value) {
-		t.Errorf("expected %v, got %v", value, got)
-	}
+	require.NoError(t, err, "unexpected error")
+	require.Equal(t, value, got, "unexpected value")
 }
 
 func TestMemorySource_FlushAndClose(t *testing.T) {
 	src := newMemorySource()
-	if err := src.Flush(); err != nil {
-		t.Errorf("Flush should not error, got %v", err)
-	}
-	if err := src.Close(); err != nil {
-		t.Errorf("Close should not error, got %v", err)
-	}
+	require.NoError(t, src.Flush(), "Flush should not error")
+	require.NoError(t, src.Close(), "Close should not error")
 }

--- a/go/database/vt/geth/memory_source_test.go
+++ b/go/database/vt/geth/memory_source_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+package geth
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"testing"
+)
+
+func TestMemorySource_SetAndGetNode(t *testing.T) {
+	src := newMemorySource()
+	path := []byte{1, 2, 3}
+	value := []byte{4, 5, 6}
+	owner := common.Hash{}
+	hash := common.Hash{}
+
+	// Initially, Node should return nil
+	got, err := src.Node(owner, path, hash)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+
+	// Set value and retrieve
+	if err := src.set(path, value); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+	got, err = src.Node(owner, path, hash)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != string(value) {
+		t.Errorf("expected %v, got %v", value, got)
+	}
+}
+
+func TestMemorySource_FlushAndClose(t *testing.T) {
+	src := newMemorySource()
+	if err := src.Flush(); err != nil {
+		t.Errorf("Flush should not error, got %v", err)
+	}
+	if err := src.Close(); err != nil {
+		t.Errorf("Close should not error, got %v", err)
+	}
+}

--- a/go/database/vt/geth/node_source.go
+++ b/go/database/vt/geth/node_source.go
@@ -25,7 +25,7 @@ type nodeSource interface {
 	database.NodeReader
 
 	// set sets the node at the given path.
-	// The input is navigation path in tree and the serialised node.
+	// The input is navigation path in the tree and the serialised node.
 	set(path []byte, value []byte) error
 }
 

--- a/go/database/vt/geth/node_source.go
+++ b/go/database/vt/geth/node_source.go
@@ -26,7 +26,7 @@ type NodeSource interface {
 	database.NodeReader
 
 	// Set sets the node at the given path.
-	// The input is navigation path in three and the serialised node.
+	// The input is navigation path in tree and the serialised node.
 	Set(path []byte, value []byte) error
 }
 

--- a/go/database/vt/geth/node_source.go
+++ b/go/database/vt/geth/node_source.go
@@ -24,7 +24,7 @@ type nodeSource interface {
 	common.FlushAndCloser
 	database.NodeReader
 
-	// Set sets the node at the given path.
+	// set sets the node at the given path.
 	// The input is navigation path in tree and the serialised node.
 	set(path []byte, value []byte) error
 }

--- a/go/database/vt/geth/node_source.go
+++ b/go/database/vt/geth/node_source.go
@@ -17,7 +17,7 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 
-// NodeSource is an interface for a source of verkle nodes.
+// nodeSource is an interface for a source of verkle nodes.
 // It provides methods to get and set nodes at specific paths.
 // It supports the adaptation for Geth's Verkle trie implementation.
 // adopted from Geth implementation.

--- a/go/database/vt/geth/node_source.go
+++ b/go/database/vt/geth/node_source.go
@@ -21,26 +21,26 @@ import (
 // It provides methods to get and set nodes at specific paths.
 // It supports the adaptation for Geth's Verkle trie implementation.
 // adopted from Geth implementation.
-type NodeSource interface {
+type nodeSource interface {
 	common.FlushAndCloser
 	database.NodeReader
 
 	// Set sets the node at the given path.
 	// The input is navigation path in tree and the serialised node.
-	Set(path []byte, value []byte) error
+	set(path []byte, value []byte) error
 }
 
-// singletonNodeReader is a wrapper around a single NodeReader.
+// singleNodeReader is a wrapper around a single NodeReader.
 // When the method NodeReader is called, it returns always the same NodeReader.
-type singletonNodeReader struct {
-	source NodeSource
+type singleNodeReader struct {
+	source nodeSource
 }
 
-func (r singletonNodeReader) NodeReader(stateRoot ethcommon.Hash) (database.NodeReader, error) {
+func (r singleNodeReader) NodeReader(stateRoot ethcommon.Hash) (database.NodeReader, error) {
 	return r.source, nil
 }
 
 // get is a convenience method to retrieve the underlying NodeSource.
-func (r singletonNodeReader) get() NodeSource {
+func (r singleNodeReader) getSource() nodeSource {
 	return r.source
 }

--- a/go/database/vt/geth/node_source.go
+++ b/go/database/vt/geth/node_source.go
@@ -20,7 +20,6 @@ import (
 // nodeSource is an interface for a source of verkle nodes.
 // It provides methods to get and set nodes at specific paths.
 // It supports the adaptation for Geth's Verkle trie implementation.
-// adopted from Geth implementation.
 type nodeSource interface {
 	common.FlushAndCloser
 	database.NodeReader

--- a/go/database/vt/geth/node_source.go
+++ b/go/database/vt/geth/node_source.go
@@ -19,7 +19,7 @@ import (
 
 // NodeSource is an interface for a source of verkle nodes.
 // It provides methods to get and set nodes at specific paths.
-// It is implemented to support implementation of verkle trie
+// It supports the adaptation for Geth's Verkle trie implementation.
 // adopted from Geth implementation.
 type NodeSource interface {
 	common.FlushAndCloser

--- a/go/database/vt/geth/node_source.go
+++ b/go/database/vt/geth/node_source.go
@@ -31,7 +31,7 @@ type NodeSource interface {
 }
 
 // singletonNodeReader is a wrapper around a single NodeReader.
-// When method NodeReader is called, it returns always the same NodeReader.
+// When the method NodeReader is called, it returns always the same NodeReader.
 type singletonNodeReader struct {
 	source NodeSource
 }

--- a/go/database/vt/geth/node_source.go
+++ b/go/database/vt/geth/node_source.go
@@ -39,7 +39,7 @@ func (r singleNodeReader) NodeReader(stateRoot ethcommon.Hash) (database.NodeRea
 	return r.source, nil
 }
 
-// get is a convenience method to retrieve the underlying NodeSource.
+// getSource is a convenience method to retrieve the underlying NodeSource.
 func (r singleNodeReader) getSource() nodeSource {
 	return r.source
 }

--- a/go/database/vt/geth/node_source.go
+++ b/go/database/vt/geth/node_source.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package geth
+
+import (
+	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/ethereum/go-ethereum/triedb/database"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+)
+
+// NodeSource is an interface for a source of verkle nodes.
+// It provides methods to get and set nodes at specific paths.
+// It is implemented to support implementation of verkle trie
+// adopted from Geth implementation.
+type NodeSource interface {
+	common.FlushAndCloser
+	database.NodeReader
+
+	// Set sets the node at the given path.
+	// The input is navigation path in three and the serialised node.
+	Set(path []byte, value []byte) error
+}
+
+// singletonNodeReader is a wrapper around a single NodeReader.
+// When method NodeReader is called, it returns always the same NodeReader.
+type singletonNodeReader struct {
+	source NodeSource
+}
+
+func (r singletonNodeReader) NodeReader(stateRoot ethcommon.Hash) (database.NodeReader, error) {
+	return r.source, nil
+}
+
+// get is a convenience method to retrieve the underlying NodeSource.
+func (r singletonNodeReader) get() NodeSource {
+	return r.source
+}

--- a/go/database/vt/geth/state.go
+++ b/go/database/vt/geth/state.go
@@ -1,0 +1,296 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package geth
+
+import (
+	"context"
+	"errors"
+	"github.com/0xsoniclabs/carmen/go/backend"
+	"github.com/0xsoniclabs/carmen/go/backend/archive"
+	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/0xsoniclabs/carmen/go/common/amount"
+	"github.com/0xsoniclabs/carmen/go/common/witness"
+	"github.com/0xsoniclabs/carmen/go/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/trie"
+	"github.com/ethereum/go-ethereum/trie/utils"
+	"io"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+)
+
+func init() {
+	// Verkle Trie schemas
+	state.RegisterStateFactory(state.Configuration{
+		Variant: "geth-memory",
+		Schema:  6,
+		Archive: state.NoArchive,
+	}, NewState)
+}
+
+// NewState creates a new verkle state using an in-memory source.
+// It uses Verkle Trie from the Ethereum Geth implementation.
+// This state is experimental, stores data in-memory only,
+// and not intended for production use.
+func NewState(params state.Parameters) (state.State, error) {
+	source := singletonNodeReader{source: NewMemorySource()}
+	pointCache := utils.NewPointCache(4096)
+	vt, err := trie.NewVerkleTrie(ethcommon.Hash{}, source, pointCache)
+	if err != nil {
+		return nil, errors.Join(source.get().Close(), err)
+	}
+	return &verkleState{
+		pointCache: pointCache,
+		verkle:     vt,
+		source:     source,
+		codes:      make(map[common.Address][]byte),
+	}, nil
+}
+
+// verkleState implements the state.State interface for a verkle trie.
+// It adapts to the VerkleTrie implementation from the Ethereum Geth library.
+// This is a reference implementation to compare with the original Geth.
+type verkleState struct {
+	pointCache *utils.PointCache
+	verkle     *trie.VerkleTrie
+	source     singletonNodeReader
+	codes      map[common.Address][]byte // current Verkle Trie does not support code storage, so we use a map to store codes
+}
+
+func (s *verkleState) DeleteAccount(address common.Address) error {
+	account := types.NewEmptyStateAccount()
+	return s.verkle.UpdateAccount(ethcommon.Address(address), account, 0)
+}
+
+func (s *verkleState) SetNonce(address common.Address, nonce common.Nonce) error {
+	account, err := s.getAccount(address)
+	if err != nil {
+		return err
+	}
+
+	account.Nonce = nonce.ToUint64()
+	return s.verkle.UpdateAccount(ethcommon.Address(address), account, 0)
+}
+
+func (s *verkleState) SetStorage(address common.Address, key common.Key, value common.Value) error {
+	return s.verkle.UpdateStorage(ethcommon.Address(address), key[:], value[:])
+}
+
+func (s *verkleState) SetCode(address common.Address, code []byte) error {
+	account, err := s.getAccount(address)
+	if err != nil {
+		return err
+	}
+
+	// update code len and code hash first
+	codeHash := common.Keccak256(code)
+	account.CodeHash = codeHash[:]
+	if err := s.verkle.UpdateAccount(ethcommon.Address(address), account, len(code)); err != nil {
+		return err
+	}
+
+	// insert code into the trie
+	if err := s.verkle.UpdateContractCode(ethcommon.Address(address), ethcommon.Hash(codeHash), code); err != nil {
+		return err
+	}
+
+	// put in the local map for retrieval
+	s.codes[address] = code
+	return nil
+}
+
+func (s *verkleState) Exists(address common.Address) (bool, error) {
+	account, err := s.getAccount(address)
+	if err != nil {
+		return false, err
+	}
+
+	return account.Nonce != 0 || account.Balance.Uint64() != 0, nil
+}
+
+func (s *verkleState) GetNonce(address common.Address) (common.Nonce, error) {
+	account, err := s.getAccount(address)
+	if err != nil {
+		return common.Nonce{}, err
+	}
+
+	return common.ToNonce(account.Nonce), nil
+}
+
+func (s *verkleState) GetStorage(address common.Address, key common.Key) (common.Value, error) {
+	value, err := s.verkle.GetStorage(ethcommon.Address(address), key[:])
+	if value == nil || err != nil {
+		return common.Value{}, err
+	}
+
+	return common.Value(value), nil
+}
+
+func (s *verkleState) GetCode(address common.Address) ([]byte, error) {
+	// current Verkle Trie does not support retrieval of codes, i.e. we pick them from the map
+	return s.codes[address], nil
+}
+
+func (s *verkleState) GetCodeSize(address common.Address) (int, error) {
+	code := s.codes[address]
+	if code == nil {
+		return 0, nil
+	}
+
+	return len(code), nil
+}
+
+func (s *verkleState) GetCodeHash(address common.Address) (common.Hash, error) {
+	account, err := s.getAccount(address)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	return common.Hash(account.CodeHash), nil
+}
+
+func (s *verkleState) HasEmptyStorage(addr common.Address) (bool, error) {
+	return false, nil
+}
+
+func (s *verkleState) GetHash() (common.Hash, error) {
+	return common.Hash(s.verkle.Hash()), nil
+}
+
+func (s *verkleState) GetMemoryFootprint() *common.MemoryFootprint {
+	return common.NewMemoryFootprint(uintptr(1))
+}
+
+func (s *verkleState) GetArchiveState(block uint64) (state.State, error) {
+	return nil, state.NoArchiveError
+}
+
+func (s *verkleState) GetArchiveBlockHeight() (height uint64, empty bool, err error) {
+	return 0, true, nil
+}
+
+func (s *verkleState) CreateAccount(address common.Address) error {
+	account := types.NewEmptyStateAccount()
+	return s.verkle.UpdateAccount(ethcommon.Address(address), account, 0)
+}
+
+func (s *verkleState) SetBalance(address common.Address, balance amount.Amount) error {
+	account, err := s.getAccount(address)
+	if err != nil {
+		return err
+	}
+
+	val := balance.Uint256()
+	account.Balance = &val
+
+	return s.verkle.UpdateAccount(ethcommon.Address(address), account, 0)
+}
+
+func (s *verkleState) GetBalance(address common.Address) (amount.Amount, error) {
+	account, err := s.getAccount(address)
+	if err != nil {
+		return amount.Amount{}, err
+	}
+
+	return amount.NewFromUint256(account.Balance), nil
+}
+
+func (s *verkleState) Apply(block uint64, update common.Update) error {
+	if err := update.ApplyTo(s); err != nil {
+		return err
+	}
+
+	// Propagate all nodes into the database
+	var errs []error
+
+	rootHash, nodeSet := s.verkle.Commit(false)
+	for path, node := range nodeSet.Nodes {
+		errs = append(errs, s.source.get().Set([]byte(path), node.Blob))
+	}
+
+	if err := errors.Join(errs...); err != nil {
+		return err
+	}
+
+	// recreate the verkle trie to flush the in-memory nodes
+	vt, err := trie.NewVerkleTrie(rootHash, s.source, s.pointCache)
+	s.verkle = vt
+
+	return err
+}
+
+//
+//		Witness Proof features -- not supported at the moment
+//
+
+func (s *verkleState) CreateWitnessProof(address common.Address, keys ...common.Key) (witness.Proof, error) {
+	return nil, archive.ErrWitnessProofNotSupported // not supported at the moment, will be implemented later
+}
+
+//
+//		Snapshot features -- not supported in Verkle Trie
+//
+
+func (s *verkleState) GetProof() (backend.Proof, error) {
+	return nil, archive.ErrWitnessProofNotSupported // not supported at the moment, will be implemented later
+}
+
+func (s *verkleState) CreateSnapshot() (backend.Snapshot, error) {
+	return nil, backend.ErrSnapshotNotSupported
+}
+
+func (s *verkleState) Restore(data backend.SnapshotData) error {
+	return backend.ErrSnapshotNotSupported
+}
+
+func (s *verkleState) GetSnapshotVerifier(metadata []byte) (backend.SnapshotVerifier, error) {
+	return nil, backend.ErrSnapshotNotSupported
+}
+
+//
+//	Operation features -- not supported
+//
+
+func (s *verkleState) Export(ctx context.Context, out io.Writer) (common.Hash, error) {
+	return common.Hash{}, nil
+}
+
+func (s *verkleState) Check() error {
+	return nil
+}
+
+func (s *verkleState) MemoryFootprint() uint64 {
+	return 0
+}
+
+//
+//	I/O features
+//
+
+func (s *verkleState) Flush() error {
+	return s.source.get().Flush()
+}
+
+func (s *verkleState) Close() error {
+	return s.source.get().Close()
+}
+
+func (s *verkleState) getAccount(address common.Address) (*types.StateAccount, error) {
+	account, err := s.verkle.GetAccount(ethcommon.Address(address))
+	if err != nil {
+		return nil, err
+	}
+	if account == nil {
+		account = types.NewEmptyStateAccount()
+	}
+
+	return account, nil
+}

--- a/go/database/vt/geth/state.go
+++ b/go/database/vt/geth/state.go
@@ -39,7 +39,7 @@ func init() {
 }
 
 // NewState creates a new verkle state using an in-memory source.
-// It uses Verkle Trie from the Ethereum Geth implementation.
+// It uses the Verkle Trie from the Ethereum Geth implementation.
 // This state is experimental, stores data in-memory only,
 // and not intended for production use.
 func NewState(params state.Parameters) (state.State, error) {

--- a/go/database/vt/geth/state.go
+++ b/go/database/vt/geth/state.go
@@ -160,7 +160,7 @@ func (s *verkleState) GetCodeHash(address common.Address) (common.Hash, error) {
 }
 
 func (s *verkleState) HasEmptyStorage(addr common.Address) (bool, error) {
-	return false, nil
+	return false, fmt.Errorf("not supported: verkle trie does not support has empty storage")
 }
 
 func (s *verkleState) GetHash() (common.Hash, error) {
@@ -176,7 +176,7 @@ func (s *verkleState) GetArchiveState(block uint64) (state.State, error) {
 }
 
 func (s *verkleState) GetArchiveBlockHeight() (height uint64, empty bool, err error) {
-	return 0, true, nil
+	return 0, true, state.NoArchiveError
 }
 
 func (s *verkleState) CreateAccount(address common.Address) error {
@@ -242,7 +242,7 @@ func (s *verkleState) CreateWitnessProof(address common.Address, keys ...common.
 //
 
 func (s *verkleState) GetProof() (backend.Proof, error) {
-	return nil, archive.ErrWitnessProofNotSupported // not supported at the moment, will be implemented later
+	return nil, backend.ErrSnapshotNotSupported // not supported at the moment, will be implemented later
 }
 
 func (s *verkleState) CreateSnapshot() (backend.Snapshot, error) {
@@ -262,15 +262,11 @@ func (s *verkleState) GetSnapshotVerifier(metadata []byte) (backend.SnapshotVeri
 //
 
 func (s *verkleState) Export(ctx context.Context, out io.Writer) (common.Hash, error) {
-	return common.Hash{}, nil
+	return common.Hash{}, fmt.Errorf("not supported: verkle trie does not support export")
 }
 
 func (s *verkleState) Check() error {
 	return nil
-}
-
-func (s *verkleState) MemoryFootprint() uint64 {
-	return 0
 }
 
 //

--- a/go/database/vt/geth/state.go
+++ b/go/database/vt/geth/state.go
@@ -63,7 +63,7 @@ type verkleState struct {
 	pointCache *utils.PointCache
 	verkle     *trie.VerkleTrie
 	source     singletonNodeReader
-	codes      map[common.Address][]byte // current Verkle Trie does not support code storage, so we use a map to store codes
+	codes      map[common.Address][]byte // current Verkle Trie does not support code retrieval, so we use a map to store codes
 }
 
 func (s *verkleState) DeleteAccount(address common.Address) error {

--- a/go/database/vt/geth/state.go
+++ b/go/database/vt/geth/state.go
@@ -78,7 +78,13 @@ func (s *verkleState) SetNonce(address common.Address, nonce common.Nonce) error
 	}
 
 	account.Nonce = nonce.ToUint64()
-	return s.verkle.UpdateAccount(ethcommon.Address(address), account, 0) // TODO codeLen must be set
+
+	size, err := s.GetCodeSize(address)
+	if err != nil {
+		return err
+	}
+
+	return s.verkle.UpdateAccount(ethcommon.Address(address), account, size)
 }
 
 func (s *verkleState) SetStorage(address common.Address, key common.Key, value common.Value) error {
@@ -194,7 +200,12 @@ func (s *verkleState) SetBalance(address common.Address, balance amount.Amount) 
 	val := balance.Uint256()
 	account.Balance = &val
 
-	return s.verkle.UpdateAccount(ethcommon.Address(address), account, 0) // TODO codeLen must be set
+	size, err := s.GetCodeSize(address)
+	if err != nil {
+		return err
+	}
+
+	return s.verkle.UpdateAccount(ethcommon.Address(address), account, size)
 }
 
 func (s *verkleState) GetBalance(address common.Address) (amount.Amount, error) {

--- a/go/database/vt/geth/state_test.go
+++ b/go/database/vt/geth/state_test.go
@@ -139,7 +139,7 @@ func TestSet_And_Get_Storage_Success(t *testing.T) {
 	}
 }
 
-func TestGetBalance_Account_Empty(t *testing.T) {
+func TestState_GetBalance_InitialEmptyTrie_AllAccountPropertiesAreZero(t *testing.T) {
 	state, err := NewState(state.Parameters{})
 	require.NoError(t, err, "failed to create vt state")
 	defer func() {

--- a/go/database/vt/geth/state_test.go
+++ b/go/database/vt/geth/state_test.go
@@ -21,9 +21,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCreateAccounts_Many_Updates_Success(t *testing.T) {
+func TestState_CreateAccounts_Many_Updates_Success(t *testing.T) {
 	state, err := NewState(state.Parameters{})
-	require.NoError(t, err, "failed to create vt state")
+	require.NoError(t, err, "failed to create state")
 	defer func() {
 		require.NoError(t, state.Close(), "failed to close state")
 	}()
@@ -45,24 +45,24 @@ func TestCreateAccounts_Many_Updates_Success(t *testing.T) {
 		for j := 0; j < numInsertsPerBlock; j++ {
 			addr := common.Address{byte(j), byte(i), byte(i >> 8)}
 			exists, err := state.Exists(addr)
-			require.NoError(t, err, "failed to check existence of account %s", addr)
-			require.True(t, exists, "account %s should exist but does not", addr)
+			require.NoError(t, err, "failed to check existence of account %x", addr)
+			require.True(t, exists, "account %x should exist but does not", addr)
 
 			balance, err := state.GetBalance(addr)
-			require.NoError(t, err, "failed to get balance for account %s", addr)
+			require.NoError(t, err, "failed to get balance for account %x", addr)
 			expectedBalance := amount.New(uint64(i * j))
-			require.Equal(t, 0, balance.ToBig().Cmp(expectedBalance.ToBig()), "unexpected balance for account %s: got %s, want %s", addr, balance, expectedBalance)
+			require.Equal(t, 0, balance.ToBig().Cmp(expectedBalance.ToBig()), "unexpected balance for account %x: got %s, want %s", addr, balance, expectedBalance)
 
 			nonce, err := state.GetNonce(addr)
-			require.NoError(t, err, "failed to get nonce for account %s", addr)
-			require.Equal(t, common.ToNonce(1), nonce, "unexpected nonce for account %s", addr)
+			require.NoError(t, err, "failed to get nonce for account %x", addr)
+			require.Equal(t, common.ToNonce(1), nonce, "unexpected nonce for account %x", addr)
 		}
 	}
 }
 
-func TestUpdate_And_Get_Code_Success(t *testing.T) {
+func TestState_Update_And_Get_Code_Success(t *testing.T) {
 	state, err := NewState(state.Parameters{})
-	require.NoError(t, err, "failed to create vt state")
+	require.NoError(t, err, "failed to create state")
 	defer func() {
 		require.NoError(t, state.Close(), "failed to close state")
 	}()
@@ -91,22 +91,22 @@ func TestUpdate_And_Get_Code_Success(t *testing.T) {
 		addr := common.Address{byte(i), byte(i >> 8)}
 
 		code, err := state.GetCode(addr)
-		require.NoError(t, err, "failed to get code for account %s", addr)
-		require.True(t, bytes.Equal(code, expectedCodes[i]), "unexpected code for account %s: got %v, want %v", addr, code, expectedCodes[i])
+		require.NoError(t, err, "failed to get code for account %x", addr)
+		require.True(t, bytes.Equal(code, expectedCodes[i]), "unexpected code for account %x: got %v, want %v", addr, code, expectedCodes[i])
 
 		codeHash, err := state.GetCodeHash(addr)
-		require.NoError(t, err, "failed to get code hash for account %s", addr)
-		require.Equal(t, common.Keccak256(expectedCodes[i]), codeHash, "unexpected code hash for account %s", addr)
+		require.NoError(t, err, "failed to get code hash for account %x", addr)
+		require.Equal(t, common.Keccak256(expectedCodes[i]), codeHash, "unexpected code hash for account %x", addr)
 
 		codeLen, err := state.GetCodeSize(addr)
-		require.NoError(t, err, "failed to get code size for account %s", addr)
-		require.Equal(t, len(expectedCodes[i]), codeLen, "unexpected code size for account %s", addr)
+		require.NoError(t, err, "failed to get code size for account %x", addr)
+		require.Equal(t, len(expectedCodes[i]), codeLen, "unexpected code size for account %x", addr)
 	}
 }
 
-func TestSet_And_Get_Storage_Success(t *testing.T) {
+func TestState_Set_And_Get_Storage_Success(t *testing.T) {
 	state, err := NewState(state.Parameters{})
-	require.NoError(t, err, "failed to create vt state")
+	require.NoError(t, err, "failed to create state")
 	defer func() {
 		require.NoError(t, state.Close(), "failed to close state")
 	}()
@@ -133,15 +133,15 @@ func TestSet_And_Get_Storage_Success(t *testing.T) {
 		for j := 0; j < numOfKeys; j++ {
 			key := common.Key{byte(j), byte(j >> 8)}
 			value, err := state.GetStorage(addr, key)
-			require.NoError(t, err, "failed to get storage for account %s", addr)
-			require.Equal(t, common.Value{byte(i + j), byte((i + j) >> 8)}, value, "unexpected storage value for account %s, key %s", addr, key)
+			require.NoError(t, err, "failed to get storage for account %x", addr)
+			require.Equal(t, common.Value{byte(i + j), byte((i + j) >> 8)}, value, "unexpected storage value for account %x, key %x", addr, key)
 		}
 	}
 }
 
 func TestState_GetBalance_InitialEmptyTrie_AllAccountPropertiesAreZero(t *testing.T) {
 	state, err := NewState(state.Parameters{})
-	require.NoError(t, err, "failed to create vt state")
+	require.NoError(t, err, "failed to create state")
 	defer func() {
 		require.NoError(t, state.Close(), "failed to close state")
 	}()
@@ -163,9 +163,9 @@ func TestState_GetBalance_InitialEmptyTrie_AllAccountPropertiesAreZero(t *testin
 	require.Equal(t, 0, len(code), "expected empty code for empty account, got %d bytes", len(code))
 }
 
-func TestGetStorage_Empty(t *testing.T) {
+func TestState_GetStorage_Empty_Returns_Empty_Value(t *testing.T) {
 	state, err := NewState(state.Parameters{})
-	require.NoError(t, err, "failed to create vt state")
+	require.NoError(t, err, "failed to create state")
 	defer func() {
 		require.NoError(t, state.Close(), "failed to close state")
 	}()
@@ -175,7 +175,7 @@ func TestGetStorage_Empty(t *testing.T) {
 	require.Equal(t, common.Value{}, value, "unexpected storage value for empty account")
 }
 
-func TestGetHash_Is_Updated_Each_Block(t *testing.T) {
+func TestState_GetHash_Is_Updated_Each_Block(t *testing.T) {
 	state, err := NewState(state.Parameters{})
 	require.NoError(t, err, "failed to create vt state")
 	defer func() {
@@ -197,7 +197,7 @@ func TestGetHash_Is_Updated_Each_Block(t *testing.T) {
 		require.NoError(t, state.Apply(uint64(i), update), "failed to apply block %d", i)
 
 		hash, err := state.GetHash()
-		require.NoError(t, err, "failed to get block %d", i)
+		require.NoError(t, err, "failed to get hash for block %d", i)
 		require.NotEqual(t, prevHash, hash, "hash did not change")
 		prevHash = hash
 	}
@@ -205,7 +205,7 @@ func TestGetHash_Is_Updated_Each_Block(t *testing.T) {
 
 func TestState_GetArchiveState_ReturnsNoArchiveError(t *testing.T) {
 	st, err := NewState(state.Parameters{})
-	require.NoError(t, err, "failed to create vt state")
+	require.NoError(t, err, "failed to create state")
 	defer func() {
 		require.NoError(t, st.Close(), "failed to close state")
 	}()
@@ -216,7 +216,7 @@ func TestState_GetArchiveState_ReturnsNoArchiveError(t *testing.T) {
 
 func TestState_GetArchiveBlockHeight_ReturnsNoArchiveError(t *testing.T) {
 	st, err := NewState(state.Parameters{})
-	require.NoError(t, err, "failed to create vt state")
+	require.NoError(t, err, "failed to create state")
 	defer func() {
 		require.NoError(t, st.Close(), "failed to close state")
 	}()
@@ -241,18 +241,18 @@ func TestState_DeletedAccount_Unsupported(t *testing.T) {
 
 func TestState_HasEmptyStorage_Unsupported(t *testing.T) {
 	st, err := NewState(state.Parameters{})
-	require.NoError(t, err, "failed to create vt state")
+	require.NoError(t, err, "failed to create state")
 	defer func() {
 		require.NoError(t, st.Close(), "failed to close state")
 	}()
 
 	_, err = st.HasEmptyStorage(common.Address{})
-	require.Error(t, err, "expected error when checking empty storage")
+	require.ErrorContains(t, err, "not supported", "expected error containing 'not supported'")
 }
 
 func TestState_Snapshot_Unsupported(t *testing.T) {
 	st, err := NewState(state.Parameters{})
-	require.NoError(t, err, "failed to create vt state")
+	require.NoError(t, err, "failed to create state")
 	defer func() {
 		require.NoError(t, st.Close(), "failed to close state")
 	}()
@@ -272,11 +272,11 @@ func TestState_Snapshot_Unsupported(t *testing.T) {
 
 func TestState_Export_Unsupported(t *testing.T) {
 	st, err := NewState(state.Parameters{})
-	require.NoError(t, err, "failed to create vt state")
+	require.NoError(t, err, "failed to create state")
 	defer func() {
 		require.NoError(t, st.Close(), "failed to close state")
 	}()
 
 	_, err = st.Export(nil, nil)
-	require.Error(t, err, "expected error when exporting nil")
+	require.ErrorContains(t, err, "not supported", "expected error containing 'not supported'")
 }

--- a/go/database/vt/geth/state_test.go
+++ b/go/database/vt/geth/state_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package geth
+
+import (
+	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/0xsoniclabs/carmen/go/common/amount"
+	"github.com/0xsoniclabs/carmen/go/state"
+	"testing"
+)
+
+func TestCreateAccounts_Many_Updates_Success(t *testing.T) {
+	state, err := NewState(state.Parameters{})
+	if err != nil {
+		t.Fatalf("failed to create vt state: %v", err)
+	}
+	defer func() {
+		if err := state.Close(); err != nil {
+			t.Errorf("failed to close state: %v", err)
+		}
+	}()
+
+	const numBlocks = 10
+	const numInsertsPerBlock = 100
+	var counter int
+	for i := 0; i < numBlocks; i++ {
+		update := common.Update{}
+		update.CreatedAccounts = make([]common.Address, 0, numInsertsPerBlock)
+		for j := 0; j < numInsertsPerBlock; j++ {
+			addr := common.Address{byte(counter), byte(counter >> 8), byte(counter >> 16), byte(counter >> 24), byte(counter >> 32)}
+			update.CreatedAccounts = append(update.CreatedAccounts, addr)
+			update.Nonces = append(update.Nonces, common.NonceUpdate{Account: addr, Nonce: common.ToNonce(1)})
+			update.Balances = append(update.Balances, common.BalanceUpdate{Account: addr, Balance: amount.New(uint64(counter))})
+			counter++
+		}
+		if err := state.Apply(uint64(i), update); err != nil {
+			t.Errorf("failed to apply block %d: %v", i, err)
+		}
+	}
+
+	// read values
+	for i := 0; i < numBlocks*numInsertsPerBlock; i++ {
+		addr := common.Address{byte(i), byte(i >> 8), byte(i >> 16), byte(i >> 24), byte(i >> 32)}
+		exists, err := state.Exists(addr)
+		if err != nil {
+			t.Errorf("failed to check existence of account %s: %v", addr, err)
+		}
+		if !exists {
+			t.Fatalf("account %s should exist but does not", addr)
+		}
+
+		balance, err := state.GetBalance(addr)
+		if err != nil {
+			t.Errorf("failed to get balance for account %s: %v", addr, err)
+		}
+		expectedBalance := amount.New(uint64(i))
+		if balance.ToBig().Cmp(expectedBalance.ToBig()) != 0 {
+			t.Errorf("unexpected balance for account %s: got %s, want %s", addr, balance, expectedBalance)
+		}
+
+		nonce, err := state.GetNonce(addr)
+		if err != nil {
+			t.Errorf("failed to get nonce for account %s: %v", addr, err)
+		}
+		if nonce != common.ToNonce(1) {
+			t.Errorf("unexpected nonce for account %s: got %d, want %d", addr, nonce, common.ToNonce(1))
+		}
+	}
+}

--- a/go/database/vt/geth/state_test.go
+++ b/go/database/vt/geth/state_test.go
@@ -210,6 +210,30 @@ func TestGetBalance_Account_Empty(t *testing.T) {
 	if !balance.IsZero() {
 		t.Errorf("expected zero balance for empty account, got %s", balance)
 	}
+
+	nonce, err := state.GetNonce(common.Address{})
+	if err != nil {
+		t.Fatalf("failed to get nonce for empty account: %v", err)
+	}
+	if nonce != common.ToNonce(0) {
+		t.Errorf("expected nonce 0 for empty account, got %d", nonce)
+	}
+
+	value, err := state.GetCodeHash(common.Address{})
+	if err != nil {
+		t.Fatalf("failed to get code hash for empty account: %v", err)
+	}
+	if value != common.Keccak256([]byte{}) {
+		t.Errorf("expected empty code hash for empty account, got %s", value)
+	}
+
+	code, err := state.GetCode(common.Address{})
+	if err != nil {
+		t.Fatalf("failed to get code for empty account: %v", err)
+	}
+	if len(code) != 0 {
+		t.Errorf("expected empty code for empty account, got %d bytes", len(code))
+	}
 }
 
 func TestGetStorage_Empty(t *testing.T) {


### PR DESCRIPTION
This PR adapts VerkleTrie implementation from Geth (go-ethereum). It implements the `State` interface, which routes method calls to VerkleTrie as an underlaying data structure. 

It is an experimental implementation, which uses in-memory data storage, and serves for functional comparison to alternative implementations. 