### PR TITLE
Add PageCachedFile

### DIFF
--- a/rust/src/storage/file/file_backend.rs
+++ b/rust/src/storage/file/file_backend.rs
@@ -128,13 +128,16 @@ mod tests {
         fs::{File, OpenOptions},
         io::{Read, Write},
         sync::{
-            Arc,
+            Arc, Barrier,
             atomic::{AtomicU64, Ordering},
         },
     };
 
     use super::*;
-    use crate::utils::test_dir::{Permissions, TestDir};
+    use crate::{
+        storage::file::PageCachedFile,
+        utils::test_dir::{Permissions, TestDir},
+    };
 
     fn open_backends()
     -> impl Iterator<Item = fn(&Path, OpenOptions) -> std::io::Result<Arc<dyn FileBackend>>> {
@@ -145,6 +148,14 @@ mod tests {
             }) as fn(&Path, OpenOptions) -> _,
             (|path, options| {
                 <NoSeekFile as FileBackend>::open(path, options)
+                    .map(|f| Arc::new(f) as Arc<dyn FileBackend>)
+            }) as fn(&Path, OpenOptions) -> _,
+            (|path, options| {
+                <PageCachedFile<SeekFile> as FileBackend>::open(path, options)
+                    .map(|f| Arc::new(f) as Arc<dyn FileBackend>)
+            }) as fn(&Path, OpenOptions) -> _,
+            (|path, options| {
+                <PageCachedFile<NoSeekFile> as FileBackend>::open(path, options)
                     .map(|f| Arc::new(f) as Arc<dyn FileBackend>)
             }) as fn(&Path, OpenOptions) -> _,
         ]
@@ -256,6 +267,66 @@ mod tests {
     }
 
     #[test]
