### PR TITLE
Add in-memory Verkle trie reference in Go

### DIFF
--- a/go/database/vt/memory/trie/nodes.go
+++ b/go/database/vt/memory/trie/nodes.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package trie
+
+import (
+	"bytes"
+
+	"github.com/0xsoniclabs/carmen/go/database/vt/commit"
+)
+
+// ---- Nodes ----
+
+// node is an interface for trie nodes, which can be either inner or leaf nodes.
+type node interface {
+	get(key Key, depth byte) Value
+	set(Key Key, depth byte, value Value) node
+	commit() commit.Commitment
+}
+
+// ---- Inner nodes ----
+
+// inner is the type of an inner node in the Verkle trie. It contains an array
+// of 256 child nodes, indexed by one byte of the key.
+type inner struct {
+	children [256]node
+
+	// The cached commitment of this inner node. It is only valid if the
+	// commitmentClean flag is true.
+	commitment      commit.Commitment
+	commitmentClean bool
+}
+
+func (i *inner) get(key Key, depth byte) Value {
+	next := i.children[key[depth]]
+	if next == nil {
+		return Value{}
+	}
+	return next.get(key, depth+1)
+}
+
+func (i *inner) set(key Key, depth byte, value Value) node {
+	i.commitmentClean = false
+	pos := key[depth]
+	next := i.children[pos]
+	if next == nil {
+		next = newLeaf(key)
+	}
+	i.children[pos] = next.set(key, depth+1, value)
+	return i
+}
+
+func (i *inner) commit() commit.Commitment {
+	if i.commitmentClean {
+		return i.commitment
+	}
+
+	// The commitment of an inner node is computed as a Pedersen commitment
+	// as follows:
+	//
+	//   C = Commit([C_i.ToValue() for i in children])
+	//
+	// For details, see
+	// https://blog.ethereum.org/2021/12/02/verkle-tree-structure#commitment-of-internal-nodes
+
+	// Recompute the commitment for this inner node.
+	children := [256]commit.Value{}
+	for j, child := range i.children {
+		if child != nil { // for empty children, the value to commit to is zero
+			children[j] = child.commit().ToValue()
+		}
+	}
+	i.commitment = commit.Commit(children)
+	i.commitmentClean = true
+	return i.commitment
+}
+
+// ---- Leaf nodes ----
+
+// leaf is the type of a leaf node in the Verkle trie. It contains a stem (the
+// first 31 bytes of the key) and an array of values indexed by the last byte
+// of the key.
+type leaf struct {
+	stem   [31]byte      // The first 31 bytes of the key leading to this leaf.
+	values [256]Value    // The values stored in this leaf, indexed by the last byte of the key.
+	used   [256 / 8]byte // A bitmap indicating which suffixes (last byte of the key) are used.
+
+	// The cached commitment of this inner node. It is only valid if the
+	// commitmentClean flag is true.
+	commitment      commit.Commitment
+	commitmentClean bool
+}
+
+// newLeaf creates a new leaf node with the given key.
+func newLeaf(key Key) *leaf {
+	return &leaf{
+		stem: [31]byte(key[:31]),
+	}
+}
+
+func (l *leaf) get(key Key, _ byte) Value {
+	if !bytes.Equal(key[:31], l.stem[:]) {
+		return Value{}
+	}
+	return l.values[key[31]]
+}
+
+func (l *leaf) set(key Key, depth byte, value Value) node {
+	if bytes.Equal(key[:31], l.stem[:]) {
+		suffix := key[31]
+		l.values[suffix] = value
+		l.used[suffix/8] |= 1 << (suffix % 8)
+		l.commitmentClean = false
+		return l
+	}
+
+	// This leaf needs to be split
+	res := &inner{}
+	res.children[l.stem[depth]] = l
+	return res.set(key, depth, value)
+}
+
+func (l *leaf) commit() commit.Commitment {
+	if l.commitmentClean {
+		return l.commitment
+	}
+
+	// The commitment of a leaf node is computed as a Pedersen commitment
+	// as follows:
+	//
+	//    C = Commit([1,stem, C1, C2])
+	//
+	// where C1 and C2 are the Pedersen commitments of the interleaved modified
+	// lower and upper halves of the values stored in the leaf node, computed
+	// by:
+	//
+	//   C1 = Commit([v[0][:16]), v[0][16:]), v[1][:16]), v[1][16:]), ...])
+	//   C2 = Commit([v[128][:16]), v[128][16:]), v[129][:16]), v[129][16:]), ...])
+	//
+	// For details on the commitment procedure, see
+	// https://blog.ethereum.org/2021/12/02/verkle-tree-structure#commitment-to-the-values-leaf-nodes
+
+	// Compute the commitment for this leaf node.
+	values := [2][256]commit.Value{}
+	for i, v := range l.values {
+		lower := commit.NewValueFromLittleEndianBytes(v[:16])
+		upper := commit.NewValueFromLittleEndianBytes(v[16:])
+
+		if l.isUsed(byte(i)) {
+			lower.SetBit128()
+		}
+
+		values[i/128][(2*i)%256] = lower
+		values[i/128][(2*i+1)%256] = upper
+	}
+
+	c1 := commit.Commit(values[0])
+	c2 := commit.Commit(values[1])
+
+	l.commitment = commit.Commit([256]commit.Value{
+		commit.NewValue(1),
+		commit.NewValueFromLittleEndianBytes(l.stem[:]),
+		c1.ToValue(),
+		c2.ToValue(),
+	})
+	l.commitmentClean = true
+	return l.commitment
+}
+
+func (l *leaf) isUsed(suffix byte) bool {
+	return (l.used[suffix/8] & (1 << (suffix % 8))) != 0
+}

