### PR TITLE
Export FFI functions from Rust

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,5 +3,284 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f72209734318d0b619a5e0f5129918b848c416e122a3c4ce054e03cb87b726f"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
 name = "carmen"
 version = "0.1.0"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.174"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "libloading"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
+]
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "syn"
+version = "2.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "windows-targets"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,10 +1,27 @@
+# Copyright (c) 2025 Sonic Operations Ltd
+#
+# Use of this software is governed by the Business Source License included
+# in the LICENSE file and at soniclabs.com/bsl11.
+#
+# Change Date: 2028-4-16
+#
+# On the date above, in accordance with the Business Source License, use of
+# this software will be governed by the GNU Lesser General Public License v3.
+
 [package]
 name = "carmen"
 version = "0.1.0"
 edition = "2024"
 publish = false
 
+[lib]
+crate-type = ["rlib", "staticlib"]
+
 [dependencies]
+
+[build-dependencies]
+# FFI
+bindgen = "0.72.0"
 
 [lints.rust]
 macro_use_extern_crate = "warn"

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+use std::{env, path::PathBuf};
+
+fn main() {
+    let bindings = bindgen::Builder::default()
+        .header("../cpp/state/c_state.h")
+        // regenerate the bindings if any of the included header files changed
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .generate()
+        .expect("Unable to generate bindings");
+
+    // Write the bindings to the $OUT_DIR/bindings.rs file.
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}

--- a/rust/src/ffi/exported.rs
+++ b/rust/src/ffi/exported.rs
@@ -1,0 +1,244 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+#![allow(unused_variables)]
+
+use std::ffi::{c_char, c_int, c_void};
+
+use crate::ffi::bindings;
+
+/// Opens a new state object based on the provided implementation maintaining
+/// its data in the given directory. If the directory does not exist, it is
+/// created. If it is empty, a new, empty state is initialized. If it contains
+/// state information, the information is loaded.
+///
+/// The function returns an opaque pointer to a state object that can be used
+/// with the remaining functions in this file. Ownership is transferred to the
+/// caller, which is required for releasing it eventually using Carmen_Rust_ReleaseState.
+/// If for some reason the creation of the state instance failed, a nullptr is
+/// returned.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn Carmen_Rust_OpenState(
+    schema: u8,
+    state: bindings::StateImpl,
+    archive: bindings::ArchiveImpl,
+    directory: *const c_char,
+    length: c_int,
+) -> *mut c_void {
+    unimplemented!()
+}
+
+/// Flushes all committed state information to disk to guarantee permanent
+/// storage. All internally cached modifications are synced to disk.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn Carmen_Rust_Flush(state: *mut c_void) {
+    unimplemented!()
+}
+
+/// Closes this state, releasing all IO handles and locks on external resources.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn Carmen_Rust_Close(state: *mut c_void) {
+    unimplemented!()
+}
+
+/// Releases a state object, thereby causing its destruction. After releasing it,
+/// no more operations may be applied on it.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn Carmen_Rust_ReleaseState(state: *mut c_void) {
+    unimplemented!()
+}
+
+/// Creates a state snapshot reflecting the state at the given block height. The
+/// resulting state must be released and must not outlive the life time of the
+/// provided state.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn Carmen_Rust_GetArchiveState(state: *mut c_void, block: u64) -> *mut c_void {
+    unimplemented!()
+}
+
+/// Gets the current state of the given account.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn Carmen_Rust_GetAccountState(
+    state: *mut c_void,
+    addr: *mut c_void,
+    out_state: *mut c_void,
+) {
+    unimplemented!()
+}
+
+/// Retrieves the balance of the given account.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn Carmen_Rust_GetBalance(
+    state: *mut c_void,
+    addr: *mut c_void,
+    out_balance: *mut c_void,
+) {
+    unimplemented!()
+}
+
+/// Retrieves the nonce of the given account.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn Carmen_Rust_GetNonce(
+    state: *mut c_void,
+    addr: *mut c_void,
+    out_nonce: *mut c_void,
+) {
+    unimplemented!()
+}
+
+/// Retrieves the value of storage location (addr,key) in the given state.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn Carmen_Rust_GetStorageValue(
+    state: *mut c_void,
+    addr: *mut c_void,
+    key: *mut c_void,
+    out_value: *mut c_void,
+) {
+    unimplemented!()
+}
+
+/// Retrieves the code stored under the given address.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn Carmen_Rust_GetCode(
+    state: *mut c_void,
+    addr: *mut c_void,
+    out_code: *mut c_void,
+    out_length: *mut u32,
+) {
+    unimplemented!()
+}
+
+/// Retrieves the hash of the code stored under the given address.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn Carmen_Rust_GetCodeHash(
+    state: *mut c_void,
+    addr: *mut c_void,
+    out_hash: *mut c_void,
+) {
+    unimplemented!()
+}
+
+/// Retrieves the code length stored under the given address.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn Carmen_Rust_GetCodeSize(
+    state: *mut c_void,
+    addr: *mut c_void,
+    out_length: *mut u32,
+) {
+    unimplemented!()
+}
+
+/// Applies the provided block update to the maintained state.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn Carmen_Rust_Apply(
+    state: *mut c_void,
+    block: u64,
+    update: *mut c_void,
+    length: u64,
+) {
+    unimplemented!()
+}
+
+/// Retrieves a global state hash of the given state.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn Carmen_Rust_GetHash(state: *mut c_void, out_hash: *mut c_void) {
+    unimplemented!()
+}
+
+/// Retrieves a summary of the used memory. After the call the out variable will
+/// point to a buffer with a serialized summary that needs to be freed by the
+/// caller.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn Carmen_Rust_GetMemoryFootprint(
+    state: *mut c_void,
+    out: *mut *mut c_char,
+    out_length: *mut u64,
+) {
+    unimplemented!()
+}
+
+/// Releases the buffer returned by GetMemoryFootprint.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn Carmen_Rust_ReleaseMemoryFootprintBuffer(buf: *mut c_char, buf_length: u64) {
+    unimplemented!()
+}
+
+/// Compile-time check that the signatures of the exported functions match the ones generated from
+/// the C header file.
+#[allow(unused)]
+const COMPILE_TIME_CHECK_THAT_SIGNATURES_MATCH_SIGNATURES_GENERATED_FROM_C_HEADER: () = {
+    assert_same_signature(
+        Carmen_Rust_OpenState as unsafe extern "C" fn(_, _, _, _, _) -> _,
+        bindings::Carmen_Rust_OpenState,
+    );
+    assert_same_signature(
+        Carmen_Rust_GetArchiveState as unsafe extern "C" fn(_, _) -> _,
+        bindings::Carmen_Rust_GetArchiveState,
+    );
+    assert_same_signature(
+        Carmen_Rust_Flush as unsafe extern "C" fn(_),
+        bindings::Carmen_Rust_Flush,
+    );
+    assert_same_signature(
+        Carmen_Rust_Close as unsafe extern "C" fn(_),
+        bindings::Carmen_Rust_Close,
+    );
+    assert_same_signature(
+        Carmen_Rust_ReleaseState as unsafe extern "C" fn(_),
+        bindings::Carmen_Rust_ReleaseState,
+    );
+    assert_same_signature(
+        Carmen_Rust_GetAccountState as unsafe extern "C" fn(_, _, _),
+        bindings::Carmen_Rust_GetAccountState,
+    );
+    assert_same_signature(
+        Carmen_Rust_GetBalance as unsafe extern "C" fn(_, _, _),
+        bindings::Carmen_Rust_GetBalance,
+    );
+    assert_same_signature(
+        Carmen_Rust_GetNonce as unsafe extern "C" fn(_, _, _),
+        bindings::Carmen_Rust_GetNonce,
+    );
+    assert_same_signature(
+        Carmen_Rust_GetStorageValue as unsafe extern "C" fn(_, _, _, _),
+        bindings::Carmen_Rust_GetStorageValue,
+    );
+    assert_same_signature(
+        Carmen_Rust_GetCode as unsafe extern "C" fn(_, _, _, _),
+        bindings::Carmen_Rust_GetCode,
+    );
+    assert_same_signature(
+        Carmen_Rust_GetCodeHash as unsafe extern "C" fn(_, _, _),
+        bindings::Carmen_Rust_GetCodeHash,
+    );
+    assert_same_signature(
+        Carmen_Rust_GetCodeSize as unsafe extern "C" fn(_, _, _),
+        bindings::Carmen_Rust_GetCodeSize,
+    );
+    assert_same_signature(
+        Carmen_Rust_Apply as unsafe extern "C" fn(_, _, _, _),
+        bindings::Carmen_Rust_Apply,
+    );
+    assert_same_signature(
+        Carmen_Rust_GetHash as unsafe extern "C" fn(_, _),
+        bindings::Carmen_Rust_GetHash,
+    );
+    assert_same_signature(
+        Carmen_Rust_GetMemoryFootprint as unsafe extern "C" fn(_, _, _),
+        bindings::Carmen_Rust_GetMemoryFootprint,
+    );
+    assert_same_signature(
+        Carmen_Rust_ReleaseMemoryFootprintBuffer as unsafe extern "C" fn(_, _),
+        bindings::Carmen_Rust_ReleaseMemoryFootprintBuffer,
+    );
+};
+
+const fn assert_same_signature<T>(a: T, b: T) -> (T, T) {
+    (a, b)
+}

