### PR TITLE
Improve naming for FFI interface

### DIFF
--- a/cpp/state/c_state.h
+++ b/cpp/state/c_state.h
@@ -46,10 +46,10 @@ extern "C" {
 #define C_Hash void*
 #define C_AccountState void*
 
-// An enumeration of supported state implementations.
-enum StateImpl { kState_Memory = 0, kState_File = 1, kState_LevelDb = 2 };
+// An enumeration of supported live state implementations.
+enum LiveImpl { kLive_Memory = 0, kLive_File = 1, kLive_LevelDb = 2 };
 
-// An enumeration of supported archive implementations.
+// An enumeration of supported archive state implementations.
 enum ArchiveImpl {
   kArchive_None = 0,
   kArchive_LevelDb = 1,
@@ -68,8 +68,8 @@ enum ArchiveImpl {
 // caller, which is required for releasing it eventually using Release().
 // If for some reason the creation of the state instance failed, a nullptr is
 // returned.
-DUPLICATE_FOR_LANGS(C_State, OpenState(C_Schema schema, enum StateImpl state,
-                                       enum ArchiveImpl archive,
+DUPLICATE_FOR_LANGS(C_State, OpenState(C_Schema schema, enum LiveImpl live_impl,
+                                       enum ArchiveImpl archive_impl,
                                        const char* directory, int length));
 
 // Flushes all committed state information to disk to guarantee permanent
@@ -92,9 +92,9 @@ DUPLICATE_FOR_LANGS(C_State, GetArchiveState(C_State state, uint64_t block));
 
 // ------------------------------- Accounts -----------------------------------
 
-// Gets the current state of the given account.
-DUPLICATE_FOR_LANGS(void, GetAccountState(C_State state, C_Address addr,
-                                          C_AccountState out_state));
+// Checks if the given account exists.
+DUPLICATE_FOR_LANGS(void, AccountExists(C_State state, C_Address addr,
+                                        C_AccountState out_state));
 
 // -------------------------------- Balance -----------------------------------
 

--- a/go/state/cppstate/cpp_state.go
+++ b/go/state/cppstate/cpp_state.go
@@ -49,7 +49,7 @@ type CppState struct {
 	codeCache *common.LruCache[common.Address, []byte]
 }
 
-func newState(impl C.enum_StateImpl, params state.Parameters) (state.State, error) {
+func newState(impl C.enum_LiveImpl, params state.Parameters) (state.State, error) {
 	if err := os.MkdirAll(filepath.Join(params.Directory, "live"), 0700); err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func newState(impl C.enum_StateImpl, params state.Parameters) (state.State, erro
 		return nil, fmt.Errorf("%w: unsupported archive type %v", state.UnsupportedConfiguration, params.Archive)
 	}
 
-	st := C.Carmen_Cpp_OpenState(C.C_Schema(params.Schema), impl, C.enum_StateImpl(archive), dir, C.int(len(params.Directory)))
+	st := C.Carmen_Cpp_OpenState(C.C_Schema(params.Schema), impl, C.enum_LiveImpl(archive), dir, C.int(len(params.Directory)))
 	if st == unsafe.Pointer(nil) {
 		return nil, fmt.Errorf("%w: failed to create C++ state instance for parameters %v", state.UnsupportedConfiguration, params)
 	}
@@ -80,15 +80,15 @@ func newState(impl C.enum_StateImpl, params state.Parameters) (state.State, erro
 }
 
 func newInMemoryState(params state.Parameters) (state.State, error) {
-	return newState(C.kState_Memory, params)
+	return newState(C.kLive_Memory, params)
 }
 
 func newFileBasedState(params state.Parameters) (state.State, error) {
-	return newState(C.kState_File, params)
+	return newState(C.kLive_File, params)
 }
 
 func newLevelDbBasedState(params state.Parameters) (state.State, error) {
-	return newState(C.kState_LevelDb, params)
+	return newState(C.kLive_LevelDb, params)
 }
 
 func (cs *CppState) CreateAccount(address common.Address) error {
@@ -99,7 +99,7 @@ func (cs *CppState) CreateAccount(address common.Address) error {
 
 func (cs *CppState) Exists(address common.Address) (bool, error) {
 	var res common.AccountState
-	C.Carmen_Cpp_GetAccountState(cs.state, unsafe.Pointer(&address[0]), unsafe.Pointer(&res))
+	C.Carmen_Cpp_AccountExists(cs.state, unsafe.Pointer(&address[0]), unsafe.Pointer(&res))
 	return res == common.Exists, nil
 }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -22,8 +22,8 @@ mod types;
 /// state information, the information is loaded.
 pub fn open_carmen_db(
     schema: u8,
-    _state: StateImpl,
-    _archive: ArchiveImpl,
+    _live_impl: LiveImpl,
+    _archive_impl: ArchiveImpl,
     _directory: &[u8],
 ) -> Result<Box<dyn CarmenDb>, Error> {
     if schema != 6 {
@@ -50,8 +50,8 @@ pub trait CarmenDb {
     /// provided state.
     fn get_archive_state(&mut self, block: u64) -> Result<Box<dyn CarmenDb>, Error>;
 
-    /// Returns the current state of the given account.
-    fn get_account_state(&mut self, addr: &Address) -> Result<AccountState, Error>;
+    /// Checks if the given account exists.
+    fn account_exists(&mut self, addr: &Address) -> Result<bool, Error>;
 
     /// Returns the balance of the given account.
     fn get_balance(&mut self, addr: &Address) -> Result<U256, Error>;
@@ -103,7 +103,7 @@ impl CarmenDb for CarmenS6Db {
         unimplemented!()
     }
 
-    fn get_account_state(&mut self, addr: &Address) -> Result<AccountState, Error> {
+    fn account_exists(&mut self, addr: &Address) -> Result<bool, Error> {
         unimplemented!()
     }
 

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -12,8 +12,8 @@ pub use update::Update;
 
 mod update;
 
-/// The Carmen database state implementation.
-pub enum StateImpl {
+/// The Carmen live state implementation.
+pub enum LiveImpl {
     Memory = 0,
     File = 1,
     LevelDb = 2,
@@ -45,11 +45,3 @@ pub type U256 = [u8; 32];
 /// Carmen does not do any numeric operations on nonce. By using [`[u8; 8]`] instead of [`u64`], we
 /// don't require 8 byte alignment.
 pub type Nonce = [u8; 8];
-
-/// An account state.
-pub type AccountState = u8;
-
-#[allow(unused)]
-pub const ACCOUNT_STATE_UNKNOWN: AccountState = 0;
-#[allow(unused)]
-pub const ACCOUNT_STATE_EXISTS: AccountState = 1;


### PR DESCRIPTION
This PR is part 1 of 2 of the FFI refactor (see #62).
The primary goal of this PR is renaming to avoid overloading the word `state` with multiple meanings. To this end, `StateImpl` is renamed to `LiveImpl` and `GetAccountState` to `AccountExists`.
