### PR TITLE
Add safe CarmenS6 trait and call safe interface from unsafe one

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -102,6 +102,24 @@ jobs:
       uses: Swatinem/rust-cache@v2
     - name: cargo test
       run: cargo test --all-features --all-targets
+  
+  miri:
+    name: miri
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+    - name: install rust
+      uses: dtolnay/rust-toolchain@nightly
+      with:
+        components: miri
+    - name: load cache
+      uses: Swatinem/rust-cache@v2
+    - name: cargo miri test
+      env: 
+        MIRIFLAGS: "-Zmiri-backtrace=full"
+      run: cargo +nightly miri test 
 
   unused-deps:
     name: unused deps

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
 name = "bindgen"
 version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,6 +48,7 @@ name = "carmen"
 version = "0.1.0"
 dependencies = [
  "bindgen",
+ "mockall",
  "zerocopy",
 ]
 
@@ -72,10 +79,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "fragile"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "glob"
@@ -127,6 +146,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +179,32 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -215,6 +286,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "unicode-ident"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,6 +25,10 @@ zerocopy = { version = "0.8.26", features = ["derive"] }
 # FFI
 bindgen = "0.72.0"
 
+[dev-dependencies]
+# mocking
+mockall = "0.13.1"
+
 [lints.rust]
 macro_use_extern_crate = "warn"
 unused_unsafe = "warn"

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -8,6 +8,9 @@
 // On the date above, in accordance with the Business Source License, use of
 // this software will be governed by the GNU Lesser General Public License v3.
 
-/// The top level error type for Carmen S6.
+/// The top level error type for Carmen .
 /// This type is returned to the ffi interface and converted there.
-pub struct Error;
+pub enum Error {
+    /// An unsupported schema version was provided.
+    UnsupportedSchema(u8),
+}

