### PR TITLE
Address various minor issues

### DIFF
--- a/rust/src/pool/mod.rs
+++ b/rust/src/pool/mod.rs
@@ -31,7 +31,7 @@ pub trait Pool {
         id: Self::Id,
     ) -> Result<PoolItem<impl DerefMut<Target = Self::Item> + Send + Sync + 'static>, Error>;
 
-    /// Deletes an item with the given ID from the pool
+    /// Deletes an item with the given ID from the pool.
     /// The ID may be reused in the future, when creating a new item by calling [`Pool::set`].
     fn delete(&self, id: Self::Id) -> Result<(), Error>;
 

--- a/rust/src/storage/storage_with_flush_buffer.rs
+++ b/rust/src/storage/storage_with_flush_buffer.rs
@@ -109,9 +109,10 @@ where
 
     fn flush(&self) -> Result<(), Error> {
         // Busy loop until all flush workers are done.
-        // Because there are no concurrent inserts, len() might only return a number that is higher
-        // that the actual number of items. This is however not a problem because we will wait a
-        // little bit longer.
+        // Because there are no concurrent operations, len() might only return a number that is
+        // higher that the actual number of items (in case an element of the flush buffer
+        // was removed by a flush worker while iterating over the shards). This is however not a
+        // problem because we will wait a little bit longer.
         while !self.flush_buffer.is_empty() {}
         self.storage.flush()
     }
@@ -231,7 +232,7 @@ mod tests {
 
         // this opens:
         // StorageWithFlushBuffer
-        //   -> FileStoreManager
+        //   -> FileStorageManager
         //     -> A NodeFileStorage for each node type (InnerNode, SparseLeafNode<N>, ...)
         //       -> NoSeekFile
         StorageWithFlushBuffer::<FileStorageManager<NoSeekFile>>::open(dir.path()).unwrap();

--- a/rust/src/types/id.rs
+++ b/rust/src/types/id.rs
@@ -47,7 +47,7 @@ impl NodeId {
     pub fn from_idx_and_node_type(idx: u64, node_type: NodeType) -> Self {
         assert!(
             (idx & !Self::INDEX_MASK) == 0,
-            "indices can not get this large, unless we have a bug somewhere"
+            "indices cannot get this large, unless we have a bug somewhere"
         );
         let prefix = match node_type {
             NodeType::Empty => Self::EMPTY_NODE_PREFIX,


### PR DESCRIPTION
This PR refactors NodeWithMetadata and fixes a couple of typos and outdated comments in other files.

In particular, `NodeStatus` is now private and `NodeWithMetadata::new` now do longer takes a node status but just creates a node with the status clean.
The assertions with manual comparisons have been replaced by `assert_eq` and the tests that check that deref panics on deleted node use the `#[should_panic]` attribute instead of catching the panic using `catch_unwind`.