+    fn write_all_at_can_write_across_pages() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let dir = tempdir.path();
+
+        let mut options = OpenOptions::new();
+        options.create(true).read(true).write(true);
+
+        let data = [1; 4096 * 3];
+        let offset = 0;
+
+        for (i, backend) in open_backends().enumerate() {
+            let path = dir.join(format!("test_file_{i}.bin"));
+
+            {
+                let file = backend(path.as_path(), options.clone()).unwrap();
+                file.write_all_at(&data, offset).unwrap();
+            }
+
+            let file = File::open(path).unwrap();
+            assert_eq!(file.metadata().unwrap().len(), data.len() as u64);
+            let mut buf = vec![0; 4096 * 3];
+            file.read_exact_at(&mut buf, offset).unwrap();
+            assert_eq!(buf, data);
+        }
+    }
+
+    #[test]
+    fn write_all_at_can_write_data_to_different_pages() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let dir = tempdir.path();
+
+        let mut options = OpenOptions::new();
+        options.create(true).read(true).write(true);
+
+        let data = [1];
+        let offset1 = 0;
+        let offset2 = 10000;
+
+        for (i, backend) in open_backends().enumerate() {
+            let path = dir.join(format!("test_file_{i}.bin"));
+
+            {
+                let file = backend(path.as_path(), options.clone()).unwrap();
+                file.write_all_at(&data, offset1).unwrap();
+                file.write_all_at(&data, offset2).unwrap();
+            }
+
+            let mut file = File::open(path).unwrap();
+            assert_eq!(file.metadata().unwrap().len(), offset2 + 1);
+            let mut buf = [0; 1];
+            file.seek(SeekFrom::Start(offset1)).unwrap();
+            file.read_exact(&mut buf).unwrap();
+            assert_eq!(buf, data);
+            file.seek(SeekFrom::Start(offset2)).unwrap();
+            file.read_exact(&mut buf).unwrap();
+            assert_eq!(buf, data);
+        }
+    }
+
+    #[test]
     fn read_exact_at_fills_whole_buffer_by_reading_at_offset() {
         let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
         let dir = tempdir.path();
@@ -285,6 +356,64 @@ mod tests {
     }
 
     #[test]
+    fn read_exact_at_can_read_across_pages() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let dir = tempdir.path();
+
+        let mut options = OpenOptions::new();
+        options.create(true).read(true).write(true);
+
+        let data = [1; 4096 * 3];
+        let offset = 0;
+
+        for (i, backend) in open_backends().enumerate() {
+            let path = dir.join(format!("test_file_{i}.bin"));
+
+            {
+                let mut file = File::create(path.as_path()).unwrap();
+                file.write_all(&data).unwrap();
+            }
+
+            let file = backend(path.as_path(), options.clone()).unwrap();
+            let mut buf = [0; 4096 * 3];
+            file.read_exact_at(&mut buf, offset).unwrap();
+            assert_eq!(buf, data);
+        }
+    }
+
+    #[test]
+    fn read_exact_at_can_read_data_from_different_pages() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let dir = tempdir.path();
+
+        let mut options = OpenOptions::new();
+        options.create(true).read(true).write(true);
+
+        let data = [1];
+        let offset1 = 0;
+        let offset2 = 10000;
+
+        for (i, backend) in open_backends().enumerate() {
+            let path = dir.join(format!("test_file_{i}.bin"));
+
+            {
+                let mut file = File::create(path.as_path()).unwrap();
+                file.seek(SeekFrom::Start(offset1)).unwrap();
+                file.write_all(&data).unwrap();
+                file.seek(SeekFrom::Start(offset2)).unwrap();
+                file.write_all(&data).unwrap();
+            }
+
+            let file = backend(path.as_path(), options.clone()).unwrap();
+            let mut buf = [1];
+            file.read_exact_at(&mut buf, offset1).unwrap();
+            assert_eq!(buf, data);
+            file.read_exact_at(&mut buf, offset2).unwrap();
+            assert_eq!(buf, data);
+        }
+    }
+
+    #[test]
     fn read_exact_at_fails_when_out_of_bounds() {
         let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
         let dir = tempdir.path();
@@ -303,6 +432,50 @@ mod tests {
             let mut buf = [0; 5];
             let res = file.read_exact_at(&mut buf, 5);
             assert_eq!(res.unwrap_err().kind(), std::io::ErrorKind::UnexpectedEof);
+        }
+    }
+
+    #[test]
+    fn access_same_page_in_parallel_does_not_deadlock() {
+        const THREADS: usize = 128;
+        const PAGES: usize = 100;
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let dir = tempdir.path();
+
+        let mut options = OpenOptions::new();
+        options.create(true).read(true).write(true);
+
+        let data = vec![1; 4096 * PAGES];
+
+        for (i, backend) in open_backends().enumerate() {
+            let path = dir.join(format!("test_file_{i}.bin"));
+
+            {
+                let mut file = File::create(path.as_path()).unwrap();
+                file.write_all(&data).unwrap();
+            }
+
+            let file = backend(path.as_path(), options.clone()).unwrap();
+
+            let barrier = Barrier::new(THREADS);
+
+            std::thread::scope(|s| {
+                for t in 0..THREADS {
+                    let barrier = &barrier;
+                    let file = Arc::clone(&file);
+                    s.spawn(move || {
+                        const BUF_LEN: usize = 4096 / THREADS;
+                        let mut buf = [0; BUF_LEN];
+                        barrier.wait(); // ensure that all threads have at least been spawned before any starts performing I/O
+                        for page in 0..PAGES {
+                            file.read_exact_at(&mut buf, (page * 4096 + t * BUF_LEN) as u64)
+                                .unwrap();
+                            assert_eq!(buf, [1; BUF_LEN]);
+                        }
+                    });
+                }
+            });
         }
     }
 

--- a/rust/src/storage/file/mod.rs
+++ b/rust/src/storage/file/mod.rs
@@ -11,8 +11,14 @@
 mod file_backend;
 mod file_storage_manager;
 mod node_file_storage;
+#[cfg(unix)]
+mod page_cached_file;
+#[cfg(unix)]
+mod page_utils;
 
 pub use file_backend::*;
 #[cfg(test)]
 pub use file_storage_manager::{FileStorageManager, MockFileStorageManager};
 pub use node_file_storage::NodeFileStorage;