--- a/go/database/vt/memory/trie/nodes_test.go
+++ b/go/database/vt/memory/trie/nodes_test.go
@@ -1,0 +1,294 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package trie
+
+import (
+	"testing"
+
+	"github.com/0xsoniclabs/carmen/go/database/vt/commit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInnerNode_Get_ReturnsZeroIfThereIsNoNextNode(t *testing.T) {
+	require := require.New(t)
+	innerNode := &inner{}
+	require.Zero(innerNode.get(Key{}, 0))
+}
+
+func TestInnerNode_Get_ReturnsValueFromNextNode(t *testing.T) {
+	require := require.New(t)
+
+	key1 := Key{1, 2, 3}
+	key2 := Key{1, 2, 4}
+
+	var root node = newLeaf(key1)
+	root = root.set(key1, 2, Value{42})
+	root = root.set(key2, 2, Value{84})
+
+	inner, ok := root.(*inner)
+	require.True(ok, "Root should be an inner node")
+
+	require.Equal(Value{42}, inner.get(key1, 2))
+	require.Equal(Value{84}, inner.get(key2, 2))
+}
+
+func TestInnerNode_Set_CreatesNewLeafIfThereIsNoNextNode(t *testing.T) {
+	require := require.New(t)
+
+	key := Key{1, 2, 3}
+
+	innerNode := &inner{}
+	require.Nil(innerNode.children[key[2]])
+
+	res, ok := innerNode.set(key, 2, Value{42}).(*inner)
+	require.True(ok, "Setting a new key not result in a leaf node")
+	require.Equal(innerNode, res, "Setting a new key should not change the inner node")
+
+	require.NotNil(innerNode.children[key[2]])
+}
+
+func TestInnerNode_CommitCleanStateIsTracked(t *testing.T) {
+	require := require.New(t)
+
+	innerNode := &inner{}
+	require.False(innerNode.commitmentClean)
+
+	// Setting a value should mark the commitment as dirty.
+	key := Key{1, 2, 3}
+	innerNode.set(key, 0, Value{42})
+	require.False(innerNode.commitmentClean)
+
+	// Committing should clean the state.
+	firstCommit := innerNode.commit()
+	require.True(innerNode.commitmentClean)
+
+	// Committing again should return the same commitment.
+	secondCommit := innerNode.commit()
+	require.True(innerNode.commitmentClean)
+	require.True(firstCommit.Equal(secondCommit))
+
+	// Setting another value should mark the commitment as dirty again.
+	innerNode.set(Key{1, 2, 4}, 0, Value{84})
+	require.False(innerNode.commitmentClean)
+}
+
+func TestInnerNode_Commit_ComputesCommitmentFromChildren(t *testing.T) {
+	require := require.New(t)
+
+	innerNode := &inner{}
+	key1 := Key{1, 2, 3}
+	key2 := Key{1, 2, 4}
+
+	// Set two values in the inner node.
+	innerNode.set(key1, 2, Value{42})
+	innerNode.set(key2, 2, Value{84})
+
+	// Compute the commitment.
+	commitment := innerNode.commit()
+
+	require.NotNil(commitment)
+	require.True(commitment.IsValid())
+
+	// The commitment should be computed from the values of the children.
+	expectedCommitment := commit.Commit([256]commit.Value{
+		3: innerNode.children[key1[2]].commit().ToValue(),
+		4: innerNode.children[key2[2]].commit().ToValue(),
+	})
+
+	require.True(commitment.Equal(expectedCommitment))
+}
+
+func TestLeafNode_NewLeaf_ProducesEmptyLeafWithStem(t *testing.T) {
+	require := require.New(t)
+
+	// Create a new leaf node with a specific key.
+	key := Key{1, 2, 3, 4, 5}
+	leafNode := newLeaf(key)
+
+	// Check that the stem is set correctly.
+	require.Equal(key[:31], leafNode.stem[:], "Stem should match the first 31 bytes of the key")
+
+	// Check that all values are initialized to zero.
+	require.Equal([256]Value{}, leafNode.values, "All values should be initialized to zero")
+
+	// Check that the used bitmap is empty.
+	require.Equal([256 / 8]byte{}, leafNode.used, "Used bitmap should be empty")
+}
+
+func TestLeafNode_Get_ReturnsValueForMatchingStem(t *testing.T) {
+	require := require.New(t)
+
+	key := Key{1, 2, 3, 31: 1}
+	leaf := newLeaf(key)
+
+	// Initially, the value for the key should be zero.
+	require.Zero(leaf.get(key, 0), "Value for the key should be zero initially")
+
+	// Set a value for the key.
+	leaf.set(key, 0, Value{42})
+
+	// Now retrieving the value should return the set value.
+	require.Equal(Value{42}, leaf.get(key, 0), "Value for the key should match the set value")
+}
+
+func TestLeafNode_Get_ReturnsZeroForNonMatchingStem(t *testing.T) {
+	require := require.New(t)
+
+	key1 := Key{1, 2, 3}
+	key2 := Key{4, 5, 6}
+
+	leaf := newLeaf(key1)
+	leaf.set(key1, 0, Value{42})
+
+	require.Zero(leaf.get(key2, 0), "Value for non-matching key should be zero")
+}
+
+func TestLeafNode_Set_SplitsLeafIfStemDoesNotMatch(t *testing.T) {
+	require := require.New(t)
+
+	key1 := Key{1, 2, 3}
+	key2 := Key{1, 2, 4}
+
+	leafNode := newLeaf(key1)
+	leafNode.set(key1, 0, Value{42})
+
+	// Setting a different key should split the leaf.
+	newNode := leafNode.set(key2, 2, Value{84})
+
+	// The new node should be an inner node now.
+	innerNode, ok := newNode.(*inner)
+	require.True(ok, "Setting a different key should create an inner node")
+
+	// The inner node should have the leaf as one of its children.
+	require.Equal(leafNode, innerNode.children[key1[2]].(*leaf))
+	require.NotNil(innerNode.children[key2[2]])
+}
+
+func TestLeafNode_CanSetAndGetValues(t *testing.T) {
+	require := require.New(t)
+
+	key1 := Key{1, 2, 3, 31: 1}
+	key2 := Key{1, 2, 3, 31: 2}
+	key3 := Key{1, 2, 3, 31: 3}
+
+	leaf := newLeaf(key1)
+
+	require.False(leaf.isUsed(key1[31]))
+	require.False(leaf.isUsed(key2[31]))
+	require.False(leaf.isUsed(key3[31]))
+
+	require.Zero(leaf.get(key1, 0))
+	require.Zero(leaf.get(key2, 0))
+	require.Zero(leaf.get(key3, 0))
+
+	// Setting a value for key 1 makes the value retrievable and marks the
+	// suffix as used.
+	leaf.set(key1, 0, Value{10})
+
+	require.True(leaf.isUsed(key1[31]))
+	require.False(leaf.isUsed(key2[31]))
+	require.False(leaf.isUsed(key3[31]))
+
+	require.Equal(Value{10}, leaf.get(key1, 0))
+	require.Zero(leaf.get(key2, 0))
+	require.Zero(leaf.get(key3, 0))
+
+	// Setting the value for key 2 to zero does not change the value but marks
+	// the suffix as used.
+	leaf.set(key2, 0, Value{})
+
+	require.True(leaf.isUsed(key1[31]))
+	require.True(leaf.isUsed(key2[31]))
+	require.False(leaf.isUsed(key3[31]))
+
+	require.Equal(Value{10}, leaf.get(key1, 0))
+	require.Zero(leaf.get(key2, 0))
+	require.Zero(leaf.get(key3, 0))
+
+	// Resetting the value for key 1 to zero does not change the used bitmap.
+	leaf.set(key1, 0, Value{})
+	require.True(leaf.isUsed(key1[31]))
+	require.True(leaf.isUsed(key2[31]))
+	require.False(leaf.isUsed(key3[31]))
+
+	require.Zero(leaf.get(key1, 0))
+	require.Zero(leaf.get(key2, 0))
+	require.Zero(leaf.get(key3, 0))
+}
+
+func TestLeafNode_CanComputeCommitment(t *testing.T) {
+	require := require.New(t)
+
+	key1 := Key{1, 2, 3, 31: 1}
+	key2 := Key{1, 2, 3, 31: 130}
+
+	val1 := Value{8: 1, 20: 10}
+	val2 := Value{8: 2, 20: 20}
+
+	leaf := newLeaf(key1)
+	leaf.set(key1, 0, val1)
+	leaf.set(key2, 0, val2)
+
+	have := leaf.commit()
+
+	require.NotNil(have)
+	require.True(have.IsValid())
+
+	low1 := commit.NewValueFromLittleEndianBytes(val1[:16])
+	low2 := commit.NewValueFromLittleEndianBytes(val2[:16])
+	high1 := commit.NewValueFromLittleEndianBytes(val1[16:])
+	high2 := commit.NewValueFromLittleEndianBytes(val2[16:])
+
+	low1.SetBit128()
+	low2.SetBit128()
+
+	c1 := commit.Commit([256]commit.Value{2: low1, 3: high1})
+	c2 := commit.Commit([256]commit.Value{4: low2, 5: high2})
+
+	want := commit.Commit([256]commit.Value{
+		commit.NewValue(1),
+		commit.NewValueFromLittleEndianBytes(key1[:31]),
+		c1.ToValue(),
+		c2.ToValue(),
+	})
+	require.True(have.Equal(want))
+}
+
+func TestLeafNode_CommitmentDirtyStateIsTracked(t *testing.T) {
+	require := require.New(t)
+
+	key1 := Key{1, 2, 3, 31: 1}
+	key2 := Key{1, 2, 3, 31: 130}
+
+	leaf := newLeaf(key1)
+	require.False(leaf.commitmentClean)
+
+	leaf.set(key1, 0, Value{10})
+	require.False(leaf.commitmentClean)
+
+	leaf.set(key2, 0, Value{20})
+	require.False(leaf.commitmentClean)
+
+	first := leaf.commit()
+	require.True(leaf.commitmentClean)
+
+	second := leaf.commit()
+	require.True(leaf.commitmentClean)
+	require.True(first.Equal(second))
+
+	leaf.set(key1, 0, Value{30})
+	require.False(leaf.commitmentClean)
+
+	third := leaf.commit()
+	require.True(leaf.commitmentClean)
+
+	require.False(first.Equal(third))
+}

