### PR TITLE
makes diagnostics tools generally available

### DIFF
--- a/go/common/diagnostics/diagnostics.go
+++ b/go/common/diagnostics/diagnostics.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package diagnostics
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"runtime"
+	"runtime/pprof"
+	"runtime/trace"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+)
+
+// AddPerformanceDiagnosticsAction wraps an action function to add performance diagnostics
+// such as CPU profiling, tracing, and a diagnostic server.
+// It takes the action function and flags for diagnostics, CPU profiling, and tracing.
+// The diagnosticsFlag must be an integer, and it starts diagnostic server at the port parsed from this flag,
+// cpuProfileFlag is a string that starts CPU profiling giving the file name from this flag,
+// and traceFlag is a string that starts tracing giving the file name from this flag.
+func AddPerformanceDiagnosticsAction(action cli.ActionFunc, diagnosticsFlag *cli.IntFlag, cpuProfileFlag, traceFlag *cli.StringFlag) cli.ActionFunc {
+	return func(context *cli.Context) error {
+
+		// Start the diagnostic service if requested.
+		diagnosticPort := context.Int(diagnosticsFlag.Names()[0])
+		startDiagnosticServer(diagnosticPort)
+
+		// Start CPU profiling.
+		cpuProfileFileName := context.String(cpuProfileFlag.Names()[0])
+		if strings.TrimSpace(cpuProfileFileName) != "" {
+			if err := startCpuProfiler(cpuProfileFileName); err != nil {
+				return err
+			}
+			defer stopCpuProfiler()
+		}
+
+		// Start recording a trace.
+		traceFileName := context.String(traceFlag.Names()[0])
+		if strings.TrimSpace(traceFileName) != "" {
+			if err := startTracer(traceFileName); err != nil {
+				return err
+			}
+			defer stopTracer()
+		}
+
+		return action(context)
+	}
+}
+
+func startDiagnosticServer(port int) {
+	if port <= 0 || port >= (1<<16) {
+		return
+	}
+	fmt.Printf("Starting diagnostic server at port http://localhost:%d\n", port)
+	fmt.Printf("(see https://pkg.go.dev/net/http/pprof#hdr-Usage_examples for usage examples)\n")
+	fmt.Printf("Block and mutex sampling rate is set to 100%% for diagnostics, which may impact overall performance\n")
+	go func() {
+		addr := fmt.Sprintf("localhost:%d", port)
+		log.Println(http.ListenAndServe(addr, nil))
+	}()
+	runtime.SetBlockProfileRate(1)
+	runtime.SetMutexProfileFraction(1)
+}
+
+func startCpuProfiler(filename string) error {
+	f, err := os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("could not create CPU profile: %s", err)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		return fmt.Errorf("could not start CPU profile: %s", err)
+	}
+	return nil
+}
+
+func stopCpuProfiler() {
+	pprof.StopCPUProfile()
+}
+
+func startTracer(filename string) error {
+	traceFile, err := os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("failed to create trace file: %v", err)
+	}
+	if err := trace.Start(traceFile); err != nil {
+		return fmt.Errorf("failed to start trace: %v", err)
+	}
+	return nil
+}
+
+func stopTracer() {
+	trace.Stop()
+}

