### PR TITLE
Handle error codes returned via FFI in Go

### DIFF
--- a/go/state/cppstate/cpp_state.go
+++ b/go/state/cppstate/cpp_state.go
@@ -159,7 +159,6 @@ func (cs *CppState) GetStorage(address common.Address, key common.Key) (common.V
 	var value common.Value
 	result := C.Carmen_Cpp_GetStorageValue(cs.state, unsafe.Pointer(&address[0]), unsafe.Pointer(&key[0]), unsafe.Pointer(&value[0]))
 	if result != 0 {
-
 		return common.Value{}, fmt.Errorf("failed to get storage value for address %s and key %s (error code %v)", address, key, result)
 	}
 	return value, nil

--- a/go/state/cppstate/cpp_state.go
+++ b/go/state/cppstate/cpp_state.go
@@ -74,13 +74,13 @@ func newState(impl C.enum_LiveImpl, params state.Parameters) (state.State, error
 
 	db := unsafe.Pointer(nil)
 	result := C.Carmen_Cpp_OpenDatabase(C.C_Schema(params.Schema), impl, C.enum_ArchiveImpl(archive), dir, C.int(len(params.Directory)), &db)
-	if result != 0 || db == unsafe.Pointer(nil) {
+	if result != C.kResult_Success || db == unsafe.Pointer(nil) {
 		return nil, fmt.Errorf("%w: failed to create C++ database instance for parameters %v (error code %v)", state.UnsupportedConfiguration, params, result)
 	}
 
 	live := unsafe.Pointer(nil)
 	result = C.Carmen_Cpp_GetLiveState(db, &live)
-	if result != 0 || live == unsafe.Pointer(nil) {
+	if result != C.kResult_Success || live == unsafe.Pointer(nil) {
 		C.Carmen_Cpp_ReleaseDatabase(db)
 		return nil, fmt.Errorf("%w: failed to create C++ live state instance for parameters %v (error code %v)", state.UnsupportedConfiguration, params, result)
 	}
@@ -113,7 +113,7 @@ func (cs *CppState) CreateAccount(address common.Address) error {
 func (cs *CppState) Exists(address common.Address) (bool, error) {
 	var res common.AccountState
 	result := C.Carmen_Cpp_AccountExists(cs.state, unsafe.Pointer(&address[0]), unsafe.Pointer(&res))
-	if result != 0 {
+	if result != C.kResult_Success {
 		return false, fmt.Errorf("failed to check if account exists (error code %v)", result)
 	}
 	return res == common.Exists, nil
@@ -128,7 +128,7 @@ func (cs *CppState) DeleteAccount(address common.Address) error {
 func (cs *CppState) GetBalance(address common.Address) (amount.Amount, error) {
 	var balance [amount.BytesLength]byte
 	result := C.Carmen_Cpp_GetBalance(cs.state, unsafe.Pointer(&address[0]), unsafe.Pointer(&balance[0]))
-	if result != 0 {
+	if result != C.kResult_Success {
 		return amount.Amount{}, fmt.Errorf("failed to get balance for address %s (error code %v)", address, result)
 	}
 	return amount.NewFromBytes(balance[:]...), nil
@@ -143,7 +143,7 @@ func (cs *CppState) SetBalance(address common.Address, balance amount.Amount) er
 func (cs *CppState) GetNonce(address common.Address) (common.Nonce, error) {
 	var nonce common.Nonce
 	result := C.Carmen_Cpp_GetNonce(cs.state, unsafe.Pointer(&address[0]), unsafe.Pointer(&nonce[0]))
-	if result != 0 {
+	if result != C.kResult_Success {
 		return common.Nonce{}, fmt.Errorf("failed to get nonce for address %s (error code %v)", address, result)
 	}
 	return nonce, nil
@@ -158,7 +158,7 @@ func (cs *CppState) SetNonce(address common.Address, nonce common.Nonce) error {
 func (cs *CppState) GetStorage(address common.Address, key common.Key) (common.Value, error) {
 	var value common.Value
 	result := C.Carmen_Cpp_GetStorageValue(cs.state, unsafe.Pointer(&address[0]), unsafe.Pointer(&key[0]), unsafe.Pointer(&value[0]))
-	if result != 0 {
+	if result != C.kResult_Success {
 		return common.Value{}, fmt.Errorf("failed to get storage value for address %s and key %s (error code %v)", address, key, result)
 	}
 	return value, nil
@@ -181,7 +181,7 @@ func (cs *CppState) GetCode(address common.Address) ([]byte, error) {
 	code = make([]byte, CodeMaxSize)
 	var size C.uint32_t = CodeMaxSize
 	result := C.Carmen_Cpp_GetCode(cs.state, unsafe.Pointer(&address[0]), unsafe.Pointer(&code[0]), &size)
-	if result != 0 {
+	if result != C.kResult_Success {
 		return nil, fmt.Errorf("failed to get code for address %s (error code %v)", address, result)
 	}
 	if size >= CodeMaxSize {
@@ -205,7 +205,7 @@ func (cs *CppState) SetCode(address common.Address, code []byte) error {
 func (cs *CppState) GetCodeHash(address common.Address) (common.Hash, error) {
 	var hash common.Hash
 	result := C.Carmen_Cpp_GetCodeHash(cs.state, unsafe.Pointer(&address[0]), unsafe.Pointer(&hash[0]))
-	if result != 0 {
+	if result != C.kResult_Success {
 		return common.Hash{}, fmt.Errorf("failed to get code hash for address %s (error code %v)", address, result)
 	}
 	return hash, nil
@@ -214,7 +214,7 @@ func (cs *CppState) GetCodeHash(address common.Address) (common.Hash, error) {
 func (cs *CppState) GetCodeSize(address common.Address) (int, error) {
 	var size C.uint32_t
 	result := C.Carmen_Cpp_GetCodeSize(cs.state, unsafe.Pointer(&address[0]), &size)
-	if result != 0 {
+	if result != C.kResult_Success {
 		return 0, fmt.Errorf("failed to get code size for address %s (error code %v)", address, result)
 	}
 	return int(size), nil
@@ -223,7 +223,7 @@ func (cs *CppState) GetCodeSize(address common.Address) (int, error) {
 func (cs *CppState) GetHash() (common.Hash, error) {
 	var hash common.Hash
 	result := C.Carmen_Cpp_GetHash(cs.state, unsafe.Pointer(&hash[0]))
-	if result != 0 {
+	if result != C.kResult_Success {
 		return common.Hash{}, fmt.Errorf("failed to get state hash (error code %v)", result)
 	}
 	return hash, nil
@@ -239,7 +239,7 @@ func (cs *CppState) Apply(block uint64, update common.Update) error {
 	data := update.ToBytes()
 	dataPtr := unsafe.Pointer(&data[0])
 	result := C.Carmen_Cpp_Apply(cs.state, C.uint64_t(block), dataPtr, C.uint64_t(len(data)))
-	if result != 0 {
+	if result != C.kResult_Success {
 		return fmt.Errorf("failed to apply update at block %d (error code %v)", block, result)
 	}
 	// Apply code changes to Go-sided code cache.
@@ -251,7 +251,7 @@ func (cs *CppState) Apply(block uint64, update common.Update) error {
 
 func (cs *CppState) Flush() error {
 	result := C.Carmen_Cpp_Flush(cs.database)
-	if result != 0 {
+	if result != C.kResult_Success {
 		return fmt.Errorf("failed to flush state (error code %v)", result)
 	}
 	return nil
@@ -260,16 +260,16 @@ func (cs *CppState) Flush() error {
 func (cs *CppState) Close() error {
 	if cs.state != nil {
 		result := C.Carmen_Cpp_ReleaseState(cs.state)
-		if result != 0 {
+		if result != C.kResult_Success {
 			return fmt.Errorf("failed to release C++ state (error code %v)", result)
 		}
 		cs.state = nil
 		result = C.Carmen_Cpp_Close(cs.database)
-		if result != 0 {
+		if result != C.kResult_Success {
 			return fmt.Errorf("failed to close C++ database (error code %v)", result)
 		}
 		result = C.Carmen_Cpp_ReleaseDatabase(cs.database)
-		if result != 0 {
+		if result != C.kResult_Success {
 			return fmt.Errorf("failed to release C++ database (error code %v)", result)
 		}
 		cs.database = nil
@@ -302,16 +302,16 @@ func (cs *CppState) GetMemoryFootprint() *common.MemoryFootprint {
 	var buffer *C.char
 	var size C.uint64_t
 	result := C.Carmen_Cpp_GetMemoryFootprint(cs.database, &buffer, &size)
-	if result != 0 {
+	if result != C.kResult_Success {
 		res := common.NewMemoryFootprint(0)
-		res.SetNote(fmt.Sprintf("Failed to get C++ memory footprint (error code %v)", result))
-		log.Printf("Failed to get C++ memory footprint (error code %v)", result)
+		res.SetNote(fmt.Sprintf("failed to get C++ memory footprint (error code %v)", result))
+		log.Printf("failed to get C++ memory footprint (error code %v)", result)
 		return res
 	}
 	defer func() {
 		result := C.Carmen_Cpp_ReleaseMemoryFootprintBuffer(buffer, size)
-		if result != 0 {
-			log.Printf("Failed to release memory footprint buffer (error code %v)", result)
+		if result != C.kResult_Success {
+			log.Printf("failed to release memory footprint buffer (error code %v)", result)
 		}
 	}()
 
@@ -334,7 +334,7 @@ func (cs *CppState) GetMemoryFootprint() *common.MemoryFootprint {
 func (cs *CppState) GetArchiveState(block uint64) (state.State, error) {
 	state := unsafe.Pointer(nil)
 	result := C.Carmen_Cpp_GetArchiveState(cs.database, C.uint64_t(block), &state)
-	if result != 0 {
+	if result != C.kResult_Success {
 		return nil, fmt.Errorf("failed to get archive state for block %d (error code %v)", block, result)
 	}
 	return &CppState{

--- a/go/state/cppstate/cpp_state_test.go
+++ b/go/state/cppstate/cpp_state_test.go
@@ -169,8 +169,8 @@ func getTestCodes() [][]byte {
 
 func TestSetAndGetCode(t *testing.T) {
 	runForEachCppConfig(t, func(t *testing.T, state state.State) {
-		for _, code := range getTestCodes() {
-			err := state.Apply(1, common.Update{
+		for i, code := range getTestCodes() {
+			err := state.Apply(uint64(i), common.Update{
 				Codes: []common.CodeUpdate{{Account: address1, Code: code}},
 			})
 			if err != nil {
@@ -196,8 +196,8 @@ func TestSetAndGetCode(t *testing.T) {
 
 func TestSetAndGetCodeHash(t *testing.T) {
 	runForEachCppConfig(t, func(t *testing.T, state state.State) {
-		for _, code := range getTestCodes() {
-			err := state.Apply(1, common.Update{
+		for i, code := range getTestCodes() {
+			err := state.Apply(uint64(i), common.Update{
 				Codes: []common.CodeUpdate{{Account: address1, Code: code}},
 			})
 			if err != nil {


### PR DESCRIPTION
This PR uses the error codes introduced in #79 to return errors on the Go side if an operation failed.

The only exception is if `C.Carmen_Cpp_GetMemoryFootprint` fails. Unlike all other methods, `State::GetMemoryFootprint` does not return an error. One option would be to change the interface, but this requires changes in a lot of different places in the codebase and would also require either changing other interfaces as well because they now also need to be able to return an error, or swallow the error silently. The other option (which is implemented in this PR), is to set the note on the memory footprint object to an appropriate error message and log the error.


Closes https://github.com/0xsoniclabs/sonic-admin/issues/322