### PR TITLE
Add `ErrorState` type

### DIFF
--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -8,6 +8,9 @@
 // On the date above, in accordance with the Business Source License, use of
 // this software will be governed by the GNU Lesser General Public License v3.
 
+#[cfg(test)]
+use std::{ops::Deref, sync::Mutex};
+
 use thiserror::Error;
 
 use crate::storage;
@@ -26,4 +29,62 @@ pub enum Error {
     Storage(#[from] storage::Error),
     #[error("Cache error: {0}")]
     Cache(String),
+}
+
+/// A thread-safe state for storing an error.
+/// This can be used for returning errors from background threads. Only a single error can be
+/// stored, additional errors will be ignored.
+#[cfg(test)]
+#[derive(Debug, Default)]
+pub struct ErrorState {
+    error: Mutex<Option<Error>>,
+}
+
+#[cfg(test)]
+impl ErrorState {
+    /// Create a new instance of `ErrorState` with no error.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register the error if no error has been registered yet.
+    pub fn store(&self, error: Error) {
+        let mut guard = self.error.lock().unwrap();
+        if guard.is_none() {
+            *guard = Some(error);
+        }
+    }
+
+    /// Retrieve the error, if any.
+    pub fn get(&self) -> impl Deref<Target = Option<Error>> {
+        self.error.lock().unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_state_new_creates_state_with_no_error() {
+        let state = ErrorState::new();
+        assert!(state.get().is_none());
+    }
+
+    #[test]
+    fn error_state_store_sets_error_if_none_exists() {
+        let state = ErrorState::new();
+        state.store(Error::UnsupportedSchema(1));
+        {
+            let err = state.get();
+            assert!(matches!(*err, Some(Error::UnsupportedSchema(1))));
+        }
+
+        // Registering another error should not change the existing one
+        state.store(Error::UnsupportedOperation("test".to_string()));
+        {
+            let err = state.get();
+            assert!(matches!(*err, Some(Error::UnsupportedSchema(1))));
+        }
+    }
 }


### PR DESCRIPTION
> This is in preparation of the NodeCache 

This PR adds the `ErrorState` type, a thread-safe utility to store an error.
The main reason for this is that we need a way to store errors happening in worker threads during a request in order to return them through the FFI interface (see #79). 
The usage would be:
- Instantiate an `ErrorState` in a `CarmenState` request
- Propagate it through the calls to the Trie, Cache, and Storage
- Check the `ErrorState` object and return the error.

This is also used in the subsequent `NodeCache` PRs to store storage errors happening during cache eviction due to a limitation of the `quickcache` interface.