--- a/go/database/mpt/tool/block.go
+++ b/go/database/mpt/tool/block.go
@@ -14,13 +14,14 @@ import (
 	"fmt"
 
 	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/0xsoniclabs/carmen/go/common/diagnostics"
 	"github.com/0xsoniclabs/carmen/go/database/mpt"
 	"github.com/0xsoniclabs/carmen/go/database/mpt/io"
 	"github.com/urfave/cli/v2"
 )
 
 var Block = cli.Command{
-	Action:    addPerformanceDiagnoses(block),
+	Action:    diagnostics.AddPerformanceDiagnosticsAction(block, &diagnosticsFlag, &cpuProfileFlag, &traceFlag),
 	Name:      "block",
 	Usage:     "retrieves information about a given block",
 	ArgsUsage: "<archive-director>",

--- a/go/database/mpt/tool/check.go
+++ b/go/database/mpt/tool/check.go
@@ -13,13 +13,14 @@ package main
 import (
 	"fmt"
 
+	"github.com/0xsoniclabs/carmen/go/common/diagnostics"
 	"github.com/0xsoniclabs/carmen/go/database/mpt"
 	"github.com/0xsoniclabs/carmen/go/database/mpt/io"
 	"github.com/urfave/cli/v2"
 )
 
 var Check = cli.Command{
-	Action:    addPerformanceDiagnoses(check),
+	Action:    diagnostics.AddPerformanceDiagnosticsAction(check, &diagnosticsFlag, &cpuProfileFlag, &traceFlag),
 	Name:      "check",
 	Usage:     "performs extensive invariants checks",
 	ArgsUsage: "<director>",

--- a/go/database/mpt/tool/export.go
+++ b/go/database/mpt/tool/export.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/0xsoniclabs/carmen/go/common/diagnostics"
 	"github.com/0xsoniclabs/carmen/go/common/interrupt"
 	"github.com/0xsoniclabs/carmen/go/database/mpt"
 	"github.com/0xsoniclabs/carmen/go/database/mpt/io"
@@ -24,7 +25,7 @@ import (
 )
 
 var ExportCmd = cli.Command{
-	Action:    addPerformanceDiagnoses(doExport),
+	Action:    diagnostics.AddPerformanceDiagnosticsAction(doExport, &diagnosticsFlag, &cpuProfileFlag, &traceFlag),
 	Name:      "export",
 	Usage:     "exports a LiveDB or Archive instance into a file",
 	ArgsUsage: "<db director> <target-file>",

--- a/go/database/mpt/tool/import.go
+++ b/go/database/mpt/tool/import.go
@@ -18,26 +18,27 @@ import (
 	"io"
 	"os"
 
+	"github.com/0xsoniclabs/carmen/go/common/diagnostics"
 	mptIo "github.com/0xsoniclabs/carmen/go/database/mpt/io"
 	"github.com/urfave/cli/v2"
 )
 
 var ImportLiveDbCmd = cli.Command{
-	Action:    addPerformanceDiagnoses(doLiveDbImport),
+	Action:    diagnostics.AddPerformanceDiagnosticsAction(doLiveDbImport, &diagnosticsFlag, &cpuProfileFlag, &traceFlag),
 	Name:      "import-live-db",
 	Usage:     "imports a LiveDB instance from a file",
 	ArgsUsage: "<source-file> <target director>",
 }
 
 var ImportArchiveCmd = cli.Command{
-	Action:    addPerformanceDiagnoses(doArchiveImport),
+	Action:    diagnostics.AddPerformanceDiagnosticsAction(doArchiveImport, &diagnosticsFlag, &cpuProfileFlag, &traceFlag),
 	Name:      "import-archive",
 	Usage:     "imports an Archive instance from a file",
 	ArgsUsage: "<source-file> <target director>",
 }
 
 var ImportLiveAndArchiveCmd = cli.Command{
-	Action:    addPerformanceDiagnoses(doLiveAndArchiveImport),
+	Action:    diagnostics.AddPerformanceDiagnosticsAction(doLiveAndArchiveImport, &diagnosticsFlag, &cpuProfileFlag, &traceFlag),
 	Name:      "import",
 	Usage:     "imports both LiveDB and Archive instance from a file",
 	ArgsUsage: "<source-file> <target director>",

--- a/go/database/mpt/tool/info.go
+++ b/go/database/mpt/tool/info.go
@@ -13,13 +13,14 @@ package main
 import (
 	"fmt"
 
+	"github.com/0xsoniclabs/carmen/go/common/diagnostics"
 	"github.com/0xsoniclabs/carmen/go/database/mpt"
 	"github.com/0xsoniclabs/carmen/go/database/mpt/io"
 	"github.com/urfave/cli/v2"
 )
 
 var Info = cli.Command{
-	Action: addPerformanceDiagnoses(info),
+	Action: diagnostics.AddPerformanceDiagnosticsAction(info, &diagnosticsFlag, &cpuProfileFlag, &traceFlag),
 	Name:   "info",
 	Usage:  "lists information about a Carmen MTP state repository",
 	Flags: []cli.Flag{

--- a/go/database/mpt/tool/init_archive.go
+++ b/go/database/mpt/tool/init_archive.go
@@ -18,12 +18,13 @@ import (
 	"io"
 	"os"
 
+	"github.com/0xsoniclabs/carmen/go/common/diagnostics"
 	mptIo "github.com/0xsoniclabs/carmen/go/database/mpt/io"
 	"github.com/urfave/cli/v2"
 )
 
 var InitArchive = cli.Command{
-	Action:    addPerformanceDiagnoses(doArchiveInit),
+	Action:    diagnostics.AddPerformanceDiagnosticsAction(doArchiveInit, &diagnosticsFlag, &cpuProfileFlag, &traceFlag),
 	Name:      "init-archive",
 	Usage:     "initializes an Archive instance from a file",
 	ArgsUsage: "<source-file> <archive target director>",

--- a/go/database/mpt/tool/main.go
+++ b/go/database/mpt/tool/main.go
@@ -12,13 +12,7 @@ package main
 
 import (
 	"fmt"
-	"log"
-	"net/http"
 	"os"
-	"runtime"
-	"runtime/pprof"
-	"runtime/trace"
-	"strings"
 
 	"github.com/urfave/cli/v2"
 )
@@ -75,78 +69,4 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-}
-
-func addPerformanceDiagnoses(action cli.ActionFunc) cli.ActionFunc {
-	return func(context *cli.Context) error {
-
-		// Start the diagnostic service if requested.
-		diagnosticPort := context.Int(diagnosticsFlag.Name)
-		startDiagnosticServer(diagnosticPort)
-
-		// Start CPU profiling.
-		cpuProfileFileName := context.String(cpuProfileFlag.Name)
-		if strings.TrimSpace(cpuProfileFileName) != "" {
-			if err := startCpuProfiler(cpuProfileFileName); err != nil {
-				return err
-			}
-			defer stopCpuProfiler()
-		}
-
-		// Start recording a trace.
-		traceFileName := context.String(traceFlag.Name)
-		if strings.TrimSpace(traceFileName) != "" {
-			if err := startTracer(traceFileName); err != nil {
-				return err
-			}
-			defer stopTracer()
-		}
-
-		return action(context)
-	}
-}
-
-func startDiagnosticServer(port int) {
-	if port <= 0 || port >= (1<<16) {
-		return
-	}
-	fmt.Printf("Starting diagnostic server at port http://localhost:%d\n", port)
-	fmt.Printf("(see https://pkg.go.dev/net/http/pprof#hdr-Usage_examples for usage examples)\n")
-	fmt.Printf("Block and mutex sampling rate is set to 100%% for diagnostics, which may impact overall performance\n")
-	go func() {
-		addr := fmt.Sprintf("localhost:%d", port)
-		log.Println(http.ListenAndServe(addr, nil))
-	}()
-	runtime.SetBlockProfileRate(1)
-	runtime.SetMutexProfileFraction(1)
-}
-
-func startCpuProfiler(filename string) error {
-	f, err := os.Create(filename)
-	if err != nil {
-		return fmt.Errorf("could not create CPU profile: %s", err)
-	}
-	if err := pprof.StartCPUProfile(f); err != nil {
-		return fmt.Errorf("could not start CPU profile: %s", err)
-	}
-	return nil
-}
-
-func stopCpuProfiler() {
-	pprof.StopCPUProfile()
-}
-
-func startTracer(filename string) error {
-	traceFile, err := os.Create(filename)
-	if err != nil {
-		return fmt.Errorf("failed to create trace file: %v", err)
-	}
-	if err := trace.Start(traceFile); err != nil {
-		return fmt.Errorf("failed to start trace: %v", err)
-	}
-	return nil
-}
-
-func stopTracer() {
-	trace.Stop()
 }

--- a/go/database/mpt/tool/reset.go
+++ b/go/database/mpt/tool/reset.go
@@ -14,13 +14,14 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/0xsoniclabs/carmen/go/common/diagnostics"
 	"github.com/0xsoniclabs/carmen/go/database/mpt"
 	"github.com/0xsoniclabs/carmen/go/database/mpt/io"
 	"github.com/urfave/cli/v2"
 )
 
 var Reset = cli.Command{
-	Action:    addPerformanceDiagnoses(reset),
+	Action:    diagnostics.AddPerformanceDiagnosticsAction(reset, &diagnosticsFlag, &cpuProfileFlag, &traceFlag),
 	Name:      "reset",
 	Usage:     "resets the given archive to a selected block",
 	ArgsUsage: "<director> <block>",

--- a/go/database/mpt/tool/stress.go
+++ b/go/database/mpt/tool/stress.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/0xsoniclabs/carmen/go/common/diagnostics"
 	"github.com/0xsoniclabs/carmen/go/common/interrupt"
 	"github.com/0xsoniclabs/carmen/go/database/mpt"
 	"github.com/urfave/cli/v2"
@@ -31,7 +32,7 @@ import (
 // an MPT data base with the aim of stress-testing core components like the
 // node cache, the write buffer, and the background flush mechanism.
 var StressTestCmd = cli.Command{
-	Action: addPerformanceDiagnoses(stressTest),
+	Action: diagnostics.AddPerformanceDiagnosticsAction(stressTest, &diagnosticsFlag, &cpuProfileFlag, &traceFlag),
 	Name:   "stress-test",
 	Usage:  "stress test an MPT database",
 	Flags: []cli.Flag{

--- a/go/database/mpt/tool/verify.go
+++ b/go/database/mpt/tool/verify.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/0xsoniclabs/carmen/go/common/diagnostics"
 	"github.com/0xsoniclabs/carmen/go/common/interrupt"
 	"github.com/0xsoniclabs/carmen/go/database/mpt"
 	"github.com/0xsoniclabs/carmen/go/database/mpt/io"
@@ -21,7 +22,7 @@ import (
 )
 
 var Verify = cli.Command{
-	Action:    addPerformanceDiagnoses(verify),
+	Action:    diagnostics.AddPerformanceDiagnosticsAction(verify, &diagnosticsFlag, &cpuProfileFlag, &traceFlag),
 	Name:      "verify",
 	Usage:     "verifies the consistency of an MPT",
 	ArgsUsage: "<director>",

--- a/go/database/mpt/tool/verify_proof.go
+++ b/go/database/mpt/tool/verify_proof.go
@@ -12,17 +12,19 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"math"
+
+	"github.com/0xsoniclabs/carmen/go/common/diagnostics"
 	"github.com/0xsoniclabs/carmen/go/common/interrupt"
 	"github.com/0xsoniclabs/carmen/go/database/mpt"
 	"github.com/0xsoniclabs/carmen/go/database/mpt/io"
 	"github.com/0xsoniclabs/carmen/go/database/mpt/proof"
 	"github.com/urfave/cli/v2"
-	"log"
-	"math"
 )
 
 var VerifyProof = cli.Command{
-	Action:    addPerformanceDiagnoses(verifyProof),
+	Action:    diagnostics.AddPerformanceDiagnosticsAction(verifyProof, &diagnosticsFlag, &cpuProfileFlag, &traceFlag),
 	Name:      "verify-proof",
 	Usage:     "verifies the consistency of witness proofs",
 	ArgsUsage: "<director>",


### PR DESCRIPTION
This PR moves original `addPerformanceDiagnoses` to its own package and makes it public,

it is ment to be usable for tools stored in different packages