### PR TITLE
Set MSRV to 1.89

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -48,7 +48,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
     - name: install rust
-      uses: dtolnay/rust-toolchain@1.86
+      uses: dtolnay/rust-toolchain@1.89
       with:
         components: clippy
     - name: load cache
@@ -64,7 +64,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
     - name: install rust
-      uses: dtolnay/rust-toolchain@1.86
+      uses: dtolnay/rust-toolchain@1.89
     - name: load cache
       uses: Swatinem/rust-cache@v2
     - name: cargo doc
@@ -83,7 +83,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
     - name: install rust
-      uses: dtolnay/rust-toolchain@1.86
+      uses: dtolnay/rust-toolchain@1.89
     - name: load cache
       uses: Swatinem/rust-cache@v2
     - name: cargo build
@@ -97,7 +97,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
     - name: install rust
-      uses: dtolnay/rust-toolchain@1.86
+      uses: dtolnay/rust-toolchain@1.89
     - name: load cache
       uses: Swatinem/rust-cache@v2
     - name: cargo test

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,6 +13,7 @@ name = "carmen"
 version = "0.1.0"
 edition = "2024"
 publish = false
+rust-version = "1.89"
 
 [lib]
 crate-type = ["rlib", "staticlib"]


### PR DESCRIPTION
This PR sets the MSRV (Minimum Supported Rust Version) in the `Cargo.toml` file to `1.89` and updates the rust versions for the GitHub actions.

Rust `1.89` is needed for `std::fs::File::try_lock` in #75

By configuring the MSRV in the `Cargo.toml` file, you get an error message that looks like this:

```
 error: rustc 1.86.0 is not supported by the following packages:
  carmen@0.1.0 requires rustc 1.89
```
and not like this:
```
error[E0658]: use of unstable library feature `file_lock`
  --> src/storage/file/file_backend.rs:58:14
   |
58 |         file.try_lock()?;
   |              ^^^^^^^^
   |
   = note: see issue #130994 <https://github.com/rust-lang/rust/issues/130994> for more information
```
If your installed Rust version is too old.