+#[cfg(all(test, unix))]
+pub use page_cached_file::PageCachedFile;

--- a/rust/src/storage/file/page_cached_file.rs
+++ b/rust/src/storage/file/page_cached_file.rs
@@ -1,0 +1,250 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+use std::{cmp, fs::OpenOptions, os::unix::fs::OpenOptionsExt, path::Path, sync::Mutex};
+
+use crate::storage::file::{
+    FileBackend,
+    page_utils::{O_DIRECT, O_SYNC, Page},
+};
+
+/// The actual implementation of [`PageCachedFile<F>`], but without concurrency control.
+#[derive(Debug)]
+struct InnerPageCachedFile<F: FileBackend> {
+    file: F,
+    /// The logical file size, which may be smaller than the actual file size due to padding.
+    file_len: u64,
+    page: Box<Page>,
+    page_offset: u64,
+    page_dirty: bool,
+}
+
+// All methods in this impl expect for `load_page_at_offset` correspond to the methods in
+// `FileBackend`, except that they take mutable references since [`PageCachedFile`] adds the
+// synchronization on top using a mutex.
+impl<F: FileBackend> InnerPageCachedFile<F> {
+    /// See [`FileBackend::open`].
+    fn open(path: &Path, mut options: OpenOptions) -> std::io::Result<Self> {
+        let file = F::open(path, options.clone())?;
+        let file_len = file.len()?;
+        let padded_len = file_len.div_ceil(Page::SIZE as u64) * Page::SIZE as u64;
+        file.set_len(padded_len)?;
+        drop(file);
+
+        options.custom_flags(O_DIRECT | O_SYNC);
+        let file = F::open(path, options)?;
+
+        let mut page = Box::new(Page::zeroed());
+        file.read_exact_at(&mut page[..cmp::min(padded_len as usize, Page::SIZE)], 0)?;
+
+        Ok(Self {
+            file,
+            file_len,
+            page,
+            page_offset: 0,
+            page_dirty: false,
+        })
+    }
+
+    /// See [`FileBackend::write_all_at`].
+    fn write_all_at(&mut self, buf: &[u8], offset: u64) -> std::io::Result<()> {
+        self.load_page_at_offset(offset)?;
+
+        let page_start_idx = (offset - self.page_offset) as usize;
+        let page_end_idx = cmp::min(page_start_idx + buf.len(), Page::SIZE);
+        let len = page_end_idx - page_start_idx;
+
+        self.page_dirty = true;
+        self.page[page_start_idx..page_end_idx].copy_from_slice(&buf[..len]);
+
+        self.file_len = cmp::max(self.file_len, offset + len as u64);
+
+        if buf.len() > len {
+            self.write_all_at(&buf[len..], offset + len as u64)?;
+        }
+        Ok(())
+    }
+
+    /// See [`FileBackend::read_exact_at`].
+    fn read_exact_at(&mut self, buf: &mut [u8], offset: u64) -> std::io::Result<()> {
+        if offset + buf.len() as u64 > self.file_len {
+            return Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof));
+        }
+
+        self.load_page_at_offset(offset)?;
+
+        let page_start_idx = (offset - self.page_offset) as usize;
+        let page_end_idx = cmp::min(page_start_idx + buf.len(), Page::SIZE);
+        let len = page_end_idx - page_start_idx;
+
+        buf[..len].copy_from_slice(&self.page[page_start_idx..page_end_idx]);
+
+        if buf.len() > len {
+            self.read_exact_at(&mut buf[len..], offset + len as u64)?;
+        }
+        Ok(())
+    }
+
+    /// See [`FileBackend::flush`].
+    fn flush(&mut self) -> std::io::Result<()> {
+        if self.page_dirty {
+            self.file.write_all_at(&self.page, self.page_offset)?;
+        }
+        self.file.flush()?;
+        self.set_len(self.file_len)
+    }
+
+    /// See [`FileBackend::len`].
+    fn len(&self) -> Result<u64, std::io::Error> {
+        Ok(self.file_len)
+    }
+
+    /// See [`FileBackend::set_len`].
+    fn set_len(&mut self, len: u64) -> std::io::Result<()> {
+        self.file_len = len;
+        self.file.set_len(len)
+    }
+
+    /// Load the page containing the given offset into memory, flushing the current page if dirty.
+    /// If the offset is already within the currently loaded page, this is a no-op.
+    fn load_page_at_offset(&mut self, offset: u64) -> std::io::Result<()> {
+        if offset < self.page_offset || offset >= self.page_offset + Page::SIZE as u64 {
+            // O_DIRECT requires reads and writes to operate on page aligned chunks with sizes that
+            // are multiples of the page size. So the file is padded to have a size of a multiple of
+            // the page size.
+            let padded_len = self.file_len.div_ceil(Page::SIZE as u64) * Page::SIZE as u64;
+            if self.file_len < padded_len {
+                self.file.set_len(padded_len)?;
+            }
+
+            if self.page_dirty {
+                self.file.write_all_at(&self.page, self.page_offset)?;
+            }
+
+            self.page_offset = (offset / Page::SIZE as u64) * Page::SIZE as u64;
+            let len = cmp::min(
+                padded_len.saturating_sub(self.page_offset) as usize,
+                Page::SIZE,
+            );
+            self.file
+                .read_exact_at(&mut self.page[..len], self.page_offset)?;
+            self.page[len..].fill(0);
+            self.page_dirty = false;
+        }
+        Ok(())
+    }
+}
+
+/// A wrapper around a [`FileBackend`] that caches a single page (4096 bytes) in memory.
+/// All read and write operations are performed on this page, which is flushed to the underlying
+/// file when it is dirty and a different page is accessed, or when the file is flushed or dropped.
+/// All file operations use direct I/O to bypass the OS page cache.
+#[derive(Debug)]
+pub struct PageCachedFile<F: FileBackend>(Mutex<InnerPageCachedFile<F>>);
+
+impl<F: FileBackend> FileBackend for PageCachedFile<F> {
+    fn open(path: &Path, options: OpenOptions) -> std::io::Result<Self> {
+        Ok(Self(Mutex::new(InnerPageCachedFile::open(path, options)?)))
+    }
+
+    fn write_all_at(&self, buf: &[u8], offset: u64) -> std::io::Result<()> {
+        self.0.lock().unwrap().write_all_at(buf, offset)
+    }
+
+    fn read_exact_at(&self, buf: &mut [u8], offset: u64) -> std::io::Result<()> {
+        self.0.lock().unwrap().read_exact_at(buf, offset)
+    }
+
+    fn flush(&self) -> std::io::Result<()> {
+        self.0.lock().unwrap().flush()
+    }
+
+    fn len(&self) -> Result<u64, std::io::Error> {
+        self.0.lock().unwrap().len()
+    }
+
+    fn set_len(&self, size: u64) -> std::io::Result<()> {
+        self.0.lock().unwrap().set_len(size)
+    }
+}
+
+impl<F: FileBackend> Drop for PageCachedFile<F> {
+    fn drop(&mut self) {
+        let _ = self.0.lock().unwrap().flush();
+    }
+}
+
+// Note: The tests for `PageCachedFile<F> as FileBackend` are in `file_backend.rs`.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::file::MockFileBackend;
+
+    #[test]
+    fn access_of_cache_data_does_not_trigger_io_operations() {
+        // no expectations on the mock because there should not be no I/O operations.
+        let _file = MockFileBackend::new();
+
+        let file = PageCachedFile(Mutex::new(InnerPageCachedFile {
+            file: _file,
+            file_len: 4096,
+            page: Box::new(Page::zeroed()),
+            page_offset: 0,
+            page_dirty: false,
+        }));
+
+        let data = vec![1u8; 4096];
+        file.write_all_at(&data, 0).unwrap();
+
+        // Read the data back, which should hit the cache and not trigger any I/O operations.
+        let mut read_data = vec![0u8; 4096];
+        file.read_exact_at(&mut read_data, 0).unwrap();
+        assert_eq!(data, read_data);
+
+        // Prevent the destructor from running, which would trigger a flush.
+        std::mem::forget(file);
+    }
+
+    #[test]
+    fn access_non_cached_data_triggers_write_of_old_and_read_of_new_page() {
+        let mut _file = MockFileBackend::new();
+        _file
+            .expect_write_all_at()
+            .withf(|buf, offset| buf == [0; 4096] && *offset == 0)
+            .times(1)
+            .returning(|_, _| Ok(()));
+        _file
+            .expect_read_exact_at()
+            .withf(|_, offset| *offset == 4096)
+            .times(1)
+            .returning(|buf, _| {
+                buf.fill(1);
+                Ok(())
+            });
+
+        let file = PageCachedFile(Mutex::new(InnerPageCachedFile {
+            file: _file,
+            file_len: 8192,
+            page: Box::new(Page::zeroed()),
+            page_offset: 0,
+            page_dirty: false,
+        }));
+
+        // Access data outside of the cached page, which should trigger a write of the old page and
+        // a read of the new page.
+        let mut read_data = vec![0u8; 4096];
+        file.read_exact_at(&mut read_data, 4096).unwrap();
+        assert_eq!(read_data, vec![1u8; 4096]);
+
+        // Prevent the destructor from running, which would trigger a flush.
+        std::mem::forget(file);
+    }
+}

