### PR TITLE
Run miri only on ffi module

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -101,7 +101,7 @@ jobs:
     - name: load cache
       uses: Swatinem/rust-cache@v2
     - name: cargo test
-      run: cargo test --all-features --all-targets
+      run: cargo test --all-features --all-targets --no-fail-fast
   
   miri:
     name: miri
@@ -119,7 +119,7 @@ jobs:
     - name: cargo miri test
       env: 
         MIRIFLAGS: "-Zmiri-backtrace=full"
-      run: cargo +nightly miri test 
+      run: cargo +nightly miri test --no-fail-fast ffi
 
   unused-deps:
     name: unused deps


### PR DESCRIPTION
This PR configures MIRI to only run the tests in `carmen::ffi`.
Because MIRI is multiple orders of magnitude slower than even debug builds, some tests that will be added in upcoming PRs would simply run for too long. Also, we are running MIRI mainly to detect undefined behavior in unsafe code.

Additionally, `cargo test` and `cargo miri test` are now configures with `--no-fail-fast`, so that we get all failing tests.