### PR TITLE
Add configuration for  VSCode

### DIFF
--- a/rust/.editorconfig
+++ b/rust/.editorconfig
@@ -1,0 +1,12 @@
+# editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+# Markdown has special semantics for trailing whitespace
+trim_trailing_whitespace = false

--- a/rust/.vscode/extensions.json
+++ b/rust/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+        "EditorConfig.EditorConfig",
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml",
+        "vadimcn.vscode-lldb"
+    ]
+}

--- a/rust/.vscode/settings.json
+++ b/rust/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "rust-analyzer.imports.granularity.enforce": true,
+    "rust-analyzer.imports.prefix": "crate",
+    "rust-analyzer.rustfmt.extraArgs": [
+        "+nightly"
+    ],
+}


### PR DESCRIPTION
This is the fourth and last PR in a series of PRs to set up and configure the Rust crate and related tooling for Carmen S6.

This PR configures:
- the recommended extensions in VSCode for working with Rust
- rust analyzer to use nightly `rustfmt`, enforce imports granularity and use the `crate` prefix
- editorconfig