--- a/go/database/vt/memory/trie/trie.go
+++ b/go/database/vt/memory/trie/trie.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package trie
+
+import (
+	"github.com/0xsoniclabs/carmen/go/database/vt/commit"
+)
+
+// Key is a fixed-size byte array used to address values in the trie.
+type Key [32]byte
+
+// Value is a fixed-size byte array used to represent data stored in the trie.
+type Value [32]byte
+
+// Trie implements a all-in-memory version of a Verkle trie as specified by
+// Ethereum. It provides a basic key-value store with fixed-length keys and
+// values and the ability to provide a cryptographic commitment of the trie's
+// state using Pedersen commitments.
+//
+// This implementation is not optimized for performance or storage efficiency,
+// but serves as a reference for the trie structure and operations. It is
+// not intended for production use.
+//
+// For an overview of the Verkle trie structure, see
+// https://blog.ethereum.org/2021/12/02/verkle-tree-structure
+type Trie struct {
+	root node
+}
+
+// Get retrieves the value associated with the given key from the trie. All keys
+// that have not been set will return the zero value.
+func (t *Trie) Get(key Key) Value {
+	if t.root == nil {
+		return Value{}
+	}
+	return t.root.get(key, 0)
+}
+
+// Set associates the given key with the specified value in the trie. If the key
+// already exists, its value will be updated.
+func (t *Trie) Set(key Key, value Value) {
+	if t.root == nil {
+		t.root = newLeaf(key)
+	}
+	t.root = t.root.set(key, 0, value)
+}
+
+// Commit returns the cryptographic commitment of the current state of the trie.
+func (t *Trie) Commit() commit.Commitment {
+	if t.root == nil {
+		return commit.Identity()
+	}
+	return t.root.commit()
+}

