### PR TITLE
always init verkle trie with an inner node

### DIFF
--- a/go/database/vt/memory/state.go
+++ b/go/database/vt/memory/state.go
@@ -33,7 +33,7 @@ type State struct {
 // NewState creates a new, empty in-memory state instance.
 func NewState() *State {
 	return &State{
-		trie: &trie.Trie{},
+		trie: trie.NewTrie(),
 	}
 }
 

--- a/go/database/vt/memory/state.go
+++ b/go/database/vt/memory/state.go
@@ -33,7 +33,7 @@ type State struct {
 // NewState creates a new, empty in-memory state instance.
 func NewState() *State {
 	return &State{
-		trie: trie.NewTrie(),
+		trie: &trie.Trie{},
 	}
 }
 

--- a/go/database/vt/memory/state_test.go
+++ b/go/database/vt/memory/state_test.go
@@ -13,7 +13,6 @@ package memory
 import (
 	"bytes"
 	"crypto/rand"
-	"github.com/holiman/uint256"
 	"testing"
 
 	"github.com/0xsoniclabs/carmen/go/backend"
@@ -25,6 +24,7 @@ import (
 	geth_trie "github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/trie/utils"
 	"github.com/ethereum/go-ethereum/triedb/database"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 )
 
@@ -466,7 +466,7 @@ func TestState_IncrementalStateUpdatesResultInSameCommitments(t *testing.T) {
 	}
 }
 
-func TestState_NonEmptyAccount_EmptyStorage_Matching_Commitment(t *testing.T) {
+func TestState_SingleAccountFittingInASingleNode_HasSameCommitmentAsReference(t *testing.T) {
 	require := require.New(t)
 
 	addr1 := common.Address{1}
@@ -475,27 +475,17 @@ func TestState_NonEmptyAccount_EmptyStorage_Matching_Commitment(t *testing.T) {
 		Balances: []common.BalanceUpdate{
 			{Account: addr1, Balance: amount.New(1)},
 		},
-		Nonces: []common.NonceUpdate{
-			{Account: addr1, Nonce: common.ToNonce(1)},
-		},
-		Codes: []common.CodeUpdate{
-			{Account: addr1, Code: []byte{0x01, 0x02}},
-		},
 	}
 
 	state := NewState()
-	state.Apply(0, update)
-
-	codeLen, err := state.GetCodeSize(addr1)
-	require.NoError(err)
-	require.Equal(2, codeLen, "Code size should be zero for empty code")
+	require.NoError(state.Apply(0, update))
 
 	hash, err := state.GetHash()
 	require.NoError(err)
 
 	reference, err := newRefState()
 	require.NoError(err)
-	reference.Apply(0, update)
+	require.NoError(reference.Apply(0, update))
 	want, err := reference.GetHash()
 	require.NoError(err)
 

--- a/go/database/vt/memory/trie/trie.go
+++ b/go/database/vt/memory/trie/trie.go
@@ -35,6 +35,13 @@ type Trie struct {
 	root node
 }
 
+// NewTrie creates a new empty Verkle trie.
+// The root node is initialized to an empty
+// inner node.
+func NewTrie() *Trie {
+	return &Trie{root: &inner{}}
+}
+
 // Get retrieves the value associated with the given key from the trie. All keys
 // that have not been set will return the zero value.
 func (t *Trie) Get(key Key) Value {

--- a/go/database/vt/memory/trie/trie.go
+++ b/go/database/vt/memory/trie/trie.go
@@ -35,13 +35,6 @@ type Trie struct {
 	root node
 }
 
-// NewTrie creates a new empty Verkle trie.
-// The root node is initialized to an empty
-// inner node.
-func NewTrie() *Trie {
-	return &Trie{root: &inner{}}
-}
-
 // Get retrieves the value associated with the given key from the trie. All keys
 // that have not been set will return the zero value.
 func (t *Trie) Get(key Key) Value {
@@ -55,7 +48,7 @@ func (t *Trie) Get(key Key) Value {
 // already exists, its value will be updated.
 func (t *Trie) Set(key Key, value Value) {
 	if t.root == nil {
-		t.root = newLeaf(key)
+		t.root = &inner{}
 	}
 	t.root = t.root.set(key, 0, value)
 }

--- a/go/database/vt/memory/trie/trie_test.go
+++ b/go/database/vt/memory/trie/trie_test.go
@@ -102,6 +102,17 @@ func TestTrie_ManyValuesCanBeSetAndRetrieved(t *testing.T) {
 	}
 }
 
+func TestTrie_SettingASingleValueProducesAnInnerNode(t *testing.T) {
+	require := require.New(t)
+
+	trie := &Trie{}
+	require.Nil(trie.root)
+	trie.Set(Key{1}, Value{1})
+
+	_, ok := trie.root.(*inner)
+	require.True(ok, "Root should be an inner node after setting a value")
+}
+
 func TestTrie_CommitmentOfEmptyTrieIsIdentity(t *testing.T) {
 	require := require.New(t)
 


### PR DESCRIPTION
This PR modifies the in-memory implementation of VerkleTrie. It makes sure that the tree is initialised with an inner node, even when the tree is empty.

It used to be initialised with a leaf node when the inner node was not needed. For example, when there is only one account in the trie, it was attached as a leaf node directly as a root. 

Geth implementation always starts with an inner node, followed by a leaf node. 

This PR makes these two implementations consistent.  