--- a/rust/src/storage/file/page_cached_file.rs
+++ b/rust/src/storage/file/page_cached_file.rs
@@ -19,7 +19,8 @@ use crate::storage::file::{
 #[derive(Debug)]
 struct InnerPageCachedFile<F: FileBackend> {
     file: F,
-    /// The logical file size, which may be smaller than the actual file size which is padded.
+    /// The logical file size, which may be smaller than the actual file size which is padded to a
+    /// multiple of [`Page::SIZE`].
     file_len: u64,
     page: Box<Page>,
     page_index: u64,

--- a/rust/src/storage/file/page_utils.rs
+++ b/rust/src/storage/file/page_utils.rs
@@ -1,0 +1,43 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+use std::ops::{Deref, DerefMut};
+
+pub const O_DIRECT: i32 = 0x4000; // from libc::O_DIRECT
+pub const O_SYNC: i32 = 1052672; // from libc::O_SYNC
+
+/// A page aligned (4096 bytes) byte buffer.
+#[derive(Debug)]
+#[repr(align(4096))]
+pub struct Page([u8; 4096]);
+
+impl Page {
+    /// The size of a page in bytes.
+    pub const SIZE: usize = 4096;
+
+    /// Creates a new page initialized to zero.
+    pub fn zeroed() -> Self {
+        Self([0; 4096])
+    }
+}
+
+impl Deref for Page {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Page {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/rust/src/storage/file/page_utils.rs
+++ b/rust/src/storage/file/page_utils.rs
@@ -19,7 +19,9 @@ pub const O_SYNC: i32 = 1052672; // from libc::O_SYNC
 pub struct Page([u8; 4096]);
 
 impl Page {
-    /// The size of a page in bytes.
+    /// The size of a page in bytes, which is typically 4 KiB on most SSDs.
+    /// If this size is not equivalent to (a multiple of) the system page size,
+    /// page read / writes on files opened with `O_DIRECT` will fail.
     pub const SIZE: usize = 4096;
 
     /// Creates a new page initialized to zero.


### PR DESCRIPTION
This PR adds the `PageCachedFile`, a `FileBackend` that wraps another file backend and caches a single page (4096 bytes) in memory.

Every read and write goes though this page. In case the page does not correspond to the requested offset in the file, the page is written out (only if it is dirty) and then a new page is loaded.
The downside of this is that since all operations go through the same page cache, they are essentially sequentialized (because they need to acquire a mutex), but his might still be faster (depending on the access pattern) because it avoids expensive I/O operations.

Because we are now doing our own caching, the file is opened with flags for direct I/O to bypass the OS page cache.

In an upcoming PR, I will add another implementation which caches multiple pages, at the cost of a more complex implementation.

Part of https://github.com/0xsoniclabs/sonic-admin/issues/366