### PR TITLE
Add FileBackend trait and pread&pwrite and seeking based impls

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -49,6 +49,7 @@ version = "0.1.0"
 dependencies = [
  "bindgen",
  "mockall",
+ "tempfile",
  "thiserror",
  "zerocopy",
 ]
@@ -92,10 +93,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fragile"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
+]
 
 [[package]]
 name = "glob"
@@ -125,8 +154,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-targets 0.53.2",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "log"
@@ -183,6 +218,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
 name = "predicates"
 version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +278,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +319,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +346,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -321,20 +394,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -344,9 +466,21 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -356,9 +490,21 @@ checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -368,9 +514,21 @@ checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -380,9 +538,24 @@ checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "zerocopy"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,6 +33,9 @@ bindgen = "0.72.0"
 # mocking
 mockall = "0.13.1"
 
+# temporary files
+tempfile = "3.20.0"
+
 [lints.rust]
 macro_use_extern_crate = "warn"
 unused_unsafe = "warn"

--- a/rust/src/storage/file/file_backend.rs
+++ b/rust/src/storage/file/file_backend.rs
@@ -1,0 +1,484 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+use std::{
+    fs::OpenOptions,
+    io::{Read, Seek, SeekFrom, Write},
+    os::unix::fs::FileExt,
+    path::Path,
+    sync::Mutex,
+};
+
+/// An abstraction for concurrent file operations.
+///
+/// Implementations of this trait are required to ensure that concurrent operations of the
+/// implementing type are safe (in that there are no data races) as long as the operations operate
+/// on non-overlapping regions of the file.
+/// When called with overlapping regions, the behavior is undefined and may lead to data corruption.
+#[cfg_attr(test, mockall::automock)]
+pub trait FileBackend {
+    /// Opens a file at the given path with the specified options and tries to acquire an advisory
+    /// file lock.
+    fn open(path: &Path, options: &OpenOptions) -> std::io::Result<Self>
+    where
+        Self: Sized;
+
+    /// Writes the entire content of `buf` starting at the given `offset`.
+    fn write_all_at(&self, buf: &[u8], offset: u64) -> std::io::Result<()>;
+
+    /// Fills the entire `buf` with data read from the file starting at the given `offset`.
+    fn read_exact_at(&self, buf: &mut [u8], offset: u64) -> std::io::Result<()>;
+
+    /// Flushes all changes to disk.
+    fn flush(&self) -> std::io::Result<()>;
+
+    /// Returns the length of the file.
+    fn len(&self) -> Result<u64, std::io::Error>;
+
+    /// Sets the length of the file to `len`.
+    /// This may truncate the file if `len` is smaller than the current length.
+    fn set_len(&self, len: u64) -> std::io::Result<()>;
+}
+
+/// A wrapper around [`std::fs::File`] that implements [`FileBackend`] using a mutex to ensure
+/// exclusive access to the file. This is suitable for platforms where `pread` and `pwrite` are not
+/// available or where seeking is required for other reasons.
+pub struct SeekFile(Mutex<std::fs::File>);
+
+impl FileBackend for SeekFile {
+    fn open(path: &Path, options: &OpenOptions) -> std::io::Result<Self>
+    where
+        Self: Sized,
+    {
+        let file = options.open(path)?;
+        file.try_lock()?;
+        Ok(Self(Mutex::new(file)))
+    }
+
+    fn write_all_at(&self, buf: &[u8], offset: u64) -> std::io::Result<()> {
+        let mut file = self.0.lock().unwrap();
+        file.seek(SeekFrom::Start(offset))?;
+        file.write_all(buf)
+    }
+
+    fn read_exact_at(&self, buf: &mut [u8], offset: u64) -> std::io::Result<()> {
+        let mut file = self.0.lock().unwrap();
+        file.seek(SeekFrom::Start(offset))?;
+        file.read_exact(buf)
+    }
+
+    fn flush(&self) -> std::io::Result<()> {
+        self.0.lock().unwrap().sync_all()
+    }
+
+    fn len(&self) -> std::io::Result<u64> {
+        self.0.lock().unwrap().metadata().map(|m| m.len())
+    }
+
+    fn set_len(&self, len: u64) -> std::io::Result<()> {
+        self.0.lock().unwrap().set_len(len)
+    }
+}
+
+/// A wrapper around [`std::fs::File`] that implements [`FileBackend`] using the Unix-specific file
+/// operations `pread` and `pwrite` which do not modify the file offset. This avoids the syscall for
+/// seeking and allows for concurrent access without needing to manage a cursor.
+#[cfg(unix)]
+pub struct NoSeekFile(std::fs::File);
+
+#[cfg(unix)]
+impl FileBackend for NoSeekFile {
+    fn open(path: &Path, options: &OpenOptions) -> std::io::Result<Self>
+    where
+        Self: Sized,
+    {
+        let file = options.open(path)?;
+        file.try_lock()?;
+        Ok(Self(file))
+    }
+
+    fn write_all_at(&self, buf: &[u8], offset: u64) -> std::io::Result<()> {
+        self.0.write_all_at(buf, offset)
+    }
+
+    fn read_exact_at(&self, buf: &mut [u8], offset: u64) -> std::io::Result<()> {
+        self.0.read_exact_at(buf, offset)
+    }
+
+    fn flush(&self) -> std::io::Result<()> {
+        self.0.sync_all()
+    }
+
+    fn len(&self) -> std::io::Result<u64> {
+        self.0.metadata().map(|m| m.len())
+    }
+
+    fn set_len(&self, len: u64) -> std::io::Result<()> {
+        self.0.set_len(len)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs::{File, OpenOptions, Permissions},
+        io::{Read, Write},
+        os::unix::fs::PermissionsExt,
+        sync::atomic::{AtomicU64, Ordering},
+    };
+
+    use super::*;
+
+    fn open_backends() -> impl Iterator<
+        Item = fn(&Path, &OpenOptions) -> std::io::Result<Box<dyn FileBackend + Send + Sync>>,
+    > {
+        [
+            (|path, options| {
+                <SeekFile as FileBackend>::open(path, options)
+                    .map(|f| Box::new(f) as Box<dyn FileBackend + Send + Sync>)
+            })
+                as fn(&Path, &OpenOptions) -> std::io::Result<Box<dyn FileBackend + Send + Sync>>,
+            (|path, options| {
+                <NoSeekFile as FileBackend>::open(path, options)
+                    .map(|f| Box::new(f) as Box<dyn FileBackend + Send + Sync>)
+            })
+                as fn(&Path, &OpenOptions) -> std::io::Result<Box<dyn FileBackend + Send + Sync>>,
+        ]
+        .into_iter()
+    }
+
+    #[test]
+    fn open_creates_and_opens_file() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let dir = tempdir.path();
+
+        let mut options = OpenOptions::new();
+        options.create(true).read(true).write(true);
+
+        for (i, backend) in open_backends().enumerate() {
+            let path = dir.join(format!("test_file_{i}.bin"));
+            let file = backend(path.as_path(), &options);
+            assert!(file.is_ok());
+            assert!(file.unwrap().len().unwrap() == 0);
+        }
+    }
+
+    #[test]
+    fn open_opens_existing_file() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let dir = tempdir.path();
+
+        let mut options = OpenOptions::new();
+        options.create(true).read(true).write(true);
+
+        for (i, backend) in open_backends().enumerate() {
+            let path = dir.join(format!("test_file_{i}.bin"));
+
+            File::create(path.as_path()).unwrap();
+
+            let file = backend(path.as_path(), &options);
+            assert!(file.is_ok());
+            assert!(file.unwrap().len().unwrap() == 0);
+        }
+    }
+
+    #[test]
+    fn open_fails_if_file_is_locked() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let dir = tempdir.path();
+
+        let mut options = OpenOptions::new();
+        options.create(true).read(true).write(true);
+
+        for (i, backend) in open_backends().enumerate() {
+            let path = dir.join(format!("test_file_{i}.bin"));
+
+            // open the file once and lock it
+            let file = backend(path.as_path(), &options);
+            assert!(file.is_ok());
+
+            // try to open it again, should fail
+            let file = backend(path.as_path(), &options);
+            assert!(file.is_err());
+            assert!(file.map(|_| ()).unwrap_err().kind() == std::io::ErrorKind::WouldBlock);
+        }
+    }
+
+    #[test]
+    fn open_fails_if_no_permissions() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let dir = tempdir.path();
+
+        let path = dir.join("test_file.bin");
+        let file = File::create(path.as_path()).unwrap();
+        file.set_permissions(Permissions::from_mode(0o000)).unwrap();
+
+        let mut options = OpenOptions::new();
+        options.read(true).write(true);
+
+        for backend in open_backends() {
+            let file = backend(path.as_path(), &options);
+            assert!(file.is_err());
+        }
+    }
+
+    #[test]
+    fn write_all_at_writes_whole_buffer_at_offset() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let dir = tempdir.path();
+
+        let mut options = OpenOptions::new();
+        options.create(true).read(true).write(true);
+
+        let data = [1; 10];
+        let offset = 5;
+
+        for (i, backend) in open_backends().enumerate() {
+            let path = dir.join(format!("test_file_{i}.bin"));
+
+            {
+                let file = backend(path.as_path(), &options).unwrap();
+                file.write_all_at(&data, offset).unwrap();
+            }
+            // file: [_, _, _, _, _, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+
+            let mut file = File::open(path).unwrap();
+            assert_eq!(file.metadata().unwrap().len(), 15);
+            let mut buf = vec![0; 15];
+            file.read_exact(&mut buf).unwrap();
+            assert_eq!(buf[5..], data);
+        }
+    }
+
+    #[test]
+    fn read_exact_at_fills_whole_buffer_by_reading_at_offset() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let dir = tempdir.path();
+
+        let mut options = OpenOptions::new();
+        options.create(true).read(true).write(true);
+
+        for (i, backend) in open_backends().enumerate() {
+            let path = dir.join(format!("test_file_{i}.bin"));
+
+            {
+                let mut file = File::create(path.as_path()).unwrap();
+                let buf = vec![1; 10];
+                file.write_all(&buf).unwrap();
+                let buf = vec![0; 5];
+                file.write_all(&buf).unwrap();
+            }
+            // file: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]
+            // read:                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+            let file = backend(path.as_path(), &options).unwrap();
+            let mut buf = [0; 10];
+            file.read_exact_at(&mut buf, 5).unwrap();
+            assert_eq!(buf[..5], [1; 5]);
+            assert_eq!(buf[5..], [0; 5]);
+        }
+    }
+
+    #[test]
+    fn read_exact_at_fails_when_out_of_bounds() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let dir = tempdir.path();
+
+        let mut options = OpenOptions::new();
+        options.create(true).read(true).write(true);
+
+        for (i, backend) in open_backends().enumerate() {
+            let path = dir.join(format!("test_file_{i}.bin"));
+
+            {
+                File::create(path.as_path()).unwrap();
+            }
+
+            let file = backend(path.as_path(), &options).unwrap();
+            let mut buf = [0; 5];
+            let res = file.read_exact_at(&mut buf, 5);
+            dbg!(&res);
+            assert!(res.is_err());
+            let err = res.unwrap_err();
+            assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+        }
+    }
+
+    #[test]
+    fn flush_flushes_file_and_sets_length() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let dir = tempdir.path();
+
+        let mut options = OpenOptions::new();
+        options.create(true).read(true).write(true);
+
+        for (i, backend) in open_backends().enumerate() {
+            let path = dir.join(format!("test_file_{i}.bin"));
+
+            // flush with no changes
+            {
+                let file = backend(path.as_path(), &options).unwrap();
+                file.flush().unwrap();
+
+                let file = File::open(path.as_path()).unwrap();
+                assert_eq!(file.metadata().unwrap().len(), 0);
+            }
+
+            // flush with changes
+            {
+                let file = backend(path.as_path(), &options).unwrap();
+                file.write_all_at(&[1; 10], 0).unwrap();
+                file.flush().unwrap();
+
+                let mut file = File::open(path.as_path()).unwrap();
+                assert_eq!(file.metadata().unwrap().len(), 10);
+                let mut buf = [0; 10];
+                file.read_exact(&mut buf).unwrap();
+                assert_eq!(buf, [1; 10]);
+            }
+        }
+    }
+
+    #[test]
+    fn drop_flushes_file_and_sets_length() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let dir = tempdir.path();
+
+        let mut options = OpenOptions::new();
+        options.create(true).read(true).write(true);
+
+        for (i, backend) in open_backends().enumerate() {
+            let path = dir.join(format!("test_file_{i}.bin"));
+
+            {
+                let file = backend(path.as_path(), &options).unwrap();
+                file.write_all_at(&[1; 10], 0).unwrap();
+            }
+
+            let mut file = File::open(path.as_path()).unwrap();
+            assert_eq!(file.metadata().unwrap().len(), 10);
+            let mut buf = [0; 10];
+            file.read_exact(&mut buf).unwrap();
+            assert_eq!(buf, [1; 10]);
+        }
+    }
+
+    #[test]
+    fn len_returns_file_length() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let dir = tempdir.path();
+
+        let mut options = OpenOptions::new();
+        options.create(true).read(true).write(true);
+
+        for (i, backend) in open_backends().enumerate() {
+            let path = dir.join(format!("test_file_{i}.bin"));
+
+            let file = backend(path.as_path(), &options).unwrap();
+            file.write_all_at(&[1; 10], 0).unwrap();
+            assert_eq!(file.len().unwrap(), 10);
+        }
+    }
+
+    #[test]
+    fn set_len_sets_length() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let dir = tempdir.path();
+
+        let mut options = OpenOptions::new();
+        options.create(true).read(true).write(true);
+
+        for (i, backend) in open_backends().enumerate() {
+            let path = dir.join(format!("test_file_{i}.bin"));
+
+            let file = backend(path.as_path(), &options).unwrap();
+            file.set_len(100).unwrap();
+
+            let check_file = File::open(path.as_path()).unwrap();
+            assert_eq!(check_file.metadata().unwrap().len(), 100);
+        }
+    }
+
+    #[test]
+    fn read_observes_writes_of_other_threads() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let dir = tempdir.path();
+
+        let mut options = OpenOptions::new();
+        options.create(true).read(true).write(true);
+
+        for (i, backend) in open_backends().enumerate() {
+            let path = dir.join(format!("test_file_{i}.bin"));
+
+            let file = backend(path.as_path(), &options).unwrap();
+
+            let iteration = AtomicU64::new(0);
+
+            let max_iterations = 1_000_000;
+
+            std::thread::scope(|s| {
+                s.spawn(|| {
+                    let mut buf = [0; 32];
+                    loop {
+                        if iteration.load(Ordering::Relaxed) > max_iterations {
+                            break;
+                        }
+
+                        // wait until it is thread1's turn
+                        while iteration.load(Ordering::Relaxed) % 2 != 0 {}
+
+                        let offset = iteration.load(Ordering::Relaxed) * 32;
+                        if offset >= 32 {
+                            // check that the previous write of thread2 is visible
+                            file.read_exact_at(&mut buf, offset - 32).unwrap();
+                            assert_eq!(buf, [2; 32]);
+                        }
+
+                        // write data
+                        file.write_all_at([1; 32].as_slice(), offset).unwrap();
+
+                        // check that thread1 observes its own write
+                        file.read_exact_at(&mut buf, offset).unwrap();
+                        assert_eq!(buf, [1; 32]);
+
+                        iteration.fetch_add(1, Ordering::Relaxed);
+                    }
+                });
+                s.spawn(|| {
+                    let mut buf = [0; 32];
+                    loop {
+                        if iteration.load(Ordering::Relaxed) > max_iterations {
+                            break;
+                        }
+
+                        // wait until it is thread2's turn
+                        while iteration.load(Ordering::Relaxed) % 2 == 0 {}
+
+                        let offset = iteration.load(Ordering::Relaxed) * 32;
+                        if offset >= 32 {
+                            // check that the previous write of thread1 is visible
+                            file.read_exact_at(&mut buf, offset - 32).unwrap();
+                            assert_eq!(buf, [1; 32]);
+                        }
+
+                        // write data
+                        file.write_all_at([2; 32].as_slice(), offset).unwrap();
+
+                        // check that thread2 observes its own write
+                        file.read_exact_at(&mut buf, offset).unwrap();
+                        assert_eq!(buf, [2; 32]);
+
+                        iteration.fetch_add(1, Ordering::Relaxed);
+                    }
+                });
+            });
+        }
+    }
+}