--- a/rust/src/ffi/exported.rs
+++ b/rust/src/ffi/exported.rs
@@ -89,8 +89,8 @@ unsafe extern "C" fn Carmen_Rust_OpenState(
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
 /// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
-/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
-/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
+/// - `state.state` must not be mutated for the duration of the lifetime of `token`
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Carmen_Rust_Flush(state: *mut c_void) {
     let token = LifetimeToken;
@@ -104,9 +104,9 @@ unsafe extern "C" fn Carmen_Rust_Flush(state: *mut c_void) {
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
     // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
-    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
-    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
     let db_state = unsafe { state.to_ref_mut_scoped(&token) };
     #[allow(unused_variables)]
     if let Err(error) = db_state.flush() {
@@ -122,8 +122,8 @@ unsafe extern "C" fn Carmen_Rust_Flush(state: *mut c_void) {
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
 /// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
-/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
-/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
+/// - `state.state` must not be mutated for the duration of the lifetime of `token`
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Carmen_Rust_Close(state: *mut c_void) {
     let token = LifetimeToken;
@@ -137,9 +137,9 @@ unsafe extern "C" fn Carmen_Rust_Close(state: *mut c_void) {
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
     // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
-    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
-    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
     let db_state = unsafe { state.to_ref_mut_scoped(&token) };
     #[allow(unused_variables)]
     if let Err(error) = db_state.close() {
@@ -158,8 +158,8 @@ unsafe extern "C" fn Carmen_Rust_Close(state: *mut c_void) {
 /// - `state` must have been allocated using the global allocator
 /// - `state` must not be used after this call
 /// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
-/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
-/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
+/// - `state.state` must not be mutated for the duration of the lifetime of `token`
 /// - `state.state` must have been allocated using the global allocator
 /// - `state.state` must not be used after this call
 #[unsafe(no_mangle)]
@@ -179,9 +179,9 @@ unsafe extern "C" fn Carmen_Rust_ReleaseState(state: *mut c_void) {
     let state = unsafe { Box::from_raw(state) };
     // SAFETY:
     // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
-    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
-    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
     let db_state = unsafe { state.to_ref_mut_scoped(&token) };
     // SAFETY:
     // - `db_state` was allocated using the global allocator (precondition)
@@ -199,8 +199,8 @@ unsafe extern "C" fn Carmen_Rust_ReleaseState(state: *mut c_void) {
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
 /// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
-/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
-/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
+/// - `state.state` must not be mutated for the duration of the lifetime of `token`
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Carmen_Rust_GetArchiveState(state: *mut c_void, block: u64) -> *mut c_void {
     let token = LifetimeToken;
@@ -214,9 +214,9 @@ unsafe extern "C" fn Carmen_Rust_GetArchiveState(state: *mut c_void, block: u64)
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
     // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
-    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
-    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
     let db_state = unsafe { state.to_ref_mut_scoped(&token) };
     match db_state.get_archive_state(block) {
         Ok(archive_state) => {
@@ -234,8 +234,8 @@ unsafe extern "C" fn Carmen_Rust_GetArchiveState(state: *mut c_void, block: u64)
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
 /// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
-/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
-/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
+/// - `state.state` must not be mutated for the duration of the lifetime of `token`
 /// - `addr` must be a valid pointer to a byte array of length 20
 /// - `addr` must be valid for reads for the duration of the call
 /// - `addr` must not be mutated for the duration of the call
@@ -258,9 +258,9 @@ unsafe extern "C" fn Carmen_Rust_GetAccountState(
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
     // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
-    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
-    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
     let db_state = unsafe { state.to_ref_mut_scoped(&token) };
     // SAFETY:
     // - `addr` is a valid pointer to a byte array of length 20 (precondition)
@@ -286,8 +286,8 @@ unsafe extern "C" fn Carmen_Rust_GetAccountState(
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
 /// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
-/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
-/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
+/// - `state.state` must not be mutated for the duration of the lifetime of `token`
 /// - `addr` must be a valid pointer to a byte array of length 20
 /// - `addr` must be valid for reads for the duration of the call
 /// - `addr` must not be mutated for the duration of the call
@@ -310,9 +310,9 @@ unsafe extern "C" fn Carmen_Rust_GetBalance(
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
     // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
-    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
-    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
     let db_state = unsafe { state.to_ref_mut_scoped(&token) };
     // SAFETY:
     // - `addr` is a valid pointer to a byte array of length 20 (precondition)
@@ -338,8 +338,8 @@ unsafe extern "C" fn Carmen_Rust_GetBalance(
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
 /// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
-/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
-/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
+/// - `state.state` must not be mutated for the duration of the lifetime of `token`
 /// - `addr` must be a valid pointer to a byte array of length 20
 /// - `addr` must be valid for reads for the duration of the call
 /// - `addr` must not be mutated for the duration of the call
@@ -362,9 +362,9 @@ unsafe extern "C" fn Carmen_Rust_GetNonce(
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
     // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
-    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
-    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
     let db_state = unsafe { state.to_ref_mut_scoped(&token) };
     // SAFETY:
     // - `addr` is a valid pointer to a byte array of length 20 (precondition)
@@ -390,8 +390,8 @@ unsafe extern "C" fn Carmen_Rust_GetNonce(
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
 /// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
-/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
-/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
+/// - `state.state` must not be mutated for the duration of the lifetime of `token`
 /// - `addr` must be a valid pointer to a byte array of length 20
 /// - `addr` must be valid for reads for the duration of the call
 /// - `addr` must not be mutated for the duration of the call
@@ -418,9 +418,9 @@ unsafe extern "C" fn Carmen_Rust_GetStorageValue(
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
     // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
-    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
-    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
     let db_state = unsafe { state.to_ref_mut_scoped(&token) };
     // SAFETY:
     // - `addr` is a valid pointer to a byte array of length 20 (precondition)
@@ -451,8 +451,8 @@ unsafe extern "C" fn Carmen_Rust_GetStorageValue(
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
 /// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
-/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
-/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
+/// - `state.state` must not be mutated for the duration of the lifetime of `token`
 /// - `addr` must be a valid pointer to a byte array of length 20
 /// - `addr` must be valid for reads for the duration of the call
 /// - `addr` must not be mutated for the duration of the call
@@ -479,9 +479,9 @@ unsafe extern "C" fn Carmen_Rust_GetCode(
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
     // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
-    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
-    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
     let db_state = unsafe { state.to_ref_mut_scoped(&token) };
     // SAFETY:
     // - `addr` is a valid pointer to a byte array of length 20 (precondition)
@@ -514,8 +514,8 @@ unsafe extern "C" fn Carmen_Rust_GetCode(
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
 /// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
-/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
-/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
+/// - `state.state` must not be mutated for the duration of the lifetime of `token`
 /// - `addr` must be a valid pointer to a byte array of length 20
 /// - `addr` must be valid for reads for the duration of the call
 /// - `addr` must not be mutated for the duration of the call
@@ -538,9 +538,9 @@ unsafe extern "C" fn Carmen_Rust_GetCodeHash(
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
     // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
-    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
-    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
     let db_state = unsafe { state.to_ref_mut_scoped(&token) };
     // SAFETY:
     // - `addr` is a valid pointer to a byte array of length 20 (precondition)
@@ -566,8 +566,8 @@ unsafe extern "C" fn Carmen_Rust_GetCodeHash(
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
 /// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
-/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
-/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
+/// - `state.state` must not be mutated for the duration of the lifetime of `token`
 /// - `addr` must be a valid pointer to a byte array of length 20
 /// - `addr` must be valid for reads for the duration of the call
 /// - `addr` must not be mutated for the duration of the call
@@ -590,9 +590,9 @@ unsafe extern "C" fn Carmen_Rust_GetCodeSize(
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
     // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
-    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
-    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
     let db_state = unsafe { state.to_ref_mut_scoped(&token) };
     // SAFETY:
     // - `addr` is a valid pointer to a byte array of length 20 (precondition)
@@ -618,8 +618,8 @@ unsafe extern "C" fn Carmen_Rust_GetCodeSize(
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
 /// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
-/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
-/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
+/// - `state.state` must not be mutated for the duration of the lifetime of `token`
 /// - `update` must be a valid pointer to a byte array of length `length`
 /// - `update` must be valid for reads for the duration of the call
 /// - `update` must not be mutated for the duration of the call
@@ -641,9 +641,9 @@ unsafe extern "C" fn Carmen_Rust_Apply(
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
     // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
-    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
-    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
     let db_state = unsafe { state.to_ref_mut_scoped(&token) };
     // SAFETY:
     // - `update` is a valid pointer to a byte array of length `length` (precondition)
@@ -670,8 +670,8 @@ unsafe extern "C" fn Carmen_Rust_Apply(
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
 /// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
-/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
-/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
+/// - `state.state` must not be mutated for the duration of the lifetime of `token`
 /// - `out_hash` must be a valid pointer to a byte array of length 32
 /// - `out_hash` must be valid for writes for the duration of the call
 #[unsafe(no_mangle)]
@@ -687,9 +687,9 @@ unsafe extern "C" fn Carmen_Rust_GetHash(state: *mut c_void, out_hash: *mut c_vo
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
     // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
-    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
-    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
     let db_state = unsafe { state.to_ref_mut_scoped(&token) };
     match db_state.get_hash() {
         Ok(hash) => {
@@ -712,8 +712,8 @@ unsafe extern "C" fn Carmen_Rust_GetHash(state: *mut c_void, out_hash: *mut c_vo
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
 /// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
-/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
-/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
+/// - `state.state` must not be mutated for the duration of the lifetime of `token`
 /// - `out` must be a valid pointer to a byte array of length `out_length`
 /// - `out` must be valid for and writes for the duration of the call
 /// - `out` must not be mutated for the duration of the call
@@ -736,9 +736,9 @@ unsafe extern "C" fn Carmen_Rust_GetMemoryFootprint(
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
     // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
-    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
-    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
     let db_state = unsafe { state.to_ref_mut_scoped(&token) };
     match db_state.get_memory_footprint() {
         Ok(msg) => {
@@ -812,7 +812,7 @@ impl StateWrapper {
 
 /// A zero sized type, used to enforce the correct lifetime for references created from
 /// pointers obtained via FFI. It is assumed that the lifetime of the pointer is bound by the
-/// lifetime of the borrow of the token.
+/// lifetime of the borrow of [`LifetimeToken`].
 /// When the token is crated at the beginning of a function call, it ensures that the
 /// references created from pointers obtained via FFI are only valid for the duration of the
 /// function call.
@@ -820,21 +820,21 @@ struct LifetimeToken;
 
 /// # Safety
 /// - `ptr` must be non-null
-/// - `ptr` must be valid for reads for the lifetime of the borrow of token
-/// - `ptr` must not be mutated for the lifetime of the borrow of the token
+/// - `ptr` must be valid for reads for the lifetime of the borrow of `_token`
+/// - `ptr` must not be mutated for the lifetime of the borrow of `_token`
 #[allow(clippy::needless_lifetimes)] // use explicit lifetimes for easier understanding
 unsafe fn ref_from_ptr_scoped<'s, T: ?Sized>(ptr: *const T, _token: &'s LifetimeToken) -> &'s T {
     // SAFETY:
     // - `ptr` is non-null (precondition)
-    // - `ptr` is valid for reads for the lifetime of the borrow of token (precondition)
-    // - `ptr` is not mutated for the lifetime of the borrow of the token (precondition)
+    // - `ptr` is valid for reads for the lifetime of the borrow of `_token`(precondition)
+    // - `ptr` is not mutated for the lifetime of the borrow of `_token` (precondition)
     unsafe { &*ptr }
 }
 
 /// # Safety
 /// - `ptr` must be non-null
-/// - `ptr` must be valid for reads and writes for the lifetime of the borrow of token
-/// - `ptr` must not be mutated for the lifetime of the borrow of the token
+/// - `ptr` must be valid for reads and writes for the lifetime of the borrow of `_token`
+/// - `ptr` must not be mutated for the lifetime of the borrow of `_token`
 #[allow(clippy::needless_lifetimes)] // use explicit lifetimes for easier understanding
 #[allow(clippy::mut_from_ref)] // false positive
 unsafe fn ref_mut_from_ptr_scoped<'s, T: ?Sized>(
@@ -843,16 +843,17 @@ unsafe fn ref_mut_from_ptr_scoped<'s, T: ?Sized>(
 ) -> &'s mut T {
     // SAFETY:
     // - `ptr` is non-null (precondition)
-    // - `ptr` is valid for reads and writes for the lifetime of the borrow of token (precondition)
-    // - `ptr` is not mutated for the lifetime of the borrow of the token (precondition)
+    // - `ptr` is valid for reads and writes for the lifetime of the borrow of
+    //   `_token`(precondition)
+    // - `ptr` is not mutated for the lifetime of the borrow of `_token` (precondition)
     unsafe { &mut *ptr }
 }
 
 /// # Safety
 /// - `ptr` must be non-null
 /// - `ptr` must be valid for reads for `len * mem::size_of::<T>()` many bytes for the lifetime of
-///   the borrow of token
-/// - `ptr` must not be mutated for the lifetime of the borrow of the token
+///   the borrow of `_token`
+/// - `ptr` must not be mutated for the lifetime of the borrow of `_token`
 #[allow(clippy::needless_lifetimes)] // use explicit lifetimes for easier understanding
 unsafe fn slice_from_raw_parts_scoped<'s, T>(
     ptr: *const T,
@@ -862,16 +863,16 @@ unsafe fn slice_from_raw_parts_scoped<'s, T>(
     // SAFETY:
     // - `ptr` is non-null (precondition)
     // - `ptr` is valid for reads for `len * mem::size_of::<T>()` many bytes for the lifetime of the
-    //   borrow of token (precondition)
-    // - `ptr` is not mutated for the lifetime of the borrow of the token (precondition)
+    //   borrow of `_token`(precondition)
+    // - `ptr` is not mutated for the lifetime of the borrow of `_token` (precondition)
     unsafe { std::slice::from_raw_parts(ptr, len) }
 }
 
 /// # Safety
 /// - `ptr` must be non-null
 /// - `ptr` must be valid for reads and writes for `len * mem::size_of::<T>()` many bytes for the
-///   lifetime of the borrow of token
-/// - `ptr` must not be mutated for the lifetime of the borrow of the token
+///   lifetime of the borrow of `_token`
+/// - `ptr` must not be mutated for the lifetime of the borrow of `_token`
 #[allow(clippy::needless_lifetimes)] // use explicit lifetimes for easier understanding
 #[allow(clippy::mut_from_ref)] // false positive
 unsafe fn slice_from_raw_parts_mut_scoped<'s, T>(
@@ -882,8 +883,8 @@ unsafe fn slice_from_raw_parts_mut_scoped<'s, T>(
     // SAFETY:
     // - `ptr` is non-null (precondition)
     // - `ptr` is valid for reads and writes for `len * mem::size_of::<T>()` many bytes for the
-    //   lifetime of the borrow of token (precondition)
-    // - `ptr` is not mutated for the lifetime of the borrow of the token (precondition)
+    //   lifetime of the borrow of `_token`(precondition)
+    // - `ptr` is not mutated for the lifetime of the borrow of `_token` (precondition)
     unsafe { std::slice::from_raw_parts_mut(ptr, len) }
 }
 

--- a/rust/src/ffi/exported.rs
+++ b/rust/src/ffi/exported.rs
@@ -7,11 +7,24 @@
 //
 // On the date above, in accordance with the Business Source License, use of
 // this software will be governed by the GNU Lesser General Public License v3.
-#![allow(unused_variables)]
 
-use std::ffi::{c_char, c_int, c_void};
+use std::{
+    ffi::{c_char, c_int, c_void},
+    mem::MaybeUninit,
+};
 
-use crate::ffi::bindings;
+use crate::{
+    CarmenS6Db,
+    ffi::bindings,
+    open_carmen_s6_db,
+    types::{Address, ArchiveImpl, Hash, Key, StateImpl, U256, Update, Value},
+};
+
+/// The size of the buffer that gets passed to `Carmen_Rust_GetCode`.
+/// This is also the maximum size.
+/// When running in MIRI, the maximum code size is reduced to 25 bytes because MIRI is very slow
+/// otherwise.
+const MAX_CODE_SIZE: usize = if cfg!(miri) { 25 } else { 25000 };
 
 /// Opens a new state object based on the provided implementation maintaining
 /// its data in the given directory. If the directory does not exist, it is
@@ -23,6 +36,11 @@ use crate::ffi::bindings;
 /// caller, which is required for releasing it eventually using Carmen_Rust_ReleaseState.
 /// If for some reason the creation of the state instance failed, a nullptr is
 /// returned.
+///
+/// # Safety
+/// - `directory` must be a valid pointer to a byte array of length `length`
+/// - `directory` must be valid for reads for the duration of the call
+/// - `directory` must not be mutated for the duration of the call
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Carmen_Rust_OpenState(
     schema: u8,
@@ -31,68 +49,357 @@ unsafe extern "C" fn Carmen_Rust_OpenState(
     directory: *const c_char,
     length: c_int,
 ) -> *mut c_void {
-    unimplemented!()
+    let token = LifetimeToken;
+    if directory.is_null() || length <= 0 {
+        return std::ptr::null_mut();
+    }
+    let state = match state {
+        0 => StateImpl::Memory,
+        1 => StateImpl::File,
+        2 => StateImpl::LevelDb,
+        _ => return std::ptr::null_mut(),
+    };
+    let archive = match archive {
+        0 => ArchiveImpl::None,
+        1 => ArchiveImpl::LevelDb,
+        2 => ArchiveImpl::Sqlite,
+        _ => return std::ptr::null_mut(),
+    };
+    // SAFETY:
+    // - `directory` is a valid pointer to a byte array of length `length` (precondition)
+    // - `directory` is valid for reads for the duration of the call (precondition)
+    // - `directory` is not mutated for the duration of the call (precondition)
+    let directory =
+        unsafe { slice_from_raw_parts_scoped(directory as *const u8, length as usize, &token) };
+    let db_state = open_carmen_s6_db(schema, state, archive, directory);
+    match db_state {
+        Ok(db_state) => {
+            Box::into_raw(Box::new(StateWrapper::from_db_state(db_state))) as *mut c_void
+        }
+        Err(_) => std::ptr::null_mut(),
+    }
 }
 
 /// Flushes all committed state information to disk to guarantee permanent
 /// storage. All internally cached modifications are synced to disk.
+///
+/// # Safety
+/// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
+///   CarmenS6Db` object
+/// - `state` must be valid for reads and writes for the duration of the call
+/// - `state` must not be mutated for the duration of the call
+/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
+/// - `state.state` must not be mutated for the duration of the lifetime of token
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Carmen_Rust_Flush(state: *mut c_void) {
-    unimplemented!()
+    let token = LifetimeToken;
+    if state.is_null() {
+        unimplemented!();
+    }
+    // SAFETY:
+    // - `state` is a valid pointer to a `StateWrapper` object (precondition)
+    // - `state` is valid for reads and writes for the duration of the call (precondition)
+    // - `state` is not mutated for the duration of the call (precondition)
+    let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
+    // SAFETY:
+    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    //   (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    let db_state = unsafe { state.to_ref_mut_scoped(&token) };
+    #[allow(unused_variables)]
+    if let Err(error) = db_state.flush() {
+        unimplemented!();
+    }
 }
 
 /// Closes this state, releasing all IO handles and locks on external resources.
+///
+/// # Safety
+/// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
+///   CarmenS6Db` object
+/// - `state` must be valid for reads and writes for the duration of the call
+/// - `state` must not be mutated for the duration of the call
+/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
+/// - `state.state` must not be mutated for the duration of the lifetime of token
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Carmen_Rust_Close(state: *mut c_void) {
-    unimplemented!()
+    let token = LifetimeToken;
+    if state.is_null() {
+        unimplemented!();
+    }
+    // SAFETY:
+    // - `state` is a valid pointer to a `StateWrapper` object (precondition)
+    // - `state` is valid for reads and writes for the duration of the call (precondition)
+    // - `state` is not mutated for the duration of the call (precondition)
+    let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
+    // SAFETY:
+    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    //   (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    let db_state = unsafe { state.to_ref_mut_scoped(&token) };
+    #[allow(unused_variables)]
+    if let Err(error) = db_state.close() {
+        unimplemented!();
+    }
 }
 
 /// Releases a state object, thereby causing its destruction. After releasing it,
 /// no more operations may be applied on it.
+///
+/// # Safety
+/// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
+///   CarmenS6Db` object
+/// - `state` must be valid for reads and writes for the duration of the call
+/// - `state` must not be mutated for the duration of the call
+/// - `state` must have been allocated using the global allocator
+/// - `state` must not be used after this call
+/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
+/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `state.state` must have been allocated using the global allocator
+/// - `state.state` must not be used after this call
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Carmen_Rust_ReleaseState(state: *mut c_void) {
-    unimplemented!()
+    let token = LifetimeToken;
+    if state.is_null() {
+        unimplemented!();
+    }
+    // SAFETY:
+    // - `state` is a valid pointer to a `StateWrapper` object (precondition)
+    // - `state` is valid for reads and writes for the duration of the call (precondition)
+    // - `state` is not mutated for the duration of the call (precondition)
+    let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
+    // SAFETY:
+    // - `state` was allocated using the global allocator (precondition)
+    // - `state` is not used after this call (precondition)
+    let state = unsafe { Box::from_raw(state) };
+    // SAFETY:
+    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    //   (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    let db_state = unsafe { state.to_ref_mut_scoped(&token) };
+    // SAFETY:
+    // - `db_state` was allocated using the global allocator (precondition)
+    // - `db_state` is not used after this call (precondition)
+    let _ = unsafe { Box::from_raw(db_state) };
 }
 
 /// Creates a state snapshot reflecting the state at the given block height. The
 /// resulting state must be released and must not outlive the life time of the
 /// provided state.
+///
+/// # Safety
+/// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
+///   CarmenS6Db` object
+/// - `state` must be valid for reads and writes for the duration of the call
+/// - `state` must not be mutated for the duration of the call
+/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
+/// - `state.state` must not be mutated for the duration of the lifetime of token
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Carmen_Rust_GetArchiveState(state: *mut c_void, block: u64) -> *mut c_void {
-    unimplemented!()
+    let token = LifetimeToken;
+    if state.is_null() {
+        unimplemented!();
+    }
+    // SAFETY:
+    // - `state` is a valid pointer to a `StateWrapper` object (precondition)
+    // - `state` is valid for reads and writes for the duration of the call (precondition)
+    // - `state` is not mutated for the duration of the call (precondition)
+    let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
+    // SAFETY:
+    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    //   (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    let db_state = unsafe { state.to_ref_mut_scoped(&token) };
+    match db_state.get_archive_state(block) {
+        Ok(archive_state) => {
+            Box::into_raw(Box::new(StateWrapper::from_db_state(archive_state))) as *mut c_void
+        }
+        Err(_) => std::ptr::null_mut(),
+    }
 }
 
 /// Gets the current state of the given account.
+///
+/// # Safety
+/// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
+///   CarmenS6Db` object
+/// - `state` must be valid for reads and writes for the duration of the call
+/// - `state` must not be mutated for the duration of the call
+/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
+/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `addr` must be a valid pointer to a byte array of length 20
+/// - `addr` must be valid for reads for the duration of the call
+/// - `addr` must not be mutated for the duration of the call
+/// - `out_state` must be a valid pointer to a `u8`
+/// - `out_state` must be valid for writes for the duration of the call
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Carmen_Rust_GetAccountState(
     state: *mut c_void,
     addr: *mut c_void,
     out_state: *mut c_void,
 ) {
-    unimplemented!()
+    let token = LifetimeToken;
+    if state.is_null() || addr.is_null() || out_state.is_null() {
+        unimplemented!();
+    }
+    // SAFETY:
+    // - `state` is a valid pointer to a `StateWrapper` object (precondition)
+    // - `state` is valid for reads and writes for the duration of the call (precondition)
+    // - `state` is not mutated for the duration of the call (precondition)
+    let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
+    // SAFETY:
+    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    //   (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    let db_state = unsafe { state.to_ref_mut_scoped(&token) };
+    // SAFETY:
+    // - `addr` is a valid pointer to a byte array of length 20 (precondition)
+    // - `addr` is valid for reads for the duration of the call (precondition)
+    // - `addr` is not mutated for the duration of the call (precondition)
+    let addr = unsafe { ref_from_ptr_scoped(addr as *mut Address, &token) };
+    match db_state.get_account_state(addr) {
+        Ok(account_state) => {
+            // SAFETY:
+            // - `out_state` is a valid pointer to a `u8` (precondition)
+            // - `out_state` is valid for writes for the duration of the call (precondition)
+            unsafe { std::ptr::write(out_state as *mut u8, account_state) };
+        }
+        Err(_) => unimplemented!(),
+    }
 }
 
 /// Retrieves the balance of the given account.
+///
+/// # Safety
+/// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
+///   CarmenS6Db` object
+/// - `state` must be valid for reads and writes for the duration of the call
+/// - `state` must not be mutated for the duration of the call
+/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
+/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `addr` must be a valid pointer to a byte array of length 20
+/// - `addr` must be valid for reads for the duration of the call
+/// - `addr` must not be mutated for the duration of the call
+/// - `out_balance` must be a valid pointer to a byte array of length 32
+/// - `out_balance` must be valid for writes for the duration of the call
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Carmen_Rust_GetBalance(
     state: *mut c_void,
     addr: *mut c_void,
     out_balance: *mut c_void,
 ) {
-    unimplemented!()
+    let token = LifetimeToken;
+    if state.is_null() || addr.is_null() || out_balance.is_null() {
+        unimplemented!();
+    }
+    // SAFETY:
+    // - `state` is a valid pointer to a `StateWrapper` object (precondition)
+    // - `state` is valid for reads and writes for the duration of the call (precondition)
+    // - `state` is not mutated for the duration of the call (precondition)
+    let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
+    // SAFETY:
+    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    //   (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    let db_state = unsafe { state.to_ref_mut_scoped(&token) };
+    // SAFETY:
+    // - `addr` is a valid pointer to a byte array of length 20 (precondition)
+    // - `addr` is valid for reads for the duration of the call (precondition)
+    // - `addr` is not mutated for the duration of the call (precondition)
+    let addr = unsafe { ref_from_ptr_scoped(addr as *mut Address, &token) };
+    match db_state.get_balance(addr) {
+        Ok(balance) => {
+            // SAFETY:
+            // - `out_balance` is a valid pointer to a byte array of length 32 (precondition)
+            // - `out_balance` is valid for writes for the duration of the call (precondition)
+            unsafe { std::ptr::write(out_balance as *mut U256, balance) };
+        }
+        Err(_) => unimplemented!(),
+    }
 }
 
 /// Retrieves the nonce of the given account.
+///
+/// # Safety
+/// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
+///   CarmenS6Db` object
+/// - `state` must be valid for reads and writes for the duration of the call
+/// - `state` must not be mutated for the duration of the call
+/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
+/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `addr` must be a valid pointer to a byte array of length 20
+/// - `addr` must be valid for reads for the duration of the call
+/// - `addr` must not be mutated for the duration of the call
+/// - `out_nonce` must be a valid pointer to a `u64`
+/// - `out_nonce` must be valid for writes for the duration of the call
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Carmen_Rust_GetNonce(
     state: *mut c_void,
     addr: *mut c_void,
     out_nonce: *mut c_void,
 ) {
-    unimplemented!()
+    let token = LifetimeToken;
+    if state.is_null() || addr.is_null() || out_nonce.is_null() {
+        unimplemented!();
+    }
+    // SAFETY:
+    // - `state` is a valid pointer to a `StateWrapper` object (precondition)
+    // - `state` is valid for reads and writes for the duration of the call (precondition)
+    // - `state` is not mutated for the duration of the call (precondition)
+    let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
+    // SAFETY:
+    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    //   (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    let db_state = unsafe { state.to_ref_mut_scoped(&token) };
+    // SAFETY:
+    // - `addr` is a valid pointer to a byte array of length 20 (precondition)
+    // - `addr` is valid for reads for the duration of the call (precondition)
+    // - `addr` is not mutated for the duration of the call (pre
+    let addr = unsafe { ref_from_ptr_scoped(addr as *mut Address, &token) };
+    match db_state.get_nonce(addr) {
+        Ok(nonce) => {
+            // SAFETY:
+            // - `out_nonce` is a valid pointer to a byte array of length 32 (precondition)
+            // - `out_nonce` is valid for writes for the duration of the call (precondition)
+            unsafe { std::ptr::write(out_nonce as *mut u64, nonce) };
+        }
+        Err(_) => unimplemented!(),
+    }
 }
 
 /// Retrieves the value of storage location (addr,key) in the given state.
+///
+/// # Safety
+/// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
+///   CarmenS6Db` object
+/// - `state` must be valid for reads and writes for the duration of the call
+/// - `state` must not be mutated for the duration of the call
+/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
+/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `addr` must be a valid pointer to a byte array of length 20
+/// - `addr` must be valid for reads for the duration of the call
+/// - `addr` must not be mutated for the duration of the call
+/// - `key` must be a valid pointer to a byte array of length 32
+/// - `key` must be valid for reads and writes for the duration of the call
+/// - `key` must not be mutated for the duration of the call
+/// - `out_value` must be a valid pointer to a byte array of length 32
+/// - `out_value` must be valid for writes for the duration of the call
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Carmen_Rust_GetStorageValue(
     state: *mut c_void,
@@ -100,10 +407,60 @@ unsafe extern "C" fn Carmen_Rust_GetStorageValue(
     key: *mut c_void,
     out_value: *mut c_void,
 ) {
-    unimplemented!()
+    let token = LifetimeToken;
+    if state.is_null() || addr.is_null() || key.is_null() || out_value.is_null() {
+        unimplemented!();
+    }
+    // SAFETY:
+    // - `state` is a valid pointer to a `StateWrapper` object (precondition)
+    // - `state` is valid for reads and writes for the duration of the call (precondition)
+    // - `state` is not mutated for the duration of the call (precondition)
+    let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
+    // SAFETY:
+    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    //   (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    let db_state = unsafe { state.to_ref_mut_scoped(&token) };
+    // SAFETY:
+    // - `addr` is a valid pointer to a byte array of length 20 (precondition)
+    // - `addr` is valid for reads for the duration of the call (precondition)
+    // - `addr` is not mutated for the duration of the call (precondition)
+    let addr = unsafe { ref_from_ptr_scoped(addr as *mut Address, &token) };
+    // SAFETY:
+    // - `key` is a valid pointer to a byte array of length 32 (precondition)
+    // - `key` is valid for reads and writes for the duration of the call (precondition)
+    // - `key` is not mutated for the duration of the call (precondition)
+    let key = unsafe { ref_mut_from_ptr_scoped(key as *mut Key, &token) };
+    match db_state.get_storage_value(addr, key) {
+        Ok(value) => {
+            // SAFETY:
+            // - `out_value` is a valid pointer to a byte array of length 32 (precondition)
+            // - `out_value` is valid for writes for the duration of the call (precondition)
+            unsafe { std::ptr::write(out_value as *mut Value, value) };
+        }
+        Err(_) => unimplemented!(),
+    }
 }
 
 /// Retrieves the code stored under the given address.
+///
+/// # Safety
+/// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
+///   CarmenS6Db` object
+/// - `state` must be valid for reads and writes for the duration of the call
+/// - `state` must not be mutated for the duration of the call
+/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
+/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `addr` must be a valid pointer to a byte array of length 20
+/// - `addr` must be valid for reads for the duration of the call
+/// - `addr` must not be mutated for the duration of the call
+/// - `out_code` must be a valid pointer to a byte array of length `MAX_CODE_SIZE`
+/// - `out_code` must be valid for writes for the duration of the call
+/// - `out_code` must not be mutated for the duration of the call
+/// - `out_length` must be a valid pointer to a `u32`
+/// - `out_length` must be valid for writes for the duration of the call
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Carmen_Rust_GetCode(
     state: *mut c_void,
@@ -111,30 +468,161 @@ unsafe extern "C" fn Carmen_Rust_GetCode(
     out_code: *mut c_void,
     out_length: *mut u32,
 ) {
-    unimplemented!()
+    let token = LifetimeToken;
+    if state.is_null() || addr.is_null() || out_code.is_null() || out_length.is_null() {
+        unimplemented!();
+    }
+    // SAFETY:
+    // - `state` is a valid pointer to a `StateWrapper` object (precondition)
+    // - `state` is valid for reads and writes for the duration of the call (precondition)
+    // - `state` is not mutated for the duration of the call (precondition)
+    let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
+    // SAFETY:
+    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    //   (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    let db_state = unsafe { state.to_ref_mut_scoped(&token) };
+    // SAFETY:
+    // - `addr` is a valid pointer to a byte array of length 20 (precondition)
+    // - `addr` is valid for reads for the duration of the call (precondition)
+    // - `addr` is not mutated for the duration of the call (precondition)
+    let addr = unsafe { ref_from_ptr_scoped(addr as *mut Address, &token) };
+    // SAFETY:
+    // - `out_code` is a valid pointer to a byte array of length `MAX_CODE_SIZE` (precondition)
+    // - `out_code` is valid for writes for the duration of the call (precondition)
+    // - `out_code` is not mutated for the duration of the call (precondition)
+    let out_code = unsafe {
+        slice_from_raw_parts_mut_scoped(out_code as *mut MaybeUninit<u8>, MAX_CODE_SIZE, &token)
+    };
+    match db_state.get_code(addr, out_code) {
+        Ok(len) => {
+            // SAFETY:
+            // - `out_length` is a valid pointer to a `u32` (precondition)
+            // - `out_length` is valid for writes for the duration of the call (precondition)
+            unsafe { std::ptr::write(out_length, len as u32) };
+        }
+        Err(_) => unimplemented!(),
+    }
 }
 
 /// Retrieves the hash of the code stored under the given address.
+///
+/// # Safety
+/// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
+///   CarmenS6Db` object
+/// - `state` must be valid for reads and writes for the duration of the call
+/// - `state` must not be mutated for the duration of the call
+/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
+/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `addr` must be a valid pointer to a byte array of length 20
+/// - `addr` must be valid for reads for the duration of the call
+/// - `addr` must not be mutated for the duration of the call
+/// - `out_hash` must be a valid pointer to a byte array of length 32
+/// - `out_hash` must be valid for writes for the duration of the call
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Carmen_Rust_GetCodeHash(
     state: *mut c_void,
     addr: *mut c_void,
     out_hash: *mut c_void,
 ) {
-    unimplemented!()
+    let token = LifetimeToken;
+    if state.is_null() || addr.is_null() || out_hash.is_null() {
+        unimplemented!();
+    }
+    // SAFETY:
+    // - `state` is a valid pointer to a `StateWrapper` object (precondition)
+    // - `state` is valid for reads and writes for the duration of the call (precondition)
+    // - `state` is not mutated for the duration of the call (precondition)
+    let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
+    // SAFETY:
+    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    //   (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    let db_state = unsafe { state.to_ref_mut_scoped(&token) };
+    // SAFETY:
+    // - `addr` is a valid pointer to a byte array of length 20 (precondition)
+    // - `addr` is valid for reads for the duration of the call (precondition)
+    // - `addr` is not mutated for the duration of the call (precondition)
+    let addr = unsafe { ref_from_ptr_scoped(addr as *const Address, &token) };
+    match db_state.get_code_hash(addr) {
+        Ok(code_hash) => {
+            // SAFETY:
+            // - `out_hash` is a valid pointer to a `u32` (precondition)
+            // - `out_hash` is valid for writes for the duration of the call (precondition)
+            unsafe { std::ptr::write(out_hash as *mut Hash, code_hash) };
+        }
+        Err(_) => unimplemented!(),
+    }
 }
 
 /// Retrieves the code length stored under the given address.
+///
+/// # Safety
+/// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
+///   CarmenS6Db` object
+/// - `state` must be valid for reads and writes for the duration of the call
+/// - `state` must not be mutated for the duration of the call
+/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
+/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `addr` must be a valid pointer to a byte array of length 20
+/// - `addr` must be valid for reads for the duration of the call
+/// - `addr` must not be mutated for the duration of the call
+/// - `out_length` must be a valid pointer to a `u32`
+/// - `out_length` must be valid for writes for the duration of the call
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Carmen_Rust_GetCodeSize(
     state: *mut c_void,
     addr: *mut c_void,
     out_length: *mut u32,
 ) {
-    unimplemented!()
+    let token = LifetimeToken;
+    if state.is_null() || addr.is_null() || out_length.is_null() {
+        unimplemented!();
+    }
+    // SAFETY:
+    // - `state` is a valid pointer to a `StateWrapper` object (precondition)
+    // - `state` is valid for reads and writes for the duration of the call (precondition)
+    // - `state` is not mutated for the duration of the call (precondition)
+    let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
+    // SAFETY:
+    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    //   (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    let db_state = unsafe { state.to_ref_mut_scoped(&token) };
+    // SAFETY:
+    // - `addr` is a valid pointer to a byte array of length 20 (precondition)
+    // - `addr` is valid for reads for the duration of the call (precondition)
+    // - `addr` is not mutated for the duration of the call (precondition)
+    let addr = unsafe { ref_from_ptr_scoped(addr as *const Address, &token) };
+    match db_state.get_code_len(addr) {
+        Ok(code_size) => {
+            // SAFETY:
+            // - `out_length` is a valid pointer to a `u32` (precondition)
+            // - `out_length` is valid for writes for the duration of the call (precondition)
+            unsafe { std::ptr::write(out_length, code_size) };
+        }
+        Err(_) => unimplemented!(),
+    }
 }
 
 /// Applies the provided block update to the maintained state.
+///
+/// # Safety
+/// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
+///   CarmenS6Db` object
+/// - `state` must be valid for reads and writes for the duration of the call
+/// - `state` must not be mutated for the duration of the call
+/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
+/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `update` must be a valid pointer to a byte array of length `length`
+/// - `update` must be valid for reads for the duration of the call
+/// - `update` must not be mutated for the duration of the call
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Carmen_Rust_Apply(
     state: *mut c_void,
@@ -142,31 +630,261 @@ unsafe extern "C" fn Carmen_Rust_Apply(
     update: *mut c_void,
     length: u64,
 ) {
-    unimplemented!()
+    let token = LifetimeToken;
+    if state.is_null() || update.is_null() || length == 0 {
+        unimplemented!();
+    }
+    // SAFETY:
+    // - `state` is a valid pointer to a `StateWrapper` object (precondition)
+    // - `state` is valid for reads and writes for the duration of the call (precondition)
+    // - `state` is not mutated for the duration of the call (precondition)
+    let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
+    // SAFETY:
+    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    //   (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    let db_state = unsafe { state.to_ref_mut_scoped(&token) };
+    // SAFETY:
+    // - `update` is a valid pointer to a byte array of length `length` (precondition)
+    // - `update` is valid for reads for the duration of the call
+    // - `update` is not mutated for the duration of the call (precondition)
+    let update_data =
+        unsafe { slice_from_raw_parts_mut_scoped(update as *mut u8, length as usize, &token) };
+    let update = match Update::from_encoded(update_data) {
+        Ok(update) => update,
+        #[allow(unused_variables)]
+        Err(error) => unimplemented!(),
+    };
+    #[allow(unused_variables)]
+    if let Err(error) = db_state.apply_block_update(block, update) {
+        unimplemented!();
+    }
 }
 
 /// Retrieves a global state hash of the given state.
+///
+/// # Safety
+/// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
+///   CarmenS6Db` object
+/// - `state` must be valid for reads and writes for the duration of the call
+/// - `state` must not be mutated for the duration of the call
+/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
+/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `out_hash` must be a valid pointer to a byte array of length 32
+/// - `out_hash` must be valid for writes for the duration of the call
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Carmen_Rust_GetHash(state: *mut c_void, out_hash: *mut c_void) {
-    unimplemented!()
+    let token = LifetimeToken;
+    if state.is_null() || out_hash.is_null() {
+        unimplemented!();
+    }
+    // SAFETY:
+    // - `state` is a valid pointer to a `StateWrapper` object (precondition)
+    // - `state` is valid for reads and writes for the duration of the call (precondition)
+    // - `state` is not mutated for the duration of the call (precondition)
+    let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
+    // SAFETY:
+    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    //   (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    let db_state = unsafe { state.to_ref_mut_scoped(&token) };
+    match db_state.get_hash() {
+        Ok(hash) => {
+            // SAFETY:
+            // - `out_hash` is a valid pointer to a byte array of length 32 (precondition)
+            // - `out_hash` is valid for writes for the duration of the call (precondition)
+            unsafe { std::ptr::write(out_hash as *mut Hash, hash) };
+        }
+        Err(_) => unimplemented!(),
+    }
 }
 
 /// Retrieves a summary of the used memory. After the call the out variable will
 /// point to a buffer with a serialized summary that needs to be freed by the
 /// caller.
+///
+/// # Safety
+/// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
+///   CarmenS6Db` object
+/// - `state` must be valid for reads and writes for the duration of the call
+/// - `state` must not be mutated for the duration of the call
+/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be valid for reads and writes for the duration of the lifetime of token
+/// - `state.state` must not be mutated for the duration of the lifetime of token
+/// - `out` must be a valid pointer to a byte array of length `out_length`
+/// - `out` must be valid for and writes for the duration of the call
+/// - `out` must not be mutated for the duration of the call
+/// - `out_length` must be a valid pointer to a `u64`
+/// - `out_length` must be valid for writes for the duration of the call
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Carmen_Rust_GetMemoryFootprint(
     state: *mut c_void,
     out: *mut *mut c_char,
     out_length: *mut u64,
 ) {
-    unimplemented!()
+    let token = LifetimeToken;
+    if state.is_null() || out.is_null() || out_length.is_null() {
+        unimplemented!();
+    }
+    // SAFETY:
+    // - `state` is a valid pointer to a `StateWrapper` object (precondition)
+    // - `state` is valid for reads and writes for the duration of the call (precondition)
+    // - `state` is not mutated for the duration of the call (precondition)
+    let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
+    // SAFETY:
+    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is valid for reads and writes for the duration of the lifetime of token
+    //   (precondition)
+    // - `state.state` is not mutated for the duration of the lifetime of token (precondition)
+    let db_state = unsafe { state.to_ref_mut_scoped(&token) };
+    match db_state.get_memory_footprint() {
+        Ok(msg) => {
+            // SAFETY:
+            // - `out_length` is a valid pointer to a `u64` (precondition)
+            // - `out_length` is valid for writes for the duration of the call (precondition)
+            unsafe { std::ptr::write(out_length, msg.len() as u64) };
+            // SAFETY:
+            // - `out` is a valid pointer to a byte array of length `out_length` (precondition)
+            // - `out` is valid for writes for the duration of the call (precondition)
+            unsafe { std::ptr::write(out, Box::into_raw(msg) as *mut c_char) };
+        }
+        Err(_) => unimplemented!(),
+    }
 }
 
 /// Releases the buffer returned by GetMemoryFootprint.
+///
+/// # Safety
+/// - `buf` must be a valid pointer to a byte array of length `buf_length`
+/// - `buf` must be valid for reads and writes for the duration of the call
+/// - `buf` must not be mutated for the duration of the call
+/// - `buf` must have been allocated using the global allocator
+/// - `buf` must not be used after this call
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Carmen_Rust_ReleaseMemoryFootprintBuffer(buf: *mut c_char, buf_length: u64) {
-    unimplemented!()
+    if buf.is_null() || buf_length == 0 {
+        unimplemented!();
+    }
+    let buf = std::ptr::slice_from_raw_parts_mut(buf as *mut u8, buf_length as usize);
+    // SAFETY:
+    // - `buf` is a valid pointer to a byte array of length `buf_length` (precondition)
+    // - `buf` is valid for reads and writes for the duration of the call (precondition)
+    // - `buf` is not mutated for the duration of the call (precondition)
+    // - `buf` has been allocated using the global allocator (precondition)
+    // - `buf` is not used after this call (precondition)
+    unsafe {
+        let _ = Box::from_raw(buf);
+    }
+}
+
+/// A transparent wrapper around a pointer to a `dyn CarmenS6Db` object. Pointers to this wrapper
+/// type are passed as `state` through the FFI interface.
+#[repr(transparent)]
+struct StateWrapper {
+    state: *mut dyn CarmenS6Db,
+}
+
+impl StateWrapper {
+    /// # Safety
+    /// - `self.state` must be a valid pointer to a `dyn CarmenS6Db`
+    /// - `self.state` must be valid for reads and writes for the duration of the lifetime of
+    ///   `_token`
+    /// - `self.state` must not be mutated for the duration of the lifetime of `_token`
+    #[allow(clippy::mut_from_ref)] // false positive
+    unsafe fn to_ref_mut_scoped<'db>(&self, _token: &'db LifetimeToken) -> &'db mut dyn CarmenS6Db {
+        // SAFETY:
+        // - `self.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+        // - `self.state` is valid for reads and writes for the duration of the lifetime of `_token`
+        // (precondition)
+        // - `self.state` is not mutated for the duration of the lifetime of `_token` (precondition)
+        unsafe { &mut *self.state }
+    }
+
+    fn from_db_state(state: Box<dyn CarmenS6Db>) -> Self {
+        Self {
+            state: Box::into_raw(state),
+        }
+    }
+}
+
+/// A zero sized type, used to enforce the correct lifetime for references created from
+/// pointers obtained via FFI. It is assumed that the lifetime of the pointer is bound by the
+/// lifetime of the borrow of the token.
+/// When the token is crated at the beginning of a function call, it ensures that the
+/// references created from pointers obtained via FFI are only valid for the duration of the
+/// function call.
+struct LifetimeToken;
+
+/// # Safety
+/// - `ptr` must be non-null
+/// - `ptr` must be valid for reads for the lifetime of the borrow of token
+/// - `ptr` must not be mutated for the lifetime of the borrow of the token
+#[allow(clippy::needless_lifetimes)] // use explicit lifetimes for easier understanding
+unsafe fn ref_from_ptr_scoped<'s, T: ?Sized>(ptr: *const T, _token: &'s LifetimeToken) -> &'s T {
+    // SAFETY:
+    // - `ptr` is non-null (precondition)
+    // - `ptr` is valid for reads for the lifetime of the borrow of token (precondition)
+    // - `ptr` is not mutated for the lifetime of the borrow of the token (precondition)
+    unsafe { &*ptr }
+}
+
+/// # Safety
+/// - `ptr` must be non-null
+/// - `ptr` must be valid for reads and writes for the lifetime of the borrow of token
+/// - `ptr` must not be mutated for the lifetime of the borrow of the token
+#[allow(clippy::needless_lifetimes)] // use explicit lifetimes for easier understanding
+#[allow(clippy::mut_from_ref)] // false positive
+unsafe fn ref_mut_from_ptr_scoped<'s, T: ?Sized>(
+    ptr: *mut T,
+    _token: &'s LifetimeToken,
+) -> &'s mut T {
+    // SAFETY:
+    // - `ptr` is non-null (precondition)
+    // - `ptr` is valid for reads and writes for the lifetime of the borrow of token (precondition)
+    // - `ptr` is not mutated for the lifetime of the borrow of the token (precondition)
+    unsafe { &mut *ptr }
+}
+
+/// # Safety
+/// - `ptr` must be non-null
+/// - `ptr` must be valid for reads for `len * mem::size_of::<T>()` many bytes for the lifetime of
+///   the borrow of token
+/// - `ptr` must not be mutated for the lifetime of the borrow of the token
+#[allow(clippy::needless_lifetimes)] // use explicit lifetimes for easier understanding
+unsafe fn slice_from_raw_parts_scoped<'s, T>(
+    ptr: *const T,
+    len: usize,
+    _token: &'s LifetimeToken,
+) -> &'s [T] {
+    // SAFETY:
+    // - `ptr` is non-null (precondition)
+    // - `ptr` is valid for reads for `len * mem::size_of::<T>()` many bytes for the lifetime of the
+    //   borrow of token (precondition)
+    // - `ptr` is not mutated for the lifetime of the borrow of the token (precondition)
+    unsafe { std::slice::from_raw_parts(ptr, len) }
+}
+
+/// # Safety
+/// - `ptr` must be non-null
+/// - `ptr` must be valid for reads and writes for `len * mem::size_of::<T>()` many bytes for the
+///   lifetime of the borrow of token
+/// - `ptr` must not be mutated for the lifetime of the borrow of the token
+#[allow(clippy::needless_lifetimes)] // use explicit lifetimes for easier understanding
+#[allow(clippy::mut_from_ref)] // false positive
+unsafe fn slice_from_raw_parts_mut_scoped<'s, T>(
+    ptr: *mut T,
+    len: usize,
+    _token: &'s LifetimeToken,
+) -> &'s mut [T] {
+    // SAFETY:
+    // - `ptr` is non-null (precondition)
+    // - `ptr` is valid for reads and writes for `len * mem::size_of::<T>()` many bytes for the
+    //   lifetime of the borrow of token (precondition)
+    // - `ptr` is not mutated for the lifetime of the borrow of the token (precondition)
+    unsafe { std::slice::from_raw_parts_mut(ptr, len) }
 }
 
 /// Compile-time check that the signatures of the exported functions match the ones generated from
@@ -241,4 +959,360 @@ const COMPILE_TIME_CHECK_THAT_SIGNATURES_MATCH_SIGNATURES_GENERATED_FROM_C_HEADE
 
 const fn assert_same_signature<T>(a: T, b: T) -> (T, T) {
     (a, b)
+}
+
+const _COMPILE_TIME_CHECK_THAT_STATE_WRAPPER_HAS_DOUBLE_THE_SIZE_OF_VOID_POINTERS: () =
+    assert!(size_of::<StateWrapper>() == 2 * size_of::<*mut c_void>());
+
+#[allow(
+    clippy::multiple_unsafe_ops_per_block,
+    clippy::undocumented_unsafe_blocks
+)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::MockCarmenS6Db;
+
+    #[test]
+    fn carmen_rust_open_state_returns_non_null_pointers() {
+        unsafe {
+            let dir = "dir";
+            let state = Carmen_Rust_OpenState(
+                6,
+                StateImpl::Memory as u8 as u32,
+                ArchiveImpl::LevelDb as u8 as u32,
+                dir.as_ptr() as *const c_char,
+                dir.len() as i32,
+            );
+            assert!(!state.is_null());
+            let state_ref = &mut *(state as *mut StateWrapper);
+            assert!(!state_ref.state.is_null());
+            Carmen_Rust_ReleaseState(state);
+        }
+    }
+
+    #[test]
+    fn carmen_rust_flush_calls_flush_on_carmen_s6_db() {
+        create_state_then_call_fn_then_release_state(
+            |mock_db| {
+                mock_db.expect_flush().returning(|| Ok(()));
+            },
+            |state| unsafe {
+                Carmen_Rust_Flush(state);
+            },
+        );
+    }
+
+    #[test]
+    fn carmen_rust_close_calls_close_on_carmen_s6_db() {
+        create_state_then_call_fn_then_release_state(
+            |mock_db| {
+                mock_db.expect_close().returning(|| Ok(()));
+            },
+            |state| unsafe {
+                Carmen_Rust_Close(state);
+            },
+        );
+    }
+
+    #[test]
+    fn carmen_rust_get_archive_state_returns_archive_state_from_carmen_s6_db() {
+        let block = 1;
+        create_state_then_call_fn_then_release_state(
+            move |mock_db| {
+                mock_db
+                    .expect_get_archive_state()
+                    .withf(move |b| *b == block)
+                    .returning(|_| Ok(Box::new(MockCarmenS6Db::new())));
+            },
+            move |state| {
+                let archive_state = unsafe { Carmen_Rust_GetArchiveState(state, block) };
+                assert!(!archive_state.is_null());
+                unsafe { Carmen_Rust_ReleaseState(archive_state) };
+            },
+        );
+    }
+
+    #[test]
+    fn carmen_rust_get_account_state_returns_value_from_carmen_s6_db() {
+        let addr = [1; 20];
+        let expected_account_state = 1;
+        create_state_then_call_fn_then_release_state(
+            move |mock_db| {
+                mock_db
+                    .expect_get_account_state()
+                    .withf(move |a| a == &addr)
+                    .returning(move |_| Ok(expected_account_state));
+            },
+            move |state| {
+                let mut addr = addr;
+                let mut out_state = 0u8;
+                unsafe {
+                    Carmen_Rust_GetAccountState(
+                        state,
+                        &mut addr as *mut Address as *mut c_void,
+                        &mut out_state as *mut u8 as *mut c_void,
+                    );
+                }
+                assert_eq!(out_state, expected_account_state);
+            },
+        );
+    }
+
+    #[test]
+    fn carmen_rust_get_balance_returns_value_from_carmen_s6_db() {
+        let addr = [1; 20];
+        let expected_balance = [2; 32];
+        create_state_then_call_fn_then_release_state(
+            move |mock_db| {
+                mock_db
+                    .expect_get_balance()
+                    .withf(move |a| a == &addr)
+                    .returning(move |_| Ok(expected_balance));
+            },
+            move |state| {
+                let mut addr = addr;
+                let mut out_balance = [0u8; 32];
+                unsafe {
+                    Carmen_Rust_GetBalance(
+                        state,
+                        &mut addr as *mut Address as *mut c_void,
+                        &mut out_balance as *mut U256 as *mut c_void,
+                    );
+                }
+                assert_eq!(out_balance, expected_balance);
+            },
+        );
+    }
+
+    #[test]
+    fn carmen_rust_get_nonce_returns_value_from_carmen_s6_db() {
+        let addr = [1u8; 20];
+        let expected_nonce = 2;
+        create_state_then_call_fn_then_release_state(
+            move |mock_db| {
+                mock_db
+                    .expect_get_nonce()
+                    .withf(move |a| a == &addr)
+                    .returning(move |_| Ok(expected_nonce));
+            },
+            move |state| {
+                let mut addr = addr;
+                let mut out_nonce: u64 = 0;
+                unsafe {
+                    Carmen_Rust_GetNonce(
+                        state,
+                        &mut addr as *mut Address as *mut c_void,
+                        &mut out_nonce as *mut u64 as *mut c_void,
+                    );
+                }
+                assert_eq!(out_nonce, expected_nonce);
+            },
+        );
+    }
+
+    #[test]
+    fn carmen_rust_get_storage_value_returns_value_from_carmen_s6_db() {
+        let addr = [1; 20];
+        let key = [2; 32];
+        let expected_value = [3; 32];
+        create_state_then_call_fn_then_release_state(
+            move |mock_db| {
+                mock_db
+                    .expect_get_storage_value()
+                    .withf(move |a, k| a == &addr && k == &key)
+                    .returning(move |_, _| Ok(expected_value));
+            },
+            move |state| {
+                let mut addr = addr;
+                let mut key = key;
+                let mut out_value = [0u8; 32];
+                unsafe {
+                    Carmen_Rust_GetStorageValue(
+                        state,
+                        &mut addr as *mut Address as *mut c_void,
+                        &mut key as *mut Key as *mut c_void,
+                        &mut out_value as *mut Value as *mut c_void,
+                    );
+                }
+                assert_eq!(out_value, expected_value);
+            },
+        );
+    }
+
+    #[test]
+    fn carmen_rust_get_code_returns_code_from_carmen_s6_db() {
+        let addr = [1; 20];
+        let expected_code = [2, 3, 4];
+        create_state_then_call_fn_then_release_state(
+            move |mock_db| {
+                mock_db
+                    .expect_get_code()
+                    .withf(move |a, _| a == &addr)
+                    .returning(move |_, code_buf| {
+                        for i in 0..expected_code.len() {
+                            code_buf[i].write(expected_code[i]);
+                        }
+                        Ok(expected_code.len())
+                    });
+            },
+            move |state| {
+                let mut addr = addr;
+                let mut out_code = vec![MaybeUninit::uninit(); MAX_CODE_SIZE];
+                let mut out_length = 0;
+                unsafe {
+                    Carmen_Rust_GetCode(
+                        state,
+                        &mut addr as *mut Address as *mut c_void,
+                        out_code.as_mut_ptr() as *mut c_void,
+                        &mut out_length,
+                    );
+                }
+                assert_eq!(out_length, expected_code.len() as u32);
+                let code = &out_code[..out_length as usize];
+                let code = unsafe { std::mem::transmute::<&[MaybeUninit<u8>], &[u8]>(code) };
+                assert_eq!(code, expected_code);
+            },
+        );
+    }
+
+    #[test]
+    fn carmen_rust_get_code_hash_returns_hash_from_carmen_s6_db() {
+        let addr = [1; 20];
+        let expected_hash = [2; 32];
+        create_state_then_call_fn_then_release_state(
+            move |mock_db| {
+                mock_db
+                    .expect_get_code_hash()
+                    .withf(move |a| a == &addr)
+                    .returning(move |_| Ok(expected_hash));
+            },
+            move |state| {
+                let mut addr = addr;
+                let mut out_hash = [0; 32];
+                unsafe {
+                    Carmen_Rust_GetCodeHash(
+                        state,
+                        &mut addr as *mut Address as *mut c_void,
+                        &mut out_hash as *mut Hash as *mut c_void,
+                    );
+                }
+                assert_eq!(out_hash, expected_hash);
+            },
+        );
+    }
+
+    #[test]
+    fn carmen_rust_get_code_size_returns_size_from_carmen_s6_db() {
+        let addr = [1; 20];
+        let expected_size = 2;
+        create_state_then_call_fn_then_release_state(
+            move |mock_db| {
+                mock_db
+                    .expect_get_code_len()
+                    .withf(move |a| a == &addr)
+                    .returning(move |_| Ok(expected_size));
+            },
+            move |state| {
+                let mut addr = addr;
+                let mut code_size = 0;
+                unsafe {
+                    Carmen_Rust_GetCodeSize(
+                        state,
+                        &mut addr as *mut Address as *mut c_void,
+                        &mut code_size as *mut u32,
+                    );
+                }
+                assert_eq!(code_size, expected_size);
+            },
+        );
+    }
+
+    #[test]
+    fn carmen_rust_apply_calls_apply_on_carmen_s6_db() {
+        let block: u64 = 1;
+        let update_data = [0; 25]; // empty update
+        create_state_then_call_fn_then_release_state(
+            move |mock_db| {
+                mock_db
+                    .expect_apply_block_update()
+                    .withf(move |b, _| *b == block)
+                    .returning(|_, _| Ok(()));
+            },
+            move |state| {
+                let mut update_data = update_data;
+                unsafe {
+                    Carmen_Rust_Apply(
+                        state,
+                        block,
+                        update_data.as_mut_ptr() as *mut c_void,
+                        update_data.len() as u64,
+                    );
+                }
+            },
+        );
+    }
+
+    #[test]
+    fn carmen_rust_get_hash_returns_hash_from_carmen_s6_db() {
+        let expected_hash = [1; 32];
+        create_state_then_call_fn_then_release_state(
+            move |mock_db| {
+                mock_db
+                    .expect_get_hash()
+                    .returning(move || Ok(expected_hash));
+            },
+            move |state| {
+                let mut out_hash = [0u8; 32];
+                unsafe {
+                    Carmen_Rust_GetHash(state, &mut out_hash as *mut Hash as *mut c_void);
+                }
+                assert_eq!(out_hash, expected_hash);
+            },
+        );
+    }
+
+    #[test]
+    fn carmen_rust_get_memory_footprint_returns_buffer_and_length() {
+        let expected_str = "footprint";
+        create_state_then_call_fn_then_release_state(
+            move |mock_db| {
+                mock_db
+                    .expect_get_memory_footprint()
+                    .returning(move || Ok(Box::from(expected_str)));
+            },
+            |state| {
+                let mut out_ptr: *mut c_char = std::ptr::null_mut();
+                let mut out_len: u64 = 0;
+                unsafe {
+                    Carmen_Rust_GetMemoryFootprint(state, &mut out_ptr, &mut out_len);
+                }
+                assert!(!out_ptr.is_null());
+                assert_eq!(out_len, expected_str.len() as u64);
+                // Clean up
+                unsafe {
+                    Carmen_Rust_ReleaseMemoryFootprintBuffer(out_ptr, out_len);
+                }
+            },
+        );
+    }
+
+    #[track_caller]
+    fn create_state_then_call_fn_then_release_state(
+        set_expectation: impl Fn(&mut MockCarmenS6Db) + 'static,
+        call_ffi_fn: impl Fn(*mut c_void) + 'static,
+    ) {
+        unsafe {
+            let mut mock_db = MockCarmenS6Db::new();
+
+            set_expectation(&mut mock_db);
+
+            let state_wrapper = StateWrapper::from_db_state(Box::new(mock_db));
+            let state = Box::into_raw(Box::new(state_wrapper)) as *mut c_void;
+
+            call_ffi_fn(state);
+
+            Carmen_Rust_ReleaseState(state);
+        }
+    }
 }

--- a/rust/src/ffi/exported.rs
+++ b/rust/src/ffi/exported.rs
@@ -14,9 +14,9 @@ use std::{
 };
 
 use crate::{
-    CarmenS6Db,
+    CarmenDb,
     ffi::bindings,
-    open_carmen_s6_db,
+    open_carmen_db,
     types::{Address, ArchiveImpl, Hash, Key, StateImpl, U256, Update, Value},
 };
 
@@ -71,7 +71,7 @@ unsafe extern "C" fn Carmen_Rust_OpenState(
     // - `directory` is not mutated for the duration of the call (precondition)
     let directory =
         unsafe { slice_from_raw_parts_scoped(directory as *const u8, length as usize, &token) };
-    let db_state = open_carmen_s6_db(schema, state, archive, directory);
+    let db_state = open_carmen_db(schema, state, archive, directory);
     match db_state {
         Ok(db_state) => {
             Box::into_raw(Box::new(StateWrapper::from_db_state(db_state))) as *mut c_void
@@ -85,10 +85,10 @@ unsafe extern "C" fn Carmen_Rust_OpenState(
 ///
 /// # Safety
 /// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
-///   CarmenS6Db` object
+///   CarmenDb` object
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
-/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be a valid pointer to a `dyn CarmenDb`
 /// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
 /// - `state.state` must not be mutated for the duration of the lifetime of `token`
 #[unsafe(no_mangle)]
@@ -103,7 +103,7 @@ unsafe extern "C" fn Carmen_Rust_Flush(state: *mut c_void) {
     // - `state` is not mutated for the duration of the call (precondition)
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
-    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is a valid pointer to a `dyn CarmenDb` (precondition)
     // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
     // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
@@ -118,10 +118,10 @@ unsafe extern "C" fn Carmen_Rust_Flush(state: *mut c_void) {
 ///
 /// # Safety
 /// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
-///   CarmenS6Db` object
+///   CarmenDb` object
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
-/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be a valid pointer to a `dyn CarmenDb`
 /// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
 /// - `state.state` must not be mutated for the duration of the lifetime of `token`
 #[unsafe(no_mangle)]
@@ -136,7 +136,7 @@ unsafe extern "C" fn Carmen_Rust_Close(state: *mut c_void) {
     // - `state` is not mutated for the duration of the call (precondition)
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
-    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is a valid pointer to a `dyn CarmenDb` (precondition)
     // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
     // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
@@ -152,12 +152,12 @@ unsafe extern "C" fn Carmen_Rust_Close(state: *mut c_void) {
 ///
 /// # Safety
 /// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
-///   CarmenS6Db` object
+///   CarmenDb` object
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
 /// - `state` must have been allocated using the global allocator
 /// - `state` must not be used after this call
-/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be a valid pointer to a `dyn CarmenDb`
 /// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
 /// - `state.state` must not be mutated for the duration of the lifetime of `token`
 /// - `state.state` must have been allocated using the global allocator
@@ -178,7 +178,7 @@ unsafe extern "C" fn Carmen_Rust_ReleaseState(state: *mut c_void) {
     // - `state` is not used after this call (precondition)
     let state = unsafe { Box::from_raw(state) };
     // SAFETY:
-    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is a valid pointer to a `dyn CarmenDb` (precondition)
     // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
     // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
@@ -195,10 +195,10 @@ unsafe extern "C" fn Carmen_Rust_ReleaseState(state: *mut c_void) {
 ///
 /// # Safety
 /// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
-///   CarmenS6Db` object
+///   CarmenDb` object
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
-/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be a valid pointer to a `dyn CarmenDb`
 /// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
 /// - `state.state` must not be mutated for the duration of the lifetime of `token`
 #[unsafe(no_mangle)]
@@ -213,7 +213,7 @@ unsafe extern "C" fn Carmen_Rust_GetArchiveState(state: *mut c_void, block: u64)
     // - `state` is not mutated for the duration of the call (precondition)
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
-    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is a valid pointer to a `dyn CarmenDb` (precondition)
     // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
     // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
@@ -230,10 +230,10 @@ unsafe extern "C" fn Carmen_Rust_GetArchiveState(state: *mut c_void, block: u64)
 ///
 /// # Safety
 /// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
-///   CarmenS6Db` object
+///   CarmenDb` object
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
-/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be a valid pointer to a `dyn CarmenDb`
 /// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
 /// - `state.state` must not be mutated for the duration of the lifetime of `token`
 /// - `addr` must be a valid pointer to a byte array of length 20
@@ -257,7 +257,7 @@ unsafe extern "C" fn Carmen_Rust_GetAccountState(
     // - `state` is not mutated for the duration of the call (precondition)
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
-    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is a valid pointer to a `dyn CarmenDb` (precondition)
     // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
     // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
@@ -282,10 +282,10 @@ unsafe extern "C" fn Carmen_Rust_GetAccountState(
 ///
 /// # Safety
 /// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
-///   CarmenS6Db` object
+///   CarmenDb` object
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
-/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be a valid pointer to a `dyn CarmenDb`
 /// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
 /// - `state.state` must not be mutated for the duration of the lifetime of `token`
 /// - `addr` must be a valid pointer to a byte array of length 20
@@ -309,7 +309,7 @@ unsafe extern "C" fn Carmen_Rust_GetBalance(
     // - `state` is not mutated for the duration of the call (precondition)
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
-    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is a valid pointer to a `dyn CarmenDb` (precondition)
     // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
     // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
@@ -334,10 +334,10 @@ unsafe extern "C" fn Carmen_Rust_GetBalance(
 ///
 /// # Safety
 /// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
-///   CarmenS6Db` object
+///   CarmenDb` object
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
-/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be a valid pointer to a `dyn CarmenDb`
 /// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
 /// - `state.state` must not be mutated for the duration of the lifetime of `token`
 /// - `addr` must be a valid pointer to a byte array of length 20
@@ -361,7 +361,7 @@ unsafe extern "C" fn Carmen_Rust_GetNonce(
     // - `state` is not mutated for the duration of the call (precondition)
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
-    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is a valid pointer to a `dyn CarmenDb` (precondition)
     // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
     // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
@@ -386,17 +386,17 @@ unsafe extern "C" fn Carmen_Rust_GetNonce(
 ///
 /// # Safety
 /// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
-///   CarmenS6Db` object
+///   CarmenDb` object
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
-/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be a valid pointer to a `dyn CarmenDb`
 /// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
 /// - `state.state` must not be mutated for the duration of the lifetime of `token`
 /// - `addr` must be a valid pointer to a byte array of length 20
 /// - `addr` must be valid for reads for the duration of the call
 /// - `addr` must not be mutated for the duration of the call
 /// - `key` must be a valid pointer to a byte array of length 32
-/// - `key` must be valid for reads and writes for the duration of the call
+/// - `key` must be valid for reads for the duration of the call
 /// - `key` must not be mutated for the duration of the call
 /// - `out_value` must be a valid pointer to a byte array of length 32
 /// - `out_value` must be valid for writes for the duration of the call
@@ -417,7 +417,7 @@ unsafe extern "C" fn Carmen_Rust_GetStorageValue(
     // - `state` is not mutated for the duration of the call (precondition)
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
-    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is a valid pointer to a `dyn CarmenDb` (precondition)
     // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
     // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
@@ -429,9 +429,9 @@ unsafe extern "C" fn Carmen_Rust_GetStorageValue(
     let addr = unsafe { ref_from_ptr_scoped(addr as *mut Address, &token) };
     // SAFETY:
     // - `key` is a valid pointer to a byte array of length 32 (precondition)
-    // - `key` is valid for reads and writes for the duration of the call (precondition)
+    // - `key` is valid for reads for the duration of the call (precondition)
     // - `key` is not mutated for the duration of the call (precondition)
-    let key = unsafe { ref_mut_from_ptr_scoped(key as *mut Key, &token) };
+    let key = unsafe { ref_from_ptr_scoped(key as *mut Key, &token) };
     match db_state.get_storage_value(addr, key) {
         Ok(value) => {
             // SAFETY:
@@ -447,10 +447,10 @@ unsafe extern "C" fn Carmen_Rust_GetStorageValue(
 ///
 /// # Safety
 /// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
-///   CarmenS6Db` object
+///   CarmenDb` object
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
-/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be a valid pointer to a `dyn CarmenDb`
 /// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
 /// - `state.state` must not be mutated for the duration of the lifetime of `token`
 /// - `addr` must be a valid pointer to a byte array of length 20
@@ -478,7 +478,7 @@ unsafe extern "C" fn Carmen_Rust_GetCode(
     // - `state` is not mutated for the duration of the call (precondition)
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
-    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is a valid pointer to a `dyn CarmenDb` (precondition)
     // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
     // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
@@ -510,10 +510,10 @@ unsafe extern "C" fn Carmen_Rust_GetCode(
 ///
 /// # Safety
 /// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
-///   CarmenS6Db` object
+///   CarmenDb` object
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
-/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be a valid pointer to a `dyn CarmenDb`
 /// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
 /// - `state.state` must not be mutated for the duration of the lifetime of `token`
 /// - `addr` must be a valid pointer to a byte array of length 20
@@ -537,7 +537,7 @@ unsafe extern "C" fn Carmen_Rust_GetCodeHash(
     // - `state` is not mutated for the duration of the call (precondition)
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
-    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is a valid pointer to a `dyn CarmenDb` (precondition)
     // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
     // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
@@ -562,10 +562,10 @@ unsafe extern "C" fn Carmen_Rust_GetCodeHash(
 ///
 /// # Safety
 /// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
-///   CarmenS6Db` object
+///   CarmenDb` object
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
-/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be a valid pointer to a `dyn CarmenDb`
 /// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
 /// - `state.state` must not be mutated for the duration of the lifetime of `token`
 /// - `addr` must be a valid pointer to a byte array of length 20
@@ -589,7 +589,7 @@ unsafe extern "C" fn Carmen_Rust_GetCodeSize(
     // - `state` is not mutated for the duration of the call (precondition)
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
-    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is a valid pointer to a `dyn CarmenDb` (precondition)
     // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
     // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
@@ -614,10 +614,10 @@ unsafe extern "C" fn Carmen_Rust_GetCodeSize(
 ///
 /// # Safety
 /// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
-///   CarmenS6Db` object
+///   CarmenDb` object
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
-/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be a valid pointer to a `dyn CarmenDb`
 /// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
 /// - `state.state` must not be mutated for the duration of the lifetime of `token`
 /// - `update` must be a valid pointer to a byte array of length `length`
@@ -640,7 +640,7 @@ unsafe extern "C" fn Carmen_Rust_Apply(
     // - `state` is not mutated for the duration of the call (precondition)
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
-    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is a valid pointer to a `dyn CarmenDb` (precondition)
     // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
     // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
@@ -666,10 +666,10 @@ unsafe extern "C" fn Carmen_Rust_Apply(
 ///
 /// # Safety
 /// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
-///   CarmenS6Db` object
+///   CarmenDb` object
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
-/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be a valid pointer to a `dyn CarmenDb`
 /// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
 /// - `state.state` must not be mutated for the duration of the lifetime of `token`
 /// - `out_hash` must be a valid pointer to a byte array of length 32
@@ -686,7 +686,7 @@ unsafe extern "C" fn Carmen_Rust_GetHash(state: *mut c_void, out_hash: *mut c_vo
     // - `state` is not mutated for the duration of the call (precondition)
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
-    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is a valid pointer to a `dyn CarmenDb` (precondition)
     // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
     // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
@@ -708,10 +708,10 @@ unsafe extern "C" fn Carmen_Rust_GetHash(state: *mut c_void, out_hash: *mut c_vo
 ///
 /// # Safety
 /// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
-///   CarmenS6Db` object
+///   CarmenDb` object
 /// - `state` must be valid for reads and writes for the duration of the call
 /// - `state` must not be mutated for the duration of the call
-/// - `state.state` must be a valid pointer to a `dyn CarmenS6Db`
+/// - `state.state` must be a valid pointer to a `dyn CarmenDb`
 /// - `state.state` must be valid for reads and writes for the duration of the lifetime of `token`
 /// - `state.state` must not be mutated for the duration of the lifetime of `token`
 /// - `out` must be a valid pointer to a byte array of length `out_length`
@@ -735,7 +735,7 @@ unsafe extern "C" fn Carmen_Rust_GetMemoryFootprint(
     // - `state` is not mutated for the duration of the call (precondition)
     let state = unsafe { ref_mut_from_ptr_scoped(state as *mut StateWrapper, &token) };
     // SAFETY:
-    // - `state.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+    // - `state.state` is a valid pointer to a `dyn CarmenDb` (precondition)
     // - `state.state` is valid for reads and writes for the duration of the lifetime of `token`
     //   (precondition)
     // - `state.state` is not mutated for the duration of the lifetime of `token`(precondition)
@@ -780,30 +780,30 @@ unsafe extern "C" fn Carmen_Rust_ReleaseMemoryFootprintBuffer(buf: *mut c_char, 
     }
 }
 
-/// A transparent wrapper around a pointer to a `dyn CarmenS6Db` object. Pointers to this wrapper
+/// A transparent wrapper around a pointer to a `dyn CarmenDb` object. Pointers to this wrapper
 /// type are passed as `state` through the FFI interface.
 #[repr(transparent)]
 struct StateWrapper {
-    state: *mut dyn CarmenS6Db,
+    state: *mut dyn CarmenDb,
 }
 
 impl StateWrapper {
     /// # Safety
-    /// - `self.state` must be a valid pointer to a `dyn CarmenS6Db`
+    /// - `self.state` must be a valid pointer to a `dyn CarmenDb`
     /// - `self.state` must be valid for reads and writes for the duration of the lifetime of
     ///   `_token`
     /// - `self.state` must not be mutated for the duration of the lifetime of `_token`
     #[allow(clippy::mut_from_ref)] // false positive
-    unsafe fn to_ref_mut_scoped<'db>(&self, _token: &'db LifetimeToken) -> &'db mut dyn CarmenS6Db {
+    unsafe fn to_ref_mut_scoped<'db>(&self, _token: &'db LifetimeToken) -> &'db mut dyn CarmenDb {
         // SAFETY:
-        // - `self.state` is a valid pointer to a `dyn CarmenS6Db` (precondition)
+        // - `self.state` is a valid pointer to a `dyn CarmenDb` (precondition)
         // - `self.state` is valid for reads and writes for the duration of the lifetime of `_token`
         // (precondition)
         // - `self.state` is not mutated for the duration of the lifetime of `_token` (precondition)
         unsafe { &mut *self.state }
     }
 
-    fn from_db_state(state: Box<dyn CarmenS6Db>) -> Self {
+    fn from_db_state(state: Box<dyn CarmenDb>) -> Self {
         Self {
             state: Box::into_raw(state),
         }
@@ -813,7 +813,7 @@ impl StateWrapper {
 /// A zero sized type, used to enforce the correct lifetime for references created from
 /// pointers obtained via FFI. It is assumed that the lifetime of the pointer is bound by the
 /// lifetime of the borrow of [`LifetimeToken`].
-/// When the token is crated at the beginning of a function call, it ensures that the
+/// When the token is created at the beginning of a function call, it ensures that the
 /// references created from pointers obtained via FFI are only valid for the duration of the
 /// function call.
 struct LifetimeToken;
@@ -972,7 +972,7 @@ const _COMPILE_TIME_CHECK_THAT_STATE_WRAPPER_HAS_DOUBLE_THE_SIZE_OF_VOID_POINTER
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::MockCarmenS6Db;
+    use crate::MockCarmenDb;
 
     #[test]
     fn carmen_rust_open_state_returns_non_null_pointers() {
@@ -1024,7 +1024,7 @@ mod tests {
                 mock_db
                     .expect_get_archive_state()
                     .withf(move |b| *b == block)
-                    .returning(|_| Ok(Box::new(MockCarmenS6Db::new())));
+                    .returning(|_| Ok(Box::new(MockCarmenDb::new())));
             },
             move |state| {
                 let archive_state = unsafe { Carmen_Rust_GetArchiveState(state, block) };
@@ -1300,11 +1300,11 @@ mod tests {
 
     #[track_caller]
     fn create_state_then_call_fn_then_release_state(
-        set_expectation: impl Fn(&mut MockCarmenS6Db) + 'static,
+        set_expectation: impl Fn(&mut MockCarmenDb) + 'static,
         call_ffi_fn: impl Fn(*mut c_void) + 'static,
     ) {
         unsafe {
-            let mut mock_db = MockCarmenS6Db::new();
+            let mut mock_db = MockCarmenDb::new();
 
             set_expectation(&mut mock_db);
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -7,8 +7,140 @@
 //
 // On the date above, in accordance with the Business Source License, use of
 // this software will be governed by the GNU Lesser General Public License v3.
-#![allow(unused)]
+
+use std::mem::MaybeUninit;
+
+use crate::{error::Error, types::*};
 
 mod error;
 mod ffi;
 mod types;
+
+/// Opens a new [CarmenS6Db] database object based on the provided implementation maintaining
+/// its data in the given directory. If the directory does not exist, it is
+/// created. If it is empty, a new, empty state is initialized. If it contains
+/// state information, the information is loaded.
+pub fn open_carmen_s6_db(
+    _schema: u8,
+    _state: StateImpl,
+    _archive: ArchiveImpl,
+    _directory: &[u8],
+) -> Result<Box<dyn CarmenS6Db>, Error> {
+    // here we would choose the specific implementation of CarmenS6Db based on the state and
+    // archive.
+    Ok(Box::new(DbState))
+}
+
+/// The safe Carmen S6 interface.
+/// This is the safe interface which gets called from the exported FFI functions.
+#[cfg_attr(test, mockall::automock)]
+pub trait CarmenS6Db {
+    /// Flushes all committed state information to disk to guarantee permanent
+    /// storage. All internally cached modifications are synced to disk.
+    fn flush(&mut self) -> Result<(), Error>;
+
+    /// Closes this state, releasing all IO handles and locks on external resources.
+    fn close(&mut self) -> Result<(), Error>;
+
+    /// Creates a state snapshot reflecting the state at the given block height. The
+    /// resulting state must be released and must not outlive the life time of the
+    /// provided state.
+    fn get_archive_state(&mut self, block: u64) -> Result<Box<dyn CarmenS6Db>, Error>;
+
+    /// Returns the current state of the given account.
+    fn get_account_state(&mut self, addr: &Address) -> Result<AccountState, Error>;
+
+    /// Returns the balance of the given account.
+    fn get_balance(&mut self, addr: &Address) -> Result<U256, Error>;
+
+    /// Returns the nonce of the given account.
+    fn get_nonce(&mut self, addr: &Address) -> Result<u64, Error>;
+
+    /// Returns the value of storage location (addr,key) in the given state.
+    fn get_storage_value(&mut self, addr: &Address, key: &mut Key) -> Result<Value, Error>;
+
+    /// Returns the code stored under the given address.
+    fn get_code(
+        &mut self,
+        addr: &Address,
+        code_buf: &mut [MaybeUninit<u8>],
+    ) -> Result<usize, Error>;
+
+    /// Returns the hash of the code stored under the given address.
+    fn get_code_hash(&mut self, addr: &Address) -> Result<Hash, Error>;
+
+    /// Returns the code length stored under the given address.
+    fn get_code_len(&mut self, addr: &Address) -> Result<u32, Error>;
+
+    /// Returns a global state hash of the given state.
+    fn get_hash(&mut self) -> Result<Hash, Error>;
+
+    /// Returns a summary of the used memory.
+    fn get_memory_footprint(&mut self) -> Result<Box<str>, Error>;
+
+    /// Applies the provided block update to the maintained state.
+    #[allow(clippy::needless_lifetimes)] // using an elided lifetime here breaks automock
+    fn apply_block_update<'u>(&mut self, block: u64, update: Update<'u>) -> Result<(), Error>;
+}
+
+/// The main implementation of [`CarmenS6Db`].
+pub struct DbState;
+
+#[allow(unused_variables)]
+impl CarmenS6Db for DbState {
+    fn flush(&mut self) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    fn close(&mut self) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    fn get_archive_state(&mut self, block: u64) -> Result<Box<dyn CarmenS6Db>, Error> {
+        unimplemented!()
+    }
+
+    fn get_account_state(&mut self, addr: &Address) -> Result<AccountState, Error> {
+        unimplemented!()
+    }
+
+    fn get_balance(&mut self, addr: &Address) -> Result<U256, Error> {
+        unimplemented!()
+    }
+
+    fn get_nonce(&mut self, addr: &Address) -> Result<u64, Error> {
+        unimplemented!()
+    }
+
+    fn get_storage_value(&mut self, addr: &Address, key: &mut Key) -> Result<Value, Error> {
+        unimplemented!()
+    }
+
+    fn get_code(
+        &mut self,
+        addr: &Address,
+        code_buf: &mut [MaybeUninit<u8>],
+    ) -> Result<usize, Error> {
+        unimplemented!()
+    }
+
+    fn get_code_hash(&mut self, addr: &Address) -> Result<Hash, Error> {
+        unimplemented!()
+    }
+
+    fn get_code_len(&mut self, addr: &Address) -> Result<u32, Error> {
+        unimplemented!()
+    }
+
+    fn get_hash(&mut self) -> Result<Hash, Error> {
+        unimplemented!()
+    }
+
+    fn get_memory_footprint(&mut self) -> Result<Box<str>, Error> {
+        unimplemented!()
+    }
+
+    fn apply_block_update(&mut self, block: u64, update: Update) -> Result<(), Error> {
+        unimplemented!()
+    }
+}

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -12,14 +12,14 @@ pub use update::Update;
 
 mod update;
 
-/// The Carmen S6 database state implementation.
+/// The Carmen database state implementation.
 pub enum StateImpl {
     Memory = 0,
     File = 1,
     LevelDb = 2,
 }
 
-/// The Carmen S6 archive implementation.
+/// The Carmen archive state implementation.
 pub enum ArchiveImpl {
     None = 0,
     LevelDb = 1,

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -49,5 +49,7 @@ pub type Nonce = [u8; 8];
 /// An account state.
 pub type AccountState = u8;
 
+#[allow(unused)]
 pub const ACCOUNT_STATE_UNKNOWN: AccountState = 0;
+#[allow(unused)]
 pub const ACCOUNT_STATE_EXISTS: AccountState = 1;

--- a/rust/src/types/update.rs
+++ b/rust/src/types/update.rs
@@ -483,7 +483,7 @@ mod tests {
                         .as_slice(),
                 );
             },
-            |encoded_update: &mut Vec<u8>, update| {
+            |_encoded_update: &mut Vec<u8>, _update| {
                 // This closure corresponds to the last read in Update::from_encoded. If we would
                 // put a write operation here and also call it, Update::from_encoded will succeed.
                 // But this test is only supposed to test the cases where parsing fails so we make

--- a/rust/src/types/update.rs
+++ b/rust/src/types/update.rs
@@ -46,7 +46,7 @@ pub struct SlotUpdate {
 }
 
 /// A block update.
-/// This update contains all changes to the state of the Carmen S6 database
+/// This update contains all changes to the state of the Carmen database
 /// that happened in a single block.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Update<'d> {


### PR DESCRIPTION
This is the third and last PR in a series of PRs to expose all required functions from Rust, and call the safe interface from those functions.

This PR:
- adds the safe carmen interface (`trait CarmenS6Db`)
- adds `DbState` which will be our main type which implements `CarmenS6Db` (currently all methods are unimplemented, but we need this type already to be able to return a type from `open_carmen_s6_db`
- implements the conversion from the types passed via FFI (mostly `void` pointers) to references of the correct types and calls to the safe interface. This also includes safety comments.
- tests the unsafe interface
  - create is tested by checking that the returned value is not null
  - all other methods are called with a wrapped pointer to `MockCarmenS6Db` on which the corresponding expectation is set
  - these tests are especially useful when run with MIRI, as this checks that the unsafe operations did not cause any UB
- adds a CI step to run [MIRI](https://github.com/rust-lang/miri), which is a tool to detect undefined behavior in Rust.
  
New dependencies:
- [mockall](https://crates.io/crates/mockall) mocking library to derive mock structs from trait definitions

Disclaimer: I know this PR looks huge, but most of it is just documentation, which is also very similar between the functions. IMO, splitting this PR further makes little sense because:
- implementing the unsafe interface needs the safe interface
- the safe interface only makes sense when considering how it gets called
- the unsafe interface should not be merged without running MIRI

Closes https://github.com/0xsoniclabs/sonic-admin/issues/283