--- a/go/database/vt/memory/trie/trie.go
+++ b/go/database/vt/memory/trie/trie.go
@@ -20,7 +20,7 @@ type Key [32]byte
 // Value is a fixed-size byte array used to represent data stored in the trie.
 type Value [32]byte
 
-// Trie implements a all-in-memory version of a Verkle trie as specified by
+// Trie implements an all-in-memory version of a Verkle trie as specified by
 // Ethereum. It provides a basic key-value store with fixed-length keys and
 // values and the ability to provide a cryptographic commitment of the trie's
 // state using Pedersen commitments.

--- a/go/database/vt/memory/trie/trie_test.go
+++ b/go/database/vt/memory/trie/trie_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package trie
+
+import (
+	"testing"
+
+	"github.com/0xsoniclabs/carmen/go/database/vt/commit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrie_InitialTrieIsEmpty(t *testing.T) {
+	require := require.New(t)
+
+	trie := &Trie{}
+	require.Zero(trie.Get(Key{1}))
+	require.Zero(trie.Get(Key{2}))
+	require.Zero(trie.Get(Key{3}))
+}
+
+func TestTrie_ValuesCanBeSetAndRetrieved(t *testing.T) {
+	require := require.New(t)
+
+	trie := &Trie{}
+
+	require.Zero(trie.Get(Key{1}))
+	require.Zero(trie.Get(Key{2}))
+	require.Zero(trie.Get(Key{0, 31: 1}))
+	require.Zero(trie.Get(Key{0, 31: 2}))
+
+	trie.Set(Key{1}, Value{1})
+
+	require.Equal(Value{1}, trie.Get(Key{1}))
+	require.Zero(trie.Get(Key{2}))
+	require.Zero(trie.Get(Key{0, 31: 1}))
+	require.Zero(trie.Get(Key{0, 31: 2}))
+
+	trie.Set(Key{2}, Value{2})
+
+	require.Equal(Value{1}, trie.Get(Key{1}))
+	require.Equal(Value{2}, trie.Get(Key{2}))
+	require.Zero(trie.Get(Key{0, 31: 1}))
+	require.Zero(trie.Get(Key{0, 31: 2}))
+
+	trie.Set(Key{0, 31: 1}, Value{3})
+
+	require.Equal(Value{1}, trie.Get(Key{1}))
+	require.Equal(Value{2}, trie.Get(Key{2}))
+	require.Equal(Value{3}, trie.Get(Key{0, 31: 1}))
+	require.Zero(trie.Get(Key{0, 31: 2}))
+
+	trie.Set(Key{0, 31: 2}, Value{4})
+
+	require.Equal(Value{1}, trie.Get(Key{1}))
+	require.Equal(Value{2}, trie.Get(Key{2}))
+	require.Equal(Value{3}, trie.Get(Key{0, 31: 1}))
+	require.Equal(Value{4}, trie.Get(Key{0, 31: 2}))
+}
+
+func TestTrie_ValuesCanBeUpdated(t *testing.T) {
+	require := require.New(t)
+
+	trie := &Trie{}
+
+	key := Key{1}
+	require.Zero(trie.Get(key))
+	trie.Set(key, Value{1})
+	require.Equal(Value{1}, trie.Get(key))
+	trie.Set(key, Value{2})
+	require.Equal(Value{2}, trie.Get(key))
+	trie.Set(key, Value{3})
+	require.Equal(Value{3}, trie.Get(key))
+}
+
+func TestTrie_ManyValuesCanBeSetAndRetrieved(t *testing.T) {
+	const N = 1000
+	require := require.New(t)
+
+	toKey := func(i int) Key {
+		return Key{byte(i >> 8 & 0x0F), byte(i >> 4 & 0x0F), 31: byte(i & 0x0F)}
+	}
+
+	trie := &Trie{}
+	for i := range N {
+		for j := range N {
+			want := Value{}
+			if j < i {
+				want = Value{byte(j)}
+			}
+			got := trie.Get(toKey(j))
+			require.Equal(want, got, "In round %d Get(%d) should return %v, got %v", i, j, want, got)
+		}
+		trie.Set(toKey(i), Value{byte(i)})
+	}
+}
+
+func TestTrie_CommitmentOfEmptyTrieIsIdentity(t *testing.T) {
+	require := require.New(t)
+
+	trie := &Trie{}
+	have := trie.Commit()
+	want := commit.Identity()
+	require.True(have.Equal(want))
+}
+
+func TestTrie_CommitmentOfNonEmptyTrieIsRootNodeCommitment(t *testing.T) {
+	require := require.New(t)
+
+	trie := &Trie{}
+	trie.Set(Key{1, 31: 1}, Value{1})
+	trie.Set(Key{2, 31: 2}, Value{2})
+	trie.Set(Key{3, 31: 3}, Value{3})
+
+	have := trie.Commit()
+	require.True(have.IsValid(), "Commitment should be valid")
+
+	want := trie.root.commit()
+	require.True(have.Equal(want), "Commitment should match the root's commitment")
+}


### PR DESCRIPTION
This PR introduces a simple in-memory reference implementation of a Verkle trie.

The Verkle trie offers a simple key/value store interface, with a `Get` and `Set` function. Internally, it maintains a tree of inner and leaf nodes, and facilitates the computation of Merkle-Tree like commitments using the Pedersen commitment scheme.