### PR TITLE
Introduce cryptographic primitives for Verkle tries

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -113,8 +113,9 @@ jobs:
       with:
         workspaces: rust
     - name: cargo test
-      run: cargo test --all-features --all-targets --no-fail-fast
-  
+      # Run tests with --release as some of the crypto primitives for Verkle tries are quite slow otherwise.
+      run: cargo test --release --all-features --all-targets --no-fail-fast
+
   miri:
     name: miri
     runs-on: ubuntu-latest
@@ -131,7 +132,7 @@ jobs:
       with:
         workspaces: rust
     - name: cargo miri test
-      env: 
+      env:
         MIRIFLAGS: "-Zmiri-backtrace=full"
       run: cargo +nightly miri test --no-fail-fast ffi
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,10 +30,161 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
+name = "anyhow"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+
+[[package]]
+name = "ark-bls12-381"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
+dependencies = [
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown 0.13.2",
+ "itertools 0.10.5",
+ "num-traits",
+ "rayon",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ed-on-bls12-381-bandersnatch"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cde0f2aa063a2a5c28d39b47761aa102bda7c13c84fc118a61b87c7b2f785c"
+dependencies = [
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rayon",
+ "rustc_version",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
+dependencies = [
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+ "rayon",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "banderwagon"
+version = "0.1.0"
+source = "git+https://github.com/crate-crypto/rust-verkle.git?rev=e27b8b4#e27b8b4edf1992b4afa636c2fc7983bcc27ddb88"
+dependencies = [
+ "ark-ec",
+ "ark-ed-on-bls12-381-bandersnatch",
+ "ark-ff",
+ "ark-serialize",
+ "rayon",
+]
 
 [[package]]
 name = "bindgen"
@@ -32,7 +195,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -40,7 +203,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -50,16 +213,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "carmen"
 version = "0.1.0"
 dependencies = [
+ "ark-ff",
+ "banderwagon",
  "bindgen",
+ "const-hex",
  "dashmap",
+ "ipa-multipoint",
  "mockall",
  "rstest",
  "rstest_reuse",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.12",
+ "verkle-trie",
  "zerocopy",
 ]
 
@@ -90,10 +267,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6407bff74dea37e0fa3dc1c1c974e5d46405f0c987bf9997a0762adce71eda6"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "dashmap"
@@ -107,6 +334,35 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "crypto-common",
 ]
 
 [[package]]
@@ -163,7 +419,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -190,6 +446,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -223,6 +489,15 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -232,6 +507,12 @@ name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "indexmap"
@@ -244,6 +525,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipa-multipoint"
+version = "0.1.0"
+source = "git+https://github.com/crate-crypto/rust-verkle.git?rev=e27b8b4#e27b8b4edf1992b4afa636c2fc7983bcc27ddb88"
+dependencies = [
+ "banderwagon",
+ "hex",
+ "itertools 0.10.5",
+ "rayon",
+ "sha2",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,6 +553,18 @@ checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -325,7 +639,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -339,10 +653,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "parking_lot_core"
@@ -356,6 +704,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pin-project-lite"
@@ -411,7 +765,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -430,6 +784,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
+dependencies = [
+ "bitflags",
+ "lazy_static",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
 ]
 
 [[package]]
@@ -454,8 +824,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -465,7 +845,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -475,6 +865,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -546,7 +974,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn",
+ "syn 2.0.104",
  "unicode-ident",
 ]
 
@@ -557,8 +985,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a8fb4672e840a587a66fc577a5491375df51ddb88f2a2c2a792598c326fe14"
 dependencies = [
  "quote",
- "rand",
- "syn",
+ "rand 0.8.5",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -590,6 +1018,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +1034,16 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_core"
@@ -618,7 +1062,33 @@ checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -638,6 +1108,17 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -671,11 +1152,31 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -686,7 +1187,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -720,10 +1221,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "verkle-db"
+version = "0.1.0"
+source = "git+https://github.com/crate-crypto/rust-verkle.git?rev=e27b8b4#e27b8b4edf1992b4afa636c2fc7983bcc27ddb88"
+
+[[package]]
+name = "verkle-trie"
+version = "0.1.0"
+source = "git+https://github.com/crate-crypto/rust-verkle.git?rev=e27b8b4#e27b8b4edf1992b4afa636c2fc7983bcc27ddb88"
+dependencies = [
+ "anyhow",
+ "banderwagon",
+ "hex",
+ "ipa-multipoint",
+ "itertools 0.10.5",
+ "once_cell",
+ "rand_chacha 0.3.1",
+ "rayon",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "tempfile",
+ "thiserror 1.0.69",
+ "verkle-db",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -921,5 +1467,25 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -29,6 +29,12 @@ zerocopy = { version = "0.8.26", features = ["derive"] }
 # error handling
 thiserror = "2.0.12"
 
+# verkle trie
+ark-ff = "0.4.2"
+banderwagon = { git = "https://github.com/crate-crypto/rust-verkle.git", rev = "e27b8b4" }
+ipa-multipoint = { git = "https://github.com/crate-crypto/rust-verkle.git", rev = "e27b8b4" }
+verkle-trie = { git = "https://github.com/crate-crypto/rust-verkle.git", rev = "e27b8b4" }
+
 [build-dependencies]
 # FFI
 bindgen = "0.72.0"
@@ -38,10 +44,13 @@ bindgen = "0.72.0"
 rstest = "0.26.1"
 rstest_reuse = "0.7.0"
 
-# mocking
+# parse hex strings into byte arrays (e.g. expected hashes)
+const-hex = "1.14.1"
+
+# automatically generate mocks from traits
 mockall = "0.13.1"
 
-# temporary files
+# create temporary files and directories for tests
 tempfile = "3.20.0"
 
 [lints.rust]

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -131,6 +131,21 @@ exceptions = [
 # Each entry is a crate relative path, and the (opaque) hash of its contents
 #{ path = "LICENSE", hash = 0xbd0eed23 }
 #]
+[[licenses.clarify]]
+crate = "banderwagon"
+expression = "MIT OR Apache-2.0"
+license-files = []
+
+
+[[licenses.clarify]]
+crate = "verkle-db"
+expression = "MIT OR Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+crate = "verkle-trie"
+expression = "MIT OR Apache-2.0"
+license-files = []
 
 [licenses.private]
 # If true, ignores workspace crates that aren't published, or are only
@@ -236,7 +251,7 @@ allow-git = []
 
 [sources.allow-org]
 # github.com organizations to allow git sources for
-github = []
+github = ["crate-crypto"]
 # gitlab.com organizations to allow git sources for
 gitlab = []
 # bitbucket.org organizations to allow git sources for

--- a/rust/src/database/verkle/crypto/commitment.rs
+++ b/rust/src/database/verkle/crypto/commitment.rs
@@ -1,0 +1,245 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+use std::sync::LazyLock;
+
+use ark_ff::{BigInteger, PrimeField};
+use banderwagon::{Element, Fr};
+use ipa_multipoint::committer::{Committer, DefaultCommitter};
+use verkle_trie::constants::CRS;
+use zerocopy::{FromBytes, Immutable, IntoBytes, Unaligned};
+
+use crate::database::verkle::crypto::Scalar;
+
+/// A vector commitment to a sequence of 256 scalar values, using the Pedersen commitment scheme
+/// on the Banderwagon curve.
+///
+/// Commitments can be de-/serialized from/to bytes using zerocopy.
+/// Note that not all byte arrays correspond to valid commitments, i.e., points in the Banderwagon
+/// prime subgroup. Performing any operations on invalid commitments will produce indeterminate
+/// results (garbage in, garbage out).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromBytes, IntoBytes, Immutable, Unaligned)]
+#[repr(C)]
+pub struct Commitment {
+    // We store a byte representation to allow for easy serialization using zerocopy.
+    // Note that conversion from/to banderwagon::Element is NOT trivial (due to compression).
+    // TODO: Benchmark performance impact (https://github.com/0xsoniclabs/sonic-admin/issues/373).
+    point_bytes: [u8; 32],
+}
+
+// Creating the committer is very expensive (in the order of seconds!), so we cache it.
+static COMMITTER: LazyLock<DefaultCommitter> = LazyLock::new(|| DefaultCommitter::new(&CRS.G));
+
+impl Commitment {
+    /// Creates a commitment to the given sequence of scalar values.
+    /// At most 256 values are used, any additional values are ignored.
+    /// If fewer than 256 values are provided, the remaining values are equal to
+    /// the return value of [`Scalar::zero`].
+    pub fn new(values: &[Scalar]) -> Self {
+        // Note: The compiler should be able to eliminate this allocation, because `Fr::from` is a
+        // no-op. If this is not the case and performance critical, Scalar could be marked
+        // `#[repr(transparent)]` and then `iter-map-collect` and be replaced by a `transmute`.
+        let point =
+            COMMITTER.commit_lagrange(&values.iter().map(|v| Fr::from(*v)).collect::<Vec<Fr>>());
+        Commitment {
+            point_bytes: point.to_bytes(),
+        }
+    }
+
+    /// Updates the commitment by changing the value at the given index.
+    pub fn update(&mut self, index: u8, old_value: Scalar, new_value: Scalar) {
+        let delta = Fr::from(new_value) - Fr::from(old_value);
+        let delta_commitment = COMMITTER.scalar_mul(delta, index as usize);
+        self.point_bytes = (self.as_element() + delta_commitment).to_bytes();
+    }
+
+    /// Maps the commitment point to the Banderwagon scalar field,
+    /// allowing it to be used as input to other commitments.
+    pub fn to_scalar(self) -> Scalar {
+        Scalar::from(self.as_element().map_to_scalar_field())
+    }
+
+    /// Returns a hash corresponding to the commitment.
+    /// Used for computing keys during Verkle trie state embedding.
+    pub fn hash(&self) -> [u8; 32] {
+        let scalar = self.as_element().map_to_scalar_field();
+        scalar
+            .into_bigint()
+            .to_bytes_le()
+            .try_into()
+            .expect("scalar field element should be 32 bytes")
+    }
+
+    /// Returns a compressed 32-byte representation of the commitment.
+    /// Used as the state root commitment in Verkle tries.
+    pub fn compress(&self) -> [u8; 32] {
+        self.point_bytes
+    }
+
+    fn as_element(&self) -> Element {
+        // In case the byte sequence does not correspond to a point in the prime subgroup,
+        // we cannot construct a banderwagon::Element from it and instead return the identity
+        // element (garbage in, garbage out).
+        match Element::from_bytes(&self.point_bytes) {
+            Some(e) => e,
+            None => Element::zero(),
+        }
+    }
+}
+
+impl From<&Commitment> for Element {
+    fn from(commitment: &Commitment) -> Self {
+        commitment.as_element()
+    }
+}
+
+impl Default for Commitment {
+    fn default() -> Self {
+        Commitment {
+            point_bytes: Element::zero().to_bytes(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod slow_tests {
+    use super::*;
+    use crate::database::verkle::test_utils::FromIndexValues;
+
+    #[test]
+    fn default_is_commitment_to_zero_values() {
+        let default_commitment = Commitment::default();
+        let zero_values = vec![Scalar::from(0); 256];
+        let zero_commitment = Commitment::new(&zero_values);
+        assert_eq!(default_commitment, zero_commitment);
+    }
+
+    #[test]
+    fn commitments_to_different_values_are_different() {
+        let c1_values: Vec<_> = (0..256).map(Scalar::from).collect();
+        let c2_values: Vec<_> = (0..256).map(|i| Scalar::from(i * 2)).collect();
+        let c1 = Commitment::new(&c1_values);
+        let c2 = Commitment::new(&c2_values);
+        assert_eq!(c1, c1);
+        assert_ne!(c1, c2);
+    }
+
+    #[test]
+    fn new_commits_to_up_to_256_values() {
+        let values: Vec<_> = (0..1024).map(Scalar::from).collect();
+        let c1 = Commitment::new(&values);
+
+        let values: Vec<_> = (0..512).map(Scalar::from).collect();
+        let c2 = Commitment::new(&values);
+
+        let values: Vec<_> = (0..256).map(Scalar::from).collect();
+        let c3 = Commitment::new(&values);
+
+        assert_eq!(c1, c2);
+        assert_eq!(c1, c3);
+
+        let values: Vec<_> = (0..255).map(Scalar::from).collect();
+        let c4 = Commitment::new(&values);
+
+        assert_ne!(c3, c4);
+
+        let values = Vec::from_index_values(Scalar::zero(), &[(0, Scalar::from(42))]);
+        let c5 = Commitment::new(&values);
+
+        let values = Vec::from_index_values(
+            Scalar::zero(),
+            &[(0, Scalar::from(42)), (255, Scalar::from(0))],
+        );
+        let c6 = Commitment::new(&values);
+
+        assert_eq!(c5, c6);
+    }
+
+    #[test]
+    fn update_allows_modifying_individual_values() {
+        let mut values: Vec<_> = (0..256).map(Scalar::from).collect();
+        let mut commitment = Commitment::new(&values);
+
+        for i in 0..256 {
+            let old_value = values[i];
+            values[i] = Scalar::from(i as u64 * 10);
+            commitment.update(i as u8, old_value, values[i]);
+            let expected_commitment = Commitment::new(&values);
+            assert_eq!(commitment, expected_commitment);
+        }
+    }
+
+    #[test]
+    fn to_scalar_maps_point_to_scalar_field() {
+        let c1 = Commitment::default();
+        assert_eq!(c1.to_scalar(), Scalar::zero());
+        let c2 = Commitment::new(&[Scalar::from(42)]);
+        assert_ne!(c2.to_scalar(), Scalar::zero());
+        assert_ne!(c2.to_scalar(), Scalar::from(42));
+    }
+
+    #[test]
+    fn hash_works_as_expected() {
+        let hash = Commitment::default().hash();
+        let expected = [0u8; 32];
+        assert_eq!(hash, expected);
+
+        let values = vec![Scalar::from(12)];
+        let hash = Commitment::new(&values).hash();
+        // Value generated with Go reference implementation
+        let expected = "0xb0852d6ab1ab96f7a08e042125eb4e2c11fb3a11a63cbe60246e2f8351fe9017";
+        assert_eq!(const_hex::encode_prefixed(hash), expected);
+
+        let values = vec![Scalar::from(12), Scalar::from(13), Scalar::from(42)];
+        let hash = Commitment::new(&values).hash();
+        // Value generated with Go reference implementation
+        let expected = "0x029109502e1c90f2306e55eba15f3115f6a78edb3494246bf15b2def1911fb14";
+        assert_eq!(const_hex::encode_prefixed(hash), expected);
+    }
+
+    #[test]
+    fn compress_returns_commitment_in_compressed_form() {
+        let values = vec![Scalar::from(12)];
+        let commitment = Commitment::new(&values);
+        let compressed = commitment.compress();
+        // The compressed form is simply the internal byte representation
+        let uncompressed = Commitment::read_from_bytes(&compressed).unwrap();
+        assert_eq!(uncompressed, commitment);
+    }
+
+    #[test]
+    fn can_be_serialized_to_and_from_bytes() {
+        let c1 = Commitment::new(&vec![Scalar::from(42); 256]);
+        let c2 = Commitment::new(&vec![Scalar::from(33); 256]);
+        let c1_bytes = c1.as_bytes();
+        let c2_bytes = c2.as_bytes();
+        assert_ne!(c1_bytes, c2_bytes);
+        let c1_from_bytes = Commitment::read_from_bytes(c1_bytes).unwrap();
+        let c2_from_bytes = Commitment::read_from_bytes(c2_bytes).unwrap();
+        assert_eq!(c1, c1_from_bytes);
+        assert_eq!(c2, c2_from_bytes);
+    }
+
+    #[test]
+    fn invalid_commitment_can_still_be_used() {
+        let random_bytes = [0x01; 32];
+        // First check that this byte sequence is in fact invalid
+        assert!(Element::from_bytes(&random_bytes).is_none());
+
+        let mut c = Commitment::read_from_bytes(&random_bytes).unwrap();
+
+        // These calls should not panic
+        c.update(0, Scalar::from(0), Scalar::from(1));
+        let _ = c.as_element();
+        let _ = c.to_scalar();
+        let _ = c.hash();
+        let _ = c.compress();
+    }
+}

--- a/rust/src/database/verkle/crypto/mod.rs
+++ b/rust/src/database/verkle/crypto/mod.rs
@@ -8,6 +8,11 @@
 // On the date above, in accordance with the Business Source License, use of
 // this software will be governed by the GNU Lesser General Public License v3.
 
-mod crypto;
-#[cfg(test)]
-mod test_utils;
+mod commitment;
+mod opening;
+mod scalar;
+
+pub use commitment::Commitment;
+#[expect(unused)]
+pub use opening::Opening;
+pub use scalar::Scalar;

--- a/rust/src/database/verkle/crypto/opening.rs
+++ b/rust/src/database/verkle/crypto/opening.rs
@@ -1,0 +1,208 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+use banderwagon::Fr;
+use ipa_multipoint::{
+    lagrange_basis::LagrangeBasis,
+    multiproof::{MultiPoint, MultiPointProof, ProverQuery, VerifierQuery},
+    transcript::Transcript,
+};
+use verkle_trie::constants::{CRS, PRECOMPUTED_WEIGHTS};
+
+use crate::database::verkle::crypto::{Commitment, Scalar};
+
+/// A proof demonstrating that a [`Commitment`] contains certain values at specific positions.
+///
+/// It uses the Inner Product Argument (IPA) proof system for Pedersen commitments.
+/// Details: <https://dankradfeist.de/ethereum/2021/07/27/inner-product-arguments.html>
+pub struct Opening {
+    pub proof: MultiPointProof,
+}
+
+#[cfg_attr(not(test), expect(unused))]
+impl Opening {
+    /// Creates a new opening for a given commitment, proving that it contains the
+    /// value at the specified position. The opening can then be verified using
+    /// [`Self::verify_single`].
+    ///
+    /// For the opening to be valid, the `values` slice must contain the same sequence
+    /// of scalars that were used to create the commitment.
+    ///
+    /// NOTE: This is fairly expensive operation (tens of milliseconds).
+    /// Prefer to open multiple values or even multiple commitments at once, if possible.
+    pub fn for_single(commitment: &Commitment, values: &[Scalar], position: u8) -> Self {
+        let mut transcript = Transcript::new(b"vt");
+        let query = ProverQuery {
+            commitment: commitment.into(),
+            point: position as usize,
+            result: Fr::from(values[position as usize]),
+            poly: LagrangeBasis::new(values.iter().map(|v| Fr::from(*v)).collect()),
+        };
+        let proof = MultiPoint::open(
+            CRS.clone(),
+            &PRECOMPUTED_WEIGHTS,
+            &mut transcript,
+            vec![query],
+        );
+        Opening { proof }
+    }
+
+    /// Like [`Self::for_single`], but creates an opening that proves all values
+    /// contained in the commitment at once. The opening can then be verified using
+    /// [`Self::verify_all`].
+    pub fn for_all(commitment: &Commitment, values: &[Scalar]) -> Self {
+        let mut transcript = Transcript::new(b"vt");
+        let poly = LagrangeBasis::new(values.iter().map(|v| Fr::from(*v)).collect());
+        let queries: Vec<ProverQuery> = values
+            .iter()
+            .enumerate()
+            .map(|(i, value)| ProverQuery {
+                commitment: commitment.into(),
+                point: i,
+                result: Fr::from(*value),
+                poly: poly.clone(),
+            })
+            .collect();
+        let proof = MultiPoint::open(CRS.clone(), &PRECOMPUTED_WEIGHTS, &mut transcript, queries);
+        Opening { proof }
+    }
+
+    /// Verifies that the opening (created with [`Self::for_single`]) proves that the given
+    /// commitment contains the specified value at the specified position.
+    pub fn verify_single(&self, commitment: &Commitment, position: u8, value: &Scalar) -> bool {
+        let mut transcript = Transcript::new(b"vt");
+        let query = VerifierQuery {
+            commitment: commitment.into(),
+            point: Fr::from(position),
+            result: Fr::from(*value),
+        };
+        self.proof
+            .check(&CRS, &PRECOMPUTED_WEIGHTS, &[query], &mut transcript)
+    }
+
+    /// Verifies that the opening (created with [`Self::for_all`]) proves that the given
+    /// commitment contains the specified sequence of values.
+    pub fn verify_all(&self, commitment: &Commitment, values: &[Scalar]) -> bool {
+        let mut transcript = Transcript::new(b"vt");
+        let queries: Vec<VerifierQuery> = values
+            .iter()
+            .enumerate()
+            .map(|(i, value)| VerifierQuery {
+                commitment: commitment.into(),
+                point: Fr::from(i as u8),
+                result: Fr::from(*value),
+            })
+            .collect();
+        self.proof
+            .check(&CRS, &PRECOMPUTED_WEIGHTS, &queries, &mut transcript)
+    }
+}
+
+#[cfg(test)]
+mod slow_tests {
+    use super::*;
+
+    #[test]
+    fn for_single_can_be_used_to_proof_individual_values() {
+        let values: Vec<_> = (0..256).map(|i| Scalar::from(i + 1)).collect();
+        let commitment = Commitment::new(&values);
+
+        // Since opening is expensive, we only test a few positions.
+        for i in [0, 5, 42, 100, 254, 255] {
+            let opening = Opening::for_single(&commitment, &values, i);
+            assert!(
+                opening.verify_single(&commitment, i, &values[i as usize].clone()),
+                "failed to verify position {i}"
+            );
+            assert!(
+                !opening.verify_single(&commitment, i, &Scalar::from(i as u64 + 2)),
+                "verified wrong value at position {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn using_different_values_results_in_invalid_opening() {
+        let values_1: Vec<_> = (0..256).map(|i| Scalar::from(i + 1)).collect();
+        let values_2: Vec<_> = (0..256).map(|i| Scalar::from(i + 2)).collect();
+        let commitment = Commitment::new(&values_1);
+
+        for i in [0, 5, 42, 100, 254, 255] {
+            let opening = Opening::for_single(&commitment, &values_2, i);
+            assert!(
+                !opening.verify_single(&commitment, i, &values_1[i as usize].clone()),
+                "verified value using invalid opening at position {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn commitment_update_can_be_used_to_proof_modified_values() {
+        let mut values: Vec<_> = (0..256).map(|i| Scalar::from(i + 1)).collect();
+        let mut commitment = Commitment::new(&values);
+
+        for i in [0, 5, 42, 100, 254, 255] {
+            let old_value = values[i];
+            values[i] = Scalar::from(i as u64 * 10);
+            commitment.update(i as u8, old_value, values[i]);
+            let opening = Opening::for_single(&commitment, &values, i as u8);
+
+            assert!(
+                opening.verify_single(&commitment, i as u8, &values[i].clone()),
+                "failed to verify updated position {i}"
+            );
+
+            assert!(
+                !opening.verify_single(&commitment, i as u8, &old_value),
+                "verified outdated value at position {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn for_all_can_be_used_to_proof_all_values() {
+        let values: Vec<_> = (0..256).map(|i| Scalar::from(i + 1)).collect();
+        let commitment = Commitment::new(&values);
+        let opening = Opening::for_all(&commitment, &values);
+
+        assert!(opening.verify_all(&commitment, &values));
+
+        for i in 0..256 {
+            let mut wrong_values = values.clone();
+            wrong_values[i] = Scalar::from(9999);
+            assert!(
+                !opening.verify_all(&commitment, &wrong_values),
+                "verified wrong value at position {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn single_proof_does_not_verify_all() {
+        let values: Vec<_> = (0..256).map(|i| Scalar::from(i + 1)).collect();
+        let commitment = Commitment::new(&values);
+        let opening = Opening::for_single(&commitment, &values, 42);
+        assert!(
+            !opening.verify_all(&commitment, &values),
+            "single proof verified all values"
+        );
+    }
+
+    #[test]
+    fn all_proof_does_not_verify_single() {
+        let values: Vec<_> = (0..256).map(|i| Scalar::from(i + 1)).collect();
+        let commitment = Commitment::new(&values);
+        let opening = Opening::for_all(&commitment, &values);
+        assert!(
+            !opening.verify_single(&commitment, 42, &values[42].clone()),
+            "all proof verified single value"
+        );
+    }
+}

--- a/rust/src/database/verkle/crypto/scalar.rs
+++ b/rust/src/database/verkle/crypto/scalar.rs
@@ -1,0 +1,160 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+use ark_ff::{BigInteger, fields::PrimeField};
+use banderwagon::Fr;
+
+/// A value from the Banderwagon scalar field, which uses a 253-bit prime.
+/// One or more scalars can be committed to by creating a
+/// [`crate::database::verkle::crypto::Commitment`].
+/// Scalars can safely commit to values of at most 252 bits (slightly more than 31 bytes).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Scalar(Fr);
+
+impl Scalar {
+    /// Returns the scalar value representing zero.
+    /// Same as [`Scalar::from`]`(0)`.
+    pub fn zero() -> Self {
+        Scalar(Fr::from(0))
+    }
+
+    /// Creates a new scalar from the given little-endian byte slice.
+    /// At most 31 bytes are read from the slice, shorter slices are right-padded with zeros.
+    pub fn from_le_bytes(bytes: &[u8]) -> Self {
+        Scalar(Fr::from_le_bytes_mod_order(&bytes[..bytes.len().min(31)]))
+    }
+
+    /// Sets the 128th bit of the scalar to 1.
+    /// This is a convenience method used for computing the commitment of a
+    /// leaf node in Ethereum Verkle tries, where the 128th bit indicates
+    /// that a value has been set before (to distinguish it from the default
+    /// value, which is needed for future state expiry schemes).
+    pub fn set_bit128(&mut self) {
+        let mut bytes = self.0.into_bigint().to_bytes_le();
+        bytes[16] |= 0x01;
+        self.0 = Fr::from_le_bytes_mod_order(&bytes);
+    }
+}
+
+impl From<u64> for Scalar {
+    fn from(value: u64) -> Self {
+        Scalar(Fr::from(value))
+    }
+}
+
+impl From<Scalar> for Fr {
+    fn from(scalar: Scalar) -> Self {
+        scalar.0
+    }
+}
+
+impl From<Fr> for Scalar {
+    fn from(fr: Fr) -> Self {
+        Scalar(fr)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_returns_zero_scalar() {
+        let zero = Scalar::zero();
+        assert_eq!(zero.0, Fr::from(0));
+    }
+
+    #[test]
+    fn can_be_created_from_u64() {
+        let values = [0, 1, 42, u64::MAX - 1, u64::MAX];
+        for value in values {
+            assert_eq!(Scalar::from(value).0, Fr::from(value));
+        }
+    }
+
+    #[test]
+    fn can_be_converted_to_and_from_banderwagon_fr() {
+        let values = [0, 1, 42, u64::MAX - 1, u64::MAX];
+        for value in values {
+            let scalar = Scalar::from(value);
+            let fr = Fr::from(scalar);
+            assert_eq!(fr, Fr::from(value));
+
+            let scalar2 = Scalar::from(fr);
+            assert_eq!(scalar, scalar2);
+        }
+    }
+
+    #[test]
+    fn can_be_compared() {
+        let scalar1 = Scalar::from(42);
+        let scalar2 = Scalar::from(42);
+        let scalar3 = Scalar::from(43);
+
+        assert_eq!(scalar1, scalar1);
+        assert_eq!(scalar1, scalar2);
+        assert_ne!(scalar1, scalar3);
+    }
+
+    #[test]
+    fn from_le_bytes_interprets_slice_as_little_endian() {
+        let scalar = Scalar::from_le_bytes(&[]);
+        assert_eq!(scalar, Scalar::from(0));
+
+        let scalar = Scalar::from_le_bytes(&[0x01]);
+        assert_eq!(scalar, Scalar::from(1));
+
+        let scalar = Scalar::from_le_bytes(&[0x01, 0x02]);
+        assert_eq!(scalar, Scalar::from(0x0201));
+
+        let scalar = Scalar::from_le_bytes(&[0x01, 0x02, 0x03]);
+        assert_eq!(scalar, Scalar::from(0x030201));
+    }
+
+    #[test]
+    fn from_le_bytes_uses_at_most_31_bytes() {
+        let bytes: Vec<u8> = (0..40).collect();
+        let scalar = Scalar::from_le_bytes(&bytes);
+        let mut expected_bytes = [0u8; 32];
+        expected_bytes[..31].copy_from_slice(&bytes[..31]);
+        let expected_scalar = Scalar(Fr::from_le_bytes_mod_order(&expected_bytes));
+        assert_eq!(scalar, expected_scalar);
+    }
+
+    #[test]
+    fn set_bit128_sets_correct_bit() {
+        // Starting from zero
+        let mut scalar = Scalar::from(0);
+        assert_eq!(scalar.0.into_bigint().to_bytes_be(), &[0; 32]);
+
+        scalar.set_bit128();
+        let mut expected = [0; 32];
+        expected[15] = 0x01;
+        assert_eq!(scalar.0.into_bigint().to_bytes_be(), expected);
+
+        scalar.set_bit128();
+        assert_eq!(scalar.0.into_bigint().to_bytes_be(), expected);
+
+        // Starting from non-zero value
+        let mut scalar = Scalar::from(0xf1f2f3f4f5f6f7f8);
+        let mut expected = [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xf1, 0xf2,
+            0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8,
+        ];
+        assert_eq!(scalar.0.into_bigint().to_bytes_be(), expected);
+
+        scalar.set_bit128();
+        expected[15] = 0x01;
+        assert_eq!(scalar.0.into_bigint().to_bytes_be(), expected);
+
+        scalar.set_bit128();
+        assert_eq!(scalar.0.into_bigint().to_bytes_be(), expected);
+    }
+}

--- a/rust/src/database/verkle/test_utils.rs
+++ b/rust/src/database/verkle/test_utils.rs
@@ -64,7 +64,7 @@ mod tests {
     #[test]
     fn from_index_values_creates_vector_with_provided_default_and_values() {
         let result = Vec::<u8>::from_index_values(1, &[]);
-        assert_eq!(result, vec![]);
+        assert_eq!(result, vec![0u8; 0]);
 
         let result = Vec::<u8>::from_index_values(0, &[(0, 1), (2, 3)]);
         assert_eq!(result, vec![1, 0, 3]);


### PR DESCRIPTION
This adds three new types that form the cryptographic foundation for Verkle tries:

- `Scalar` is a value from the Banderwagon scalar field.
- `Commitment` is a vector commitment to a sequence of 256 scalar values, using the Pedersen commitment scheme.
- `Opening` is a proof demonstrating that a commitment contains certain values at specific positions.

The types are wrappers around similar types from the [`crate-crypto/rust-verkle`](https://github.com/crate-crypto/rust-verkle) repository (currently not available on crates.io), which was the best implementation of the Banderwagon curve and related functionality that I could find, even though it does not seem to be actively maintained at the moment. Notably, the `crate-crypto` organization also owns the `go-ipa` package, which is the one @HerbertJordan used for the Go reference implementation in #52.

Additional new dependencies include `ark-ff`, which is a library for finite field math operations, which `rust-verkle` also uses internally, and `const-hex`, for parsing hex-strings of expected hashes generated by the Go reference implementation.

The jury is still out on the performance of these primitives, preliminary results seem to indicate that commitments are reasonably fast (in the order of ~500us), while openings are quite slow (~30ms for a single value). However, I believe this is somewhat expected, and I don't think that we will be creating openings for individual values anyway. The library supports creating openings for multiple values and even multiple commitments at once, which should yield substantial performance gains.

NOTE that the above performance numbers are for **release builds**. In debug builds, the operations are unfortunately quite slow, leading to some tests running for 30-50s on my machine. Not sure what to do about this, other than `cargo test --release`.

Depends on #113.
Closes https://github.com/0xsoniclabs/sonic-admin/issues/267.