--- a/rust/src/storage/file/file_backend.rs
+++ b/rust/src/storage/file/file_backend.rs
@@ -39,12 +39,11 @@ pub trait FileBackend {
     /// Flushes all changes to disk.
     fn flush(&self) -> std::io::Result<()>;
 
-    /// Returns the length of the file.
+    /// Returns the size of this file in bytes.
     fn len(&self) -> Result<u64, std::io::Error>;
 
-    /// Sets the length of the file to `len`.
-    /// This may truncate the file if `len` is smaller than the current length.
-    fn set_len(&self, len: u64) -> std::io::Result<()>;
+    /// Truncates or extends the underlying file, updating the size of this file to become `size`.
+    fn set_len(&self, size: u64) -> std::io::Result<()>;
 }
 
 /// A wrapper around [`std::fs::File`] that implements [`FileBackend`] using a mutex to ensure

--- a/rust/src/storage/file/mod.rs
+++ b/rust/src/storage/file/mod.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+mod file_backend;
+
+#[allow(unused_imports)]
+use file_backend::*;

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -14,6 +14,7 @@ use std::path::Path;
 pub use self::error::Error;
 
 mod error;
+mod file;
 
 /// A trait for storage backends that can store and retrieve items by their IDs.
 /// This is used for multiple layers of the storage system, but with different types for


### PR DESCRIPTION
This PR adds the `FileBackend` trait and adds two implementations, one using [pread & pwrite](https://www.man7.org/linux/man-pages/man2/pread.2.html) and one using seeking operations for non-Unix platforms.
Later on, we might add more implementations.

The `FileBackend` is the lowest layer in the file based storage backend (the blue parts).
![Carmen Layers](https://github.com/user-attachments/assets/d7c0a952-8553-4606-b88f-fb9710d8e555)


New dev-dependencies:
- [tempfile](https://crates.io/crates/tempfile) a widely used crate to create temporary directories and delete then on drop. This is used a lot in tests.

Depends on #81 #82