### PR TITLE
Add `Pool` trait and remove `Cache` types

### DIFF
--- a/rust/src/pool/mod.rs
+++ b/rust/src/pool/mod.rs
@@ -20,7 +20,7 @@ pub trait Pool {
     fn get(
         &self,
         id: Self::Id,
-    ) -> Result<PoolEntry<impl DerefMut<Target = Self::Type> + Send + Sync + 'static>, Error>;
+    ) -> Result<PoolItem<impl DerefMut<Target = Self::Type> + Send + Sync + 'static>, Error>;
 
     /// Stores the item in the pool and assigns an ID to it.
     fn set(&self, item: Self::Type) -> Result<Self::Id, Error>;
@@ -37,9 +37,9 @@ pub trait Pool {
 /// An item retrieved from the pool which can be locked before reading to enable safe concurrent
 /// access.
 #[derive(Debug)]
-pub struct PoolEntry<T>(Arc<RwLock<T>>);
+pub struct PoolItem<T>(Arc<RwLock<T>>);
 
-impl<T> PoolEntry<T> {
+impl<T> PoolItem<T> {
     /// Creates a new pool entry with the given [`PoolEntry`].
     pub fn new(item: Arc<RwLock<T>>) -> Self {
         Self(item)
@@ -68,7 +68,7 @@ mod tests {
 
     use crate::{
         error::Error,
-        pool::{Pool, PoolEntry},
+        pool::{Pool, PoolItem},
         storage,
     };
 
@@ -315,7 +315,7 @@ mod tests {
             &self,
             id: Self::Id,
         ) -> Result<
-            PoolEntry<impl DerefMut<Target = Self::Type> + Send + Sync + 'static>,
+            PoolItem<impl DerefMut<Target = Self::Type> + Send + Sync + 'static>,
             crate::error::Error,
         > {
             self.nodes
@@ -323,7 +323,7 @@ mod tests {
                 .unwrap()
                 .get(&id)
                 .cloned()
-                .map(super::PoolEntry::new)
+                .map(super::PoolItem::new)
                 .ok_or(Error::Storage(storage::Error::NotFound))
         }
 

--- a/rust/src/pool/mod.rs
+++ b/rust/src/pool/mod.rs
@@ -17,7 +17,7 @@ pub mod node_pool_with_storage;
 /// which dereferences to [`Pool::Type`]. This abstraction allows for the pool to associate metadata
 /// with each item, for example to implement smart cache eviction.
 pub trait Pool {
-    /// The id type used to identify entries in the pool.
+    /// The id type used to identify items in the pool.
     type Id;
     /// The type of items indexed by the pool.
     type Type;
@@ -51,7 +51,7 @@ impl<T> PoolItem<T> {
         Self(item)
     }
 
-    /// Acquires a read lock on the entry.
+    /// Acquires a read lock on the item.
     pub fn read(&self) -> LockResult<std::sync::RwLockReadGuard<'_, T>> {
         self.0.read()
     }

--- a/rust/src/pool/mod.rs
+++ b/rust/src/pool/mod.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use crate::error::Error;
+pub mod node_pool_with_storage;
 
 /// An abstraction for a pool of thread-safe items
 pub trait Pool {

--- a/rust/src/pool/mod.rs
+++ b/rust/src/pool/mod.rs
@@ -23,7 +23,7 @@ pub trait Pool {
         id: Self::Id,
     ) -> Result<PoolItem<impl DerefMut<Target = Self::Type> + Send + Sync + 'static>, Error>;
 
-    /// Stores the item in the pool and assigns an ID to it.
+    /// Stores the item in the pool and returns an ID for it.
     fn set(&self, item: Self::Type) -> Result<Self::Id, Error>;
 
     /// Deletes an item with the given ID from the pool

--- a/rust/src/pool/mod.rs
+++ b/rust/src/pool/mod.rs
@@ -20,16 +20,16 @@ pub trait Pool {
     /// The id type used to identify items in the pool.
     type Id;
     /// The type of items indexed by the pool.
-    type Type;
+    type Item;
 
     /// Adds the item in the pool and returns an ID for it.
-    fn add(&self, item: Self::Type) -> Result<Self::Id, Error>;
+    fn add(&self, item: Self::Item) -> Result<Self::Id, Error>;
 
     /// Retrieves an item from the pool, if it exists. Returns [`Error::NotFound`] otherwise.
     fn get(
         &self,
         id: Self::Id,
-    ) -> Result<PoolItem<impl DerefMut<Target = Self::Type> + Send + Sync + 'static>, Error>;
+    ) -> Result<PoolItem<impl DerefMut<Target = Self::Item> + Send + Sync + 'static>, Error>;
 
     /// Deletes an item with the given ID from the pool
     /// The ID may be reused in the future, when creating a new item by calling [`Pool::set`].
@@ -88,13 +88,13 @@ mod tests {
 
     impl Pool for FakeNodePool {
         type Id = u32;
-        type Type = TestNode;
+        type Item = TestNode;
 
         fn get(
             &self,
             id: Self::Id,
         ) -> Result<
-            PoolItem<impl DerefMut<Target = Self::Type> + Send + Sync + 'static>,
+            PoolItem<impl DerefMut<Target = Self::Item> + Send + Sync + 'static>,
             crate::error::Error,
         > {
             self.nodes
@@ -193,7 +193,7 @@ mod tests {
         depth: u32,
         max_depth: u32,
         root_id: u32,
-        pool: &Arc<impl Pool<Id = u32, Type = TestNode> + Send + Sync + 'static>,
+        pool: &Arc<impl Pool<Id = u32, Item = TestNode> + Send + Sync + 'static>,
     ) {
         if depth == max_depth {
             return;
@@ -226,7 +226,7 @@ mod tests {
         cur_node: &TestNode,
         path: &[u32],
         value: u32,
-        pool: &Arc<impl Pool<Id = u32, Type = TestNode> + Send + Sync + 'static>,
+        pool: &Arc<impl Pool<Id = u32, Item = TestNode> + Send + Sync + 'static>,
     ) {
         let child_id = path
             .first()
@@ -245,7 +245,7 @@ mod tests {
     fn read_from_tree_path(
         cur_node: &TestNode,
         path: &[u32],
-        pool: &Arc<impl Pool<Id = u32, Type = TestNode> + Send + Sync + 'static>,
+        pool: &Arc<impl Pool<Id = u32, Item = TestNode> + Send + Sync + 'static>,
     ) -> u32 {
         let child_id = path
             .first()
@@ -266,7 +266,7 @@ mod tests {
         level: u32,
         id: u32,
         depth: u32,
-        pool: &Arc<impl Pool<Id = u32, Type = TestNode> + Send + Sync + 'static>,
+        pool: &Arc<impl Pool<Id = u32, Item = TestNode> + Send + Sync + 'static>,
     ) {
         if depth == level {
             pool.delete(id).unwrap();

--- a/rust/src/pool/mod.rs
+++ b/rust/src/pool/mod.rs
@@ -79,7 +79,7 @@ mod tests {
         depth: u32,
         max_depth: u32,
         root_id: u32,
-        pool: Arc<impl Pool<Key = u32, Type = Node, StoredType = Node> + Send + Sync + 'static>,
+        pool: &Arc<impl Pool<Key = u32, Type = Node, StoredType = Node> + Send + Sync + 'static>,
     ) {
         if depth == max_depth {
             return;
@@ -98,7 +98,7 @@ mod tests {
                 move || {
                     let mut child = child.write().unwrap();
                     let new_root_id = child.value;
-                    populate_tree(&mut child, depth + 1, TREE_DEPTH, new_root_id, pool);
+                    populate_tree(&mut child, depth + 1, TREE_DEPTH, new_root_id, &pool);
                 }
             }));
         }
@@ -112,7 +112,7 @@ mod tests {
         cur_node: &Node,
         path: &[u32],
         value: u32,
-        pool: Arc<impl Pool<Key = u32, Type = Node, StoredType = Node> + Send + Sync + 'static>,
+        pool: &Arc<impl Pool<Key = u32, Type = Node, StoredType = Node> + Send + Sync + 'static>,
     ) {
         let child_id = path
             .first()
@@ -123,15 +123,15 @@ mod tests {
         if path.is_empty() {
             child.write().unwrap().value = value;
         } else {
-            set_value_at_path(&child.read().unwrap(), path, value, pool)
+            set_value_at_path(&child.read().unwrap(), path, value, pool);
         }
     }
 
-    //// Recursively reads a value from the tree following the given path.
+    /// Recursively reads a value from the tree following the given path.
     fn read_from_tree_path(
         cur_node: &Node,
         path: &[u32],
-        pool: Arc<impl Pool<Key = u32, Type = Node, StoredType = Node> + Send + Sync + 'static>,
+        pool: &Arc<impl Pool<Key = u32, Type = Node, StoredType = Node> + Send + Sync + 'static>,
     ) -> u32 {
         let child_id = path
             .first()
@@ -152,7 +152,7 @@ mod tests {
         level: u32,
         id: u32,
         depth: u32,
-        pool: Arc<impl Pool<Key = u32, Type = Node, StoredType = Node> + Send + Sync + 'static>,
+        pool: &Arc<impl Pool<Key = u32, Type = Node, StoredType = Node> + Send + Sync + 'static>,
     ) {
         if depth == level {
             pool.delete(id).unwrap();
@@ -165,7 +165,7 @@ mod tests {
             handles.push(thread::spawn({
                 let pool = pool.clone();
                 move || {
-                    delete_tree_level(&child.read().unwrap(), level, child_id, depth + 1, pool);
+                    delete_tree_level(&child.read().unwrap(), level, child_id, depth + 1, &pool);
                 }
             }));
         }
@@ -188,7 +188,7 @@ mod tests {
         let root_id = pool.set(root).unwrap();
 
         let root = pool.get(root_id).unwrap();
-        populate_tree(&mut root.write().unwrap(), 3, TREE_DEPTH, 0, pool);
+        populate_tree(&mut root.write().unwrap(), 3, TREE_DEPTH, 0, &pool);
     }
 
     #[test]
@@ -204,7 +204,7 @@ mod tests {
         };
         let root_id = pool.set(root).unwrap();
         let root = pool.get(root_id).unwrap();
-        populate_tree(&mut root.write().unwrap(), 0, TREE_DEPTH, 0, pool.clone());
+        populate_tree(&mut root.write().unwrap(), 0, TREE_DEPTH, 0, &pool.clone());
 
         let mut cases = vec![];
         generate_cases_recursive(&mut cases, &mut vec![], TREE_DEPTH);
@@ -216,7 +216,7 @@ mod tests {
             handles.push(thread::spawn(move || {
                 assert_eq!(
                     case.expected,
-                    read_from_tree_path(&root.read().unwrap(), &case.path, pool)
+                    read_from_tree_path(&root.read().unwrap(), &case.path, &pool)
                 );
             }));
         }
@@ -239,10 +239,10 @@ mod tests {
         };
         let root_id = pool.set(root).unwrap();
         let root = pool.get(root_id).unwrap();
-        populate_tree(&mut root.write().unwrap(), 0, TREE_DEPTH, 0, pool.clone());
+        populate_tree(&mut root.write().unwrap(), 0, TREE_DEPTH, 0, &pool.clone());
 
         let num_nodes = pool.nodes.lock().unwrap().len();
-        delete_tree_level(&root.read().unwrap(), TREE_DEPTH, root_id, 0, pool.clone());
+        delete_tree_level(&root.read().unwrap(), TREE_DEPTH, root_id, 0, &pool);
 
         assert_eq!(
             pool.nodes.lock().unwrap().len(),
@@ -264,10 +264,12 @@ mod tests {
         };
         let root_id = pool.set(root).unwrap();
         let root = pool.get(root_id).unwrap();
-        populate_tree(&mut root.write().unwrap(), 0, TREE_DEPTH, 0, pool.clone());
+        populate_tree(&mut root.write().unwrap(), 0, TREE_DEPTH, 0, &pool.clone());
 
         let mut cases = vec![];
         generate_cases_recursive(&mut cases, &mut vec![], TREE_DEPTH);
+        // IMO this is clearer than filtering the elements in the for loop below.
+        #[allow(clippy::needless_collect)]
         let paths: Vec<Vec<u32>> = cases.into_iter().map(|c| c.path).collect();
 
         let mut handles = vec![];
@@ -278,7 +280,7 @@ mod tests {
                 let root = pool.get(root_id).unwrap();
                 let path = path.clone();
                 move || {
-                    set_value_at_path(&root.read().unwrap(), &path, i as u32, pool.clone());
+                    set_value_at_path(&root.read().unwrap(), &path, i as u32, &pool.clone());
                 }
             }));
             // Spawn get
@@ -286,9 +288,13 @@ mod tests {
                 let pool = pool.clone();
                 let root = pool.get(root_id).unwrap();
                 move || {
-                    let _ = read_from_tree_path(&root.read().unwrap(), &path, pool.clone());
+                    let _ = read_from_tree_path(&root.read().unwrap(), &path, &pool);
                 }
             }));
+        }
+
+        for h in handles {
+            h.join().unwrap();
         }
     }
 

--- a/rust/src/pool/mod.rs
+++ b/rust/src/pool/mod.rs
@@ -307,7 +307,7 @@ mod tests {
 
     /// A simple in-memory pool of nodes for testing purposes.
     struct FakeNodePool {
-        nodes: Mutex<VecArc<RwLock<Node>>>>,
+        nodes: Mutex<HashMap<u32, Arc<RwLock<Node>>>>,
     }
 
     impl Pool for FakeNodePool {


### PR DESCRIPTION
This PR adds the `Pool` trait and its basic types: `PoolItem`
The `Pool` substitutes the `Cache` component, and `PoolItem` substitutes the `Cache` types.

The `Pool` is an abstraction for a thread-safe pools of items, and it's the entry point for accessing the storage from the upcoming storage-based Verkle-trie.
The `Pool` is generic over three types:
- `Key`: The type used to index the elements in the pool
- `Type`: The type of the item handled by the pool

The `PoolItem` is the item returned from the `Pool`, defined as an `Arc<RwLock<T>>`. 
- `Arc` because the value it's shared across threads
- `RwLock` for thread-safe access

The existence of the `PoolItem` type is justified by the needing of hiding the `Arc` to avoid cloning.
The pool returns `PoolItem<impl DerefMut<Target = Type>>`. This is usually a wrapper around `Type`. This is needed as a `Pool` implementation may add metadata to `Type` for various reasons (e.g. lifecycle management, storage optimizations, etc.)