### PR TITLE
Run Rust CI also if c_state.h changed

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -9,10 +9,12 @@ on:
     branches: [ main ]
     paths:
     - "rust/**"
+    - "cpp/state/c_state.h"
   pull_request:
     branches: [ main ]
     paths:
     - "rust/**"
+    - "cpp/state/c_state.h"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This PR configures the Rust CI to also run when the C header file `cpp/state/c_state.h` was changed. This is needed because changing this file can break the Rust implementation.