### PR TITLE
Change `CarmenState::get_nonce` to return byte array

### DIFF
--- a/rust/src/ffi/exported.rs
+++ b/rust/src/ffi/exported.rs
@@ -492,7 +492,7 @@ unsafe extern "C" fn Carmen_Rust_GetNonce(
             // SAFETY:
             // - `out_nonce` is a valid pointer to a byte array of length 32 (precondition)
             // - `out_nonce` is valid for writes for the duration of the call (precondition)
-            unsafe { std::ptr::write(out_nonce as *mut u64, nonce) };
+            unsafe { std::ptr::write(out_nonce as _, nonce) };
             bindings::Result_kResult_Success
         }
         Err(err) => err.into(),
@@ -1631,7 +1631,7 @@ mod tests {
     #[test]
     fn carmen_rust_get_nonce_returns_value_from_carmen_db() {
         let addr = [1u8; 20];
-        let expected_nonce = 2;
+        let expected_nonce = [2; 8];
         create_state_then_call_fn_then_release_state(
             move |mock_db| {
                 mock_db
@@ -1641,12 +1641,12 @@ mod tests {
             },
             move |state| {
                 let mut addr = addr;
-                let mut out_nonce: u64 = 0;
+                let mut out_nonce = [0; 8];
                 unsafe {
                     Carmen_Rust_GetNonce(
                         state,
                         &mut addr as *mut Address as *mut c_void,
-                        &mut out_nonce as *mut u64 as *mut c_void,
+                        &mut out_nonce as *mut [u8; 8] as *mut c_void,
                     );
                 }
                 assert_eq!(out_nonce, expected_nonce);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -70,7 +70,7 @@ pub trait CarmenState: Send + Sync {
     fn get_balance(&self, addr: &Address) -> Result<U256, Error>;
 
     /// Returns the nonce of the given account.
-    fn get_nonce(&self, addr: &Address) -> Result<u64, Error>;
+    fn get_nonce(&self, addr: &Address) -> Result<Nonce, Error>;
 
     /// Returns the value of storage location (addr,key) in the given state.
     fn get_storage_value(&self, addr: &Address, key: &Key) -> Result<Value, Error>;
@@ -131,7 +131,7 @@ impl CarmenState for LiveState {
         unimplemented!()
     }
 
-    fn get_nonce(&self, addr: &Address) -> Result<u64, Error> {
+    fn get_nonce(&self, addr: &Address) -> Result<Nonce, Error> {
         unimplemented!()
     }
 
@@ -173,7 +173,7 @@ impl CarmenState for ArchiveState {
         unimplemented!()
     }
 
-    fn get_nonce(&self, addr: &Address) -> Result<u64, Error> {
+    fn get_nonce(&self, addr: &Address) -> Result<Nonce, Error> {
         unimplemented!()
     }
 


### PR DESCRIPTION
The `CarmenState` interface so far received nonce updates as `[u8; 8]`, but returned a `u64` from `get_nonce`. This unnecessarily complicates things, as we have to convert the `u64` back to an array for the FFI, and need to ensure we correctly deal with endianness.

This changes the `get_state` function to instead simply return a `Nonce`, which is an alias for `[u8; 8]`.