### PR TITLE
Prepare FileBackend trait for caching

### DIFF
--- a/rust/src/storage/file/node_file_storage.rs
+++ b/rust/src/storage/file/node_file_storage.rs
@@ -71,7 +71,7 @@ where
             .read(true)
             .write(true);
 
-        let node_file = F::open(dir.join(Self::NODE_STORE_FILE).as_path(), &mut file_opts)?;
+        let node_file = F::open(dir.join(Self::NODE_STORE_FILE).as_path(), file_opts.clone())?;
         let len = node_file.len()?;
         if len % size_of::<T>() as u64 != 0 {
             return Err(Error::DatabaseCorruption);


### PR DESCRIPTION
This PR introduces a couple of small changes to the `FileBackend` trait, so that it can be better used for file backends with caching (will be added in upcoming PRs).

- `FileBackend::open` takes `OpenOptions` by value, so that each layer can modify the open options before passing them to the next lower layer. This is needed because caching layers should open the lower layers with flags for direct I/O.
- `FileBackend` is now `Send + Sync`. Because `FileBackend` is supposed to be usable from different threads, these bounds are needed. All implementations already satisfy this. Having the constraint directly on the trait, ensures that also all future implementations are `Send + Sync` and removes the need to specify `F: FileBackend + Send + Sync` whenever using this layer.

Part of https://github.com/0xsoniclabs/sonic-admin/issues/366