### PR TITLE
adds correct padding to geth verkle get-storage

### DIFF
--- a/go/database/vt/geth/state.go
+++ b/go/database/vt/geth/state.go
@@ -139,7 +139,7 @@ func (s *verkleState) GetStorage(address common.Address, key common.Key) (common
 	}
 
 	var commonValue common.Value
-	copy(commonValue[:], value)
+	copy(commonValue[32-len(value):], value)
 	return commonValue, nil
 }
 


### PR DESCRIPTION
This PR adds padding to storage values obtained from Geth Verkle implementation. 

Geth does not store zeros prepended to a value, i.e. the value has to be correctly padded when retrieved. 