### PR TITLE
Add `Cache` error

### DIFF
--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -24,4 +24,6 @@ pub enum Error {
     UnsupportedOperation(String),
     #[error("storage error: {0}")]
     Storage(#[from] storage::Error),
+    #[error("Cache error: {0}")]
+    Cache(String),
 }

--- a/rust/src/ffi/mod.rs
+++ b/rust/src/ffi/mod.rs
@@ -25,7 +25,8 @@ mod bindings {
                     crate::storage::Error::NotFound
                     | crate::storage::Error::IdNodeTypeMismatch
                     | crate::storage::Error::InvalidId,
-                ) => Result_kResult_InternalError,
+                )
+                | Error::Cache(_) => Result_kResult_InternalError,
                 Error::Storage(crate::storage::Error::DatabaseCorruption) => {
                     Result_kResult_CorruptedDatabase
                 }


### PR DESCRIPTION
> This is in preparation of the `NodeCache` PR

This PR adds a `Cache` entry to the `Error` enum to allow handling internal `NodeCache` errors.
The error just takes a string as the cache can only fail on the internal cache construction, which returns a string (see [quickcache](https://docs.rs/quick_cache/latest/quick_cache)).
It also adds an entry to the FFI error handling.

NOTE: This error will actually never happen: the quickcache constructor will fail only if one doesn't provide all the required arguments to the builder, which cannot happen as we manually specify all the arguments. However, we don't know if this would change in the future and relying on white-box assumptions on a dependency it's not great, therefore I decided to explicitly handle it anyway.