--- a/rust/src/ffi/mod.rs
+++ b/rust/src/ffi/mod.rs
@@ -8,4 +8,9 @@
 // On the date above, in accordance with the Business Source License, use of
 // this software will be governed by the GNU Lesser General Public License v3.
 
-mod ffi;
+mod exported;
+
+#[allow(non_upper_case_globals, non_camel_case_types, non_snake_case, unused)]
+mod bindings {
+    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+}


### PR DESCRIPTION
This is the first PR in a series of PRs to expose all required functions from Rust, and call the safe interface from those functions.

This PR:
- generates bindings from the C header file using [bindgen](https://crates.io/crates/bindgen)
  - Strictly speaking, we don't need any of the function declarations because we are not calling another language from Rust, but rather, Rust from another language. However, they are useful for testing that our exported functions have the correct signatures.
- exports all functions of the FFI interface
- adds compile time checks that the signatures are correct
  - for this check, we pass function pointers for our exported function, and the function declared in the generated bindings to `const fn assert_same_signature<T>(a: T, b: T)`. This way we ensure that both functions have the same signature, because otherwise they would not have the same type `T` which in turn would cause compilation to fail.
  
Note: the C header file is this one `cpp/state/c_state.h`
  
New dependencies:
- [bindgen](https://crates.io/crates/bindgen) the default crate for generating bindings from C header files

Part of https://github.com/0xsoniclabs/sonic-admin/issues/283