### PR TITLE
Use rstest for file backend tests

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -56,6 +56,8 @@ dependencies = [
  "bindgen",
  "dashmap",
  "mockall",
+ "rstest",
+ "rstest_reuse",
  "tempfile",
  "thiserror",
  "zerocopy",
@@ -101,7 +103,7 @@ checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
- "hashbrown",
+ "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -118,6 +120,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -142,6 +150,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,7 +212,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -164,6 +226,22 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
+name = "indexmap"
+version = "2.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.0",
+]
 
 [[package]]
 name = "itertools"
@@ -280,6 +358,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "predicates"
 version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +415,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +446,36 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -378,10 +516,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rstest_reuse"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a8fb4672e840a587a66fc577a5491375df51ddb88f2a2c2a792598c326fe14"
+dependencies = [
+ "quote",
+ "rand",
+ "syn",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -403,10 +596,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde_core"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -432,7 +657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -465,10 +690,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3effe7c0e86fdff4f69cdd2ccc1b96f933e24811c5441d44904e8683e27184b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -624,6 +885,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -34,6 +34,10 @@ thiserror = "2.0.12"
 bindgen = "0.72.0"
 
 [dev-dependencies]
+# testing
+rstest = "0.26.1"
+rstest_reuse = "0.7.0"
+
 # mocking
 mockall = "0.13.1"
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -7,6 +7,7 @@
 //
 // On the date above, in accordance with the Business Source License, use of
 // this software will be governed by the GNU Lesser General Public License v3.
+#![cfg_attr(test, allow(non_snake_case))]
 
 use std::mem::MaybeUninit;
 

--- a/rust/src/storage/file/file_backend.rs
+++ b/rust/src/storage/file/file_backend.rs
@@ -139,115 +139,110 @@ mod tests {
         utils::test_dir::{Permissions, TestDir},
     };
 
-    fn open_backends()
-    -> impl Iterator<Item = fn(&Path, OpenOptions) -> std::io::Result<Arc<dyn FileBackend>>> {
-        [
-            (|path, options| {
-                <SeekFile as FileBackend>::open(path, options)
-                    .map(|f| Arc::new(f) as Arc<dyn FileBackend>)
-            }) as fn(&Path, OpenOptions) -> _,
-            (|path, options| {
-                <NoSeekFile as FileBackend>::open(path, options)
-                    .map(|f| Arc::new(f) as Arc<dyn FileBackend>)
-            }) as fn(&Path, OpenOptions) -> _,
-            #[cfg(unix)]
-            {
-                (|path, options| {
-                    <PageCachedFile<SeekFile> as FileBackend>::open(path, options)
-                        .map(|f| Arc::new(f) as Arc<dyn FileBackend>)
-                }) as fn(&Path, OpenOptions) -> _
-            },
-            #[cfg(unix)]
-            {
-                (|path, options| {
-                    <PageCachedFile<NoSeekFile> as FileBackend>::open(path, options)
-                        .map(|f| Arc::new(f) as Arc<dyn FileBackend>)
-                }) as fn(&Path, OpenOptions) -> _
-            },
-        ]
-        .into_iter()
-    }
+    type OpenBackendFn = fn(&Path, OpenOptions) -> std::io::Result<Arc<dyn FileBackend>>;
 
-    #[test]
-    fn open_creates_and_opens_file() {
+    #[rstest_reuse::template]
+    #[rstest::rstest]
+    #[case::seek_file(
+        (|path, options| {
+            <SeekFile as FileBackend>::open(path, options)
+                .map(|f| Arc::new(f) as Arc<dyn FileBackend>)
+        }) as OpenBackendFn
+    )]
+    #[case::no_seek_file(
+        (|path, options| {
+            <NoSeekFile as FileBackend>::open(path, options)
+                .map(|f| Arc::new(f) as Arc<dyn FileBackend>)
+        }) as OpenBackendFn
+    )]
+    #[case::page_cached_file__seek_file(
+        (|path, options| {
+            <PageCachedFile<SeekFile> as FileBackend>::open(path, options)
+                .map(|f| Arc::new(f) as Arc<dyn FileBackend>)
+        }) as OpenBackendFn
+    )]
+    #[case::page_cached_file__no_seek_file(
+        (|path, options| {
+            <PageCachedFile<NoSeekFile> as FileBackend>::open(path, options)
+                .map(|f| Arc::new(f) as Arc<dyn FileBackend>)
+        }) as OpenBackendFn
+    )]
+    fn open_backend(#[case] f: OpenBackendFn) {}
+
+    #[rstest_reuse::apply(open_backend)]
+    fn open_creates_and_opens_file(#[case] backend_open_fn: OpenBackendFn) {
         let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
-        let dir = tempdir.path();
+        let path = tempdir.path().join("test_file.bin");
 
         let mut options = OpenOptions::new();
         options.create(true).read(true).write(true);
 
-        for (i, backend) in open_backends().enumerate() {
-            let path = dir.join(format!("test_file_{i}.bin"));
-            let file = backend(path.as_path(), options.clone());
-            assert!(file.unwrap().len().unwrap() == 0);
-            assert!(std::fs::exists(path).unwrap());
-        }
+        let backend = backend_open_fn(path.as_path(), options.clone()).unwrap();
+        assert_eq!(backend.len().unwrap(), 0);
+        assert!(std::fs::exists(path).unwrap());
     }
 
-    #[test]
-    fn open_opens_existing_file() {
+    #[rstest_reuse::apply(open_backend)]
+    fn open_opens_existing_file(#[case] backend_open_fn: OpenBackendFn) {
         let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
-        let dir = tempdir.path();
+        let path = tempdir.path().join("test_file.bin");
 
         let mut options = OpenOptions::new();
         options.create(true).read(true).write(true);
 
-        for (i, backend) in open_backends().enumerate() {
-            let path = dir.join(format!("test_file_{i}.bin"));
-
-            {
-                let mut file = File::create(path.as_path()).unwrap();
-                file.write_all(&[0; 10]).unwrap();
-            }
-
-            let file = backend(path.as_path(), options.clone());
-            assert!(file.unwrap().len().unwrap() == 10);
+        {
+            let mut file = File::create(path.as_path()).unwrap();
+            file.write_all(&[0; 10]).unwrap();
         }
+
+        let backend = backend_open_fn(path.as_path(), options.clone()).unwrap();
+        assert_eq!(backend.len().unwrap(), 10);
     }
 
-    #[test]
-    fn open_fails_if_file_is_locked() {
+    #[rstest_reuse::apply(open_backend)]
+    fn open_fails_if_file_is_locked(#[case] backend_open_fn: OpenBackendFn) {
         let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
-        let dir = tempdir.path();
+        let path = tempdir.path().join("test_file.bin");
 
         let mut options = OpenOptions::new();
         options.create(true).read(true).write(true);
 
-        for (i, backend) in open_backends().enumerate() {
-            let path = dir.join(format!("test_file_{i}.bin"));
+        // Open the file once and lock it.
+        let file = backend_open_fn(path.as_path(), options.clone());
+        assert!(file.is_ok());
 
-            // open the file once and lock it
-            let file = backend(path.as_path(), options.clone());
-            assert!(file.is_ok());
-
-            // try to open it again, should fail
-            let file = backend(path.as_path(), options.clone());
-            assert!(file.map(|_| ()).unwrap_err().kind() == std::io::ErrorKind::WouldBlock);
-        }
+        // Try to open it again, while the first on is still open. This should fail.
+        let file = backend_open_fn(path.as_path(), options.clone());
+        assert_eq!(
+            file.map(|_| ()).unwrap_err().kind(),
+            std::io::ErrorKind::WouldBlock
+        );
     }
 
-    #[test]
-    fn open_fails_if_no_permissions() {
+    #[rstest_reuse::apply(open_backend)]
+    fn open_fails_if_no_permissions(#[case] backend_open_fn: OpenBackendFn) {
         let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
-        let dir = tempdir.path();
+        let path = tempdir.path().join("test_file.bin");
 
-        let path = dir.join("test_file.bin");
         let _ = File::create(path.as_path()).unwrap();
         tempdir.set_permissions(Permissions::ReadOnly).unwrap();
 
         let mut options = OpenOptions::new();
         options.read(true).write(true);
 
-        for backend in open_backends() {
-            let file = backend(path.as_path(), options.clone());
-            assert!(file.is_err());
-        }
+        assert_eq!(
+            backend_open_fn(path.as_path(), options.clone())
+                .map(|_| ())
+                .unwrap_err()
+                .kind(),
+            std::io::ErrorKind::PermissionDenied
+        );
     }
 
-    #[test]
-    fn write_all_at_writes_whole_buffer_at_offset() {
+    #[rstest_reuse::apply(open_backend)]
+    fn write_all_at_writes_whole_buffer_at_offset(#[case] backend_open_fn: OpenBackendFn) {
         let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
-        let dir = tempdir.path();
+        let path = tempdir.path().join("test_file.bin");
 
         let mut options = OpenOptions::new();
         options.create(true).read(true).write(true);
@@ -255,27 +250,23 @@ mod tests {
         let data = [1; 10];
         let offset = 5;
 
-        for (i, backend) in open_backends().enumerate() {
-            let path = dir.join(format!("test_file_{i}.bin"));
-
-            {
-                let file = backend(path.as_path(), options.clone()).unwrap();
-                file.write_all_at(&data, offset).unwrap();
-            }
-            // file: [_, _, _, _, _, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-
-            let mut file = File::open(path).unwrap();
-            assert_eq!(file.metadata().unwrap().len(), 15);
-            let mut buf = vec![0; 15];
-            file.read_exact(&mut buf).unwrap();
-            assert_eq!(buf[5..], data);
+        {
+            let backend = backend_open_fn(path.as_path(), options.clone()).unwrap();
+            backend.write_all_at(&data, offset).unwrap();
         }
+        // file: [_, _, _, _, _, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+
+        let mut file = File::open(path).unwrap();
+        assert_eq!(file.metadata().unwrap().len(), 15);
+        let mut buf = vec![0; 15];
+        file.read_exact(&mut buf).unwrap();
+        assert_eq!(buf[5..], data);
     }
 
-    #[test]
-    fn write_all_at_can_write_across_pages() {
+    #[rstest_reuse::apply(open_backend)]
+    fn write_all_at_can_write_across_pages(#[case] backend_open_fn: OpenBackendFn) {
         let tempdir = tempfile::tempdir().unwrap();
-        let dir = tempdir.path();
+        let path = tempdir.path().join("test_file.bin");
 
         let mut options = OpenOptions::new();
         options.create(true).read(true).write(true);
@@ -283,26 +274,22 @@ mod tests {
         let data = [1; Page::SIZE * 3];
         let offset = 0;
 
-        for (i, backend) in open_backends().enumerate() {
-            let path = dir.join(format!("test_file_{i}.bin"));
-
-            {
-                let file = backend(path.as_path(), options.clone()).unwrap();
-                file.write_all_at(&data, offset).unwrap();
-            }
-
-            let file = File::open(path).unwrap();
-            assert_eq!(file.metadata().unwrap().len(), data.len() as u64);
-            let mut buf = vec![0; Page::SIZE * 3];
-            file.read_exact_at(&mut buf, offset).unwrap();
-            assert_eq!(buf, data);
+        {
+            let backend = backend_open_fn(path.as_path(), options.clone()).unwrap();
+            backend.write_all_at(&data, offset).unwrap();
         }
+
+        let file = File::open(path).unwrap();
+        assert_eq!(file.metadata().unwrap().len(), data.len() as u64);
+        let mut buf = vec![0; Page::SIZE * 3];
+        file.read_exact_at(&mut buf, offset).unwrap();
+        assert_eq!(buf, data);
     }
 
-    #[test]
-    fn write_all_at_can_write_data_to_different_pages() {
+    #[rstest_reuse::apply(open_backend)]
+    fn write_all_at_can_write_data_to_different_pages(#[case] backend_open_fn: OpenBackendFn) {
         let tempdir = tempfile::tempdir().unwrap();
-        let dir = tempdir.path();
+        let path = tempdir.path().join("test_file.bin");
 
         let mut options = OpenOptions::new();
         options.create(true).read(true).write(true);
@@ -311,231 +298,183 @@ mod tests {
         let offset1 = 0;
         let offset2 = 10000;
 
-        for (i, backend) in open_backends().enumerate() {
-            let path = dir.join(format!("test_file_{i}.bin"));
+        {
+            let backend = backend_open_fn(path.as_path(), options.clone()).unwrap();
+            backend.write_all_at(&data, offset1).unwrap();
+            backend.write_all_at(&data, offset2).unwrap();
+        }
 
-            {
-                let file = backend(path.as_path(), options.clone()).unwrap();
-                file.write_all_at(&data, offset1).unwrap();
-                file.write_all_at(&data, offset2).unwrap();
-            }
+        let mut file = File::open(path).unwrap();
+        assert_eq!(file.metadata().unwrap().len(), offset2 + 1);
+        let mut buf = [0; 1];
+        file.seek(SeekFrom::Start(offset1)).unwrap();
+        file.read_exact(&mut buf).unwrap();
+        assert_eq!(buf, data);
+        buf = [0; 1];
+        file.seek(SeekFrom::Start(offset2)).unwrap();
+        file.read_exact(&mut buf).unwrap();
+        assert_eq!(buf, data);
+    }
 
-            let mut file = File::open(path).unwrap();
-            assert_eq!(file.metadata().unwrap().len(), offset2 + 1);
-            let mut buf = [0; 1];
+    #[rstest_reuse::apply(open_backend)]
+    fn read_exact_at_fills_whole_buffer_by_reading_at_offset(
+        #[case] backend_open_fn: OpenBackendFn,
+    ) {
+        let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
+        let path = tempdir.path().join("test_file.bin");
+
+        let mut options = OpenOptions::new();
+        options.create(true).read(true).write(true);
+
+        {
+            let mut file = File::create(path.as_path()).unwrap();
+            let buf = vec![1; 10];
+            file.write_all(&buf).unwrap();
+            let buf = vec![0; 5];
+            file.write_all(&buf).unwrap();
+        }
+        // file: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]
+        // read:                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+        let backend = backend_open_fn(path.as_path(), options.clone()).unwrap();
+        let mut buf = [0; 10];
+        backend.read_exact_at(&mut buf, 5).unwrap();
+        assert_eq!(buf[..5], [1; 5]);
+        assert_eq!(buf[5..], [0; 5]);
+    }
+
+    #[rstest_reuse::apply(open_backend)]
+    fn read_exact_at_can_read_across_pages(#[case] backend_open_fn: OpenBackendFn) {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = tempdir.path().join("test_file.bin");
+
+        let mut options = OpenOptions::new();
+        options.create(true).read(true).write(true);
+
+        let data = [1; Page::SIZE * 3];
+        let offset = 0;
+
+        {
+            let mut file = File::create(path.as_path()).unwrap();
+            file.write_all(&data).unwrap();
+        }
+
+        let backend = backend_open_fn(path.as_path(), options.clone()).unwrap();
+        let mut buf = [0; Page::SIZE * 3];
+        backend.read_exact_at(&mut buf, offset).unwrap();
+        assert_eq!(buf, data);
+    }
+
+    #[rstest_reuse::apply(open_backend)]
+    fn read_exact_at_can_read_data_from_different_pages(#[case] backend_open_fn: OpenBackendFn) {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = tempdir.path().join("test_file.bin");
+
+        let mut options = OpenOptions::new();
+        options.create(true).read(true).write(true);
+
+        let data = [1];
+        let offset1 = 0;
+        let offset2 = 10000;
+
+        {
+            let mut file = File::create(path.as_path()).unwrap();
             file.seek(SeekFrom::Start(offset1)).unwrap();
-            file.read_exact(&mut buf).unwrap();
-            assert_eq!(buf, data);
-            buf = [0; 1];
+            file.write_all(&data).unwrap();
             file.seek(SeekFrom::Start(offset2)).unwrap();
-            file.read_exact(&mut buf).unwrap();
-            assert_eq!(buf, data);
+            file.write_all(&data).unwrap();
         }
+
+        let backend = backend_open_fn(path.as_path(), options.clone()).unwrap();
+        let mut buf = [1];
+        backend.read_exact_at(&mut buf, offset1).unwrap();
+        assert_eq!(buf, data);
+        backend.read_exact_at(&mut buf, offset2).unwrap();
+        assert_eq!(buf, data);
     }
 
-    #[test]
-    fn read_exact_at_fills_whole_buffer_by_reading_at_offset() {
+    #[rstest_reuse::apply(open_backend)]
+    fn read_exact_at_fails_when_out_of_bounds(#[case] backend_open_fn: OpenBackendFn) {
         let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
-        let dir = tempdir.path();
+        let path = tempdir.path().join("test_file.bin");
 
         let mut options = OpenOptions::new();
         options.create(true).read(true).write(true);
 
-        for (i, backend) in open_backends().enumerate() {
-            let path = dir.join(format!("test_file_{i}.bin"));
-
-            {
-                let mut file = File::create(path.as_path()).unwrap();
-                let buf = vec![1; 10];
-                file.write_all(&buf).unwrap();
-                let buf = vec![0; 5];
-                file.write_all(&buf).unwrap();
-            }
-            // file: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]
-            // read:                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-            let file = backend(path.as_path(), options.clone()).unwrap();
-            let mut buf = [0; 10];
-            file.read_exact_at(&mut buf, 5).unwrap();
-            assert_eq!(buf[..5], [1; 5]);
-            assert_eq!(buf[5..], [0; 5]);
+        {
+            File::create(path.as_path()).unwrap();
         }
+        // The file exists but is empty.
+
+        let backend = backend_open_fn(path.as_path(), options.clone()).unwrap();
+        let mut buf = [0; 5];
+        let res = backend.read_exact_at(&mut buf, 5);
+        assert_eq!(res.unwrap_err().kind(), std::io::ErrorKind::UnexpectedEof);
     }
 
-    #[test]
-    fn read_exact_at_can_read_across_pages() {
-        let tempdir = tempfile::tempdir().unwrap();
-        let dir = tempdir.path();
-
-        let mut options = OpenOptions::new();
-        options.create(true).read(true).write(true);
-
-        let data = [1; Page::SIZE * 3];
-        let offset = 0;
-
-        for (i, backend) in open_backends().enumerate() {
-            let path = dir.join(format!("test_file_{i}.bin"));
-
-            {
-                let mut file = File::create(path.as_path()).unwrap();
-                file.write_all(&data).unwrap();
-            }
-
-            let file = backend(path.as_path(), options.clone()).unwrap();
-            let mut buf = [0; Page::SIZE * 3];
-            file.read_exact_at(&mut buf, offset).unwrap();
-            assert_eq!(buf, data);
-        }
-    }
-
-    #[test]
-    fn read_exact_at_can_read_data_from_different_pages() {
-        let tempdir = tempfile::tempdir().unwrap();
-        let dir = tempdir.path();
-
-        let mut options = OpenOptions::new();
-        options.create(true).read(true).write(true);
-
-        let data = [1];
-        let offset1 = 0;
-        let offset2 = 10000;
-
-        for (i, backend) in open_backends().enumerate() {
-            let path = dir.join(format!("test_file_{i}.bin"));
-
-            {
-                let mut file = File::create(path.as_path()).unwrap();
-                file.seek(SeekFrom::Start(offset1)).unwrap();
-                file.write_all(&data).unwrap();
-                file.seek(SeekFrom::Start(offset2)).unwrap();
-                file.write_all(&data).unwrap();
-            }
-
-            let file = backend(path.as_path(), options.clone()).unwrap();
-            let mut buf = [1];
-            file.read_exact_at(&mut buf, offset1).unwrap();
-            assert_eq!(buf, data);
-            file.read_exact_at(&mut buf, offset2).unwrap();
-            assert_eq!(buf, data);
-        }
-    }
-
-    #[test]
-    fn read_exact_at_fails_when_out_of_bounds() {
-        let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
-        let dir = tempdir.path();
-
-        let mut options = OpenOptions::new();
-        options.create(true).read(true).write(true);
-
-        for (i, backend) in open_backends().enumerate() {
-            let path = dir.join(format!("test_file_{i}.bin"));
-
-            {
-                File::create(path.as_path()).unwrap();
-            }
-
-            let file = backend(path.as_path(), options.clone()).unwrap();
-            let mut buf = [0; 5];
-            let res = file.read_exact_at(&mut buf, 5);
-            assert_eq!(res.unwrap_err().kind(), std::io::ErrorKind::UnexpectedEof);
-        }
-    }
-
-    #[test]
-    fn access_same_page_in_parallel_does_not_deadlock() {
+    #[rstest_reuse::apply(open_backend)]
+    fn access_same_page_in_parallel_does_not_deadlock(#[case] backend_open_fn: OpenBackendFn) {
         const THREADS: usize = 128;
         const PAGES: usize = 100;
 
         let tempdir = tempfile::tempdir().unwrap();
-        let dir = tempdir.path();
+        let path = tempdir.path().join("test_file.bin");
 
         let mut options = OpenOptions::new();
         options.create(true).read(true).write(true);
 
         let data = vec![1; Page::SIZE * PAGES];
 
-        for (i, backend) in open_backends().enumerate() {
-            let path = dir.join(format!("test_file_{i}.bin"));
-
-            {
-                let mut file = File::create(path.as_path()).unwrap();
-                file.write_all(&data).unwrap();
-            }
-
-            let file = backend(path.as_path(), options.clone()).unwrap();
-
-            let barrier = Barrier::new(THREADS);
-
-            std::thread::scope(|s| {
-                for t in 0..THREADS {
-                    let barrier = &barrier;
-                    let file = Arc::clone(&file);
-                    s.spawn(move || {
-                        const BUF_LEN: usize = Page::SIZE / THREADS;
-                        barrier.wait(); // ensure that all threads have at least been spawned before any starts performing I/O
-                        for page in 0..PAGES {
-                            let mut buf = [0; BUF_LEN];
-                            file.read_exact_at(&mut buf, (page * Page::SIZE + t * BUF_LEN) as u64)
-                                .unwrap();
-                            assert_eq!(buf, [1; BUF_LEN]);
-                        }
-                    });
-                }
-            });
+        {
+            let mut file = File::create(path.as_path()).unwrap();
+            file.write_all(&data).unwrap();
         }
+
+        let backend = backend_open_fn(path.as_path(), options.clone()).unwrap();
+
+        let barrier = Barrier::new(THREADS);
+
+        std::thread::scope(|s| {
+            for t in 0..THREADS {
+                let barrier = &barrier;
+                let backend = Arc::clone(&backend);
+                s.spawn(move || {
+                    const BUF_LEN: usize = Page::SIZE / THREADS;
+                    barrier.wait(); // ensure that all threads have at least been spawned before any starts performing I/O
+                    for page in 0..PAGES {
+                        let mut buf = [0; BUF_LEN];
+                        backend
+                            .read_exact_at(&mut buf, (page * Page::SIZE + t * BUF_LEN) as u64)
+                            .unwrap();
+                        assert_eq!(buf, [1; BUF_LEN]);
+                    }
+                });
+            }
+        });
     }
 
-    #[test]
-    fn flush_flushes_file_and_sets_length() {
+    #[rstest_reuse::apply(open_backend)]
+    fn flush_flushes_file_and_sets_length(#[case] backend_open_fn: OpenBackendFn) {
         let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
-        let dir = tempdir.path();
+        let path = tempdir.path().join("test_file.bin");
 
         let mut options = OpenOptions::new();
         options.create(true).read(true).write(true);
 
-        for (i, backend) in open_backends().enumerate() {
-            let path = dir.join(format!("test_file_{i}.bin"));
+        // flush with no changes
+        {
+            let backend = backend_open_fn(path.as_path(), options.clone()).unwrap();
+            backend.flush().unwrap();
 
-            // flush with no changes
-            {
-                let file = backend(path.as_path(), options.clone()).unwrap();
-                file.flush().unwrap();
-
-                let file = File::open(path.as_path()).unwrap();
-                assert_eq!(file.metadata().unwrap().len(), 0);
-            }
-
-            // flush with changes
-            {
-                let file = backend(path.as_path(), options.clone()).unwrap();
-                file.write_all_at(&[1; 10], 0).unwrap();
-                file.flush().unwrap();
-
-                let mut file = File::open(path.as_path()).unwrap();
-                assert_eq!(file.metadata().unwrap().len(), 10);
-                let mut buf = [0; 10];
-                file.read_exact(&mut buf).unwrap();
-                assert_eq!(buf, [1; 10]);
-            }
+            let file = File::open(path.as_path()).unwrap();
+            assert_eq!(file.metadata().unwrap().len(), 0);
         }
-    }
 
-    #[test]
-    fn drop_flushes_file_and_sets_length() {
-        let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
-        let dir = tempdir.path();
-
-        let mut options = OpenOptions::new();
-        options.create(true).read(true).write(true);
-
-        for (i, backend) in open_backends().enumerate() {
-            let path = dir.join(format!("test_file_{i}.bin"));
-
-            {
-                let file = backend(path.as_path(), options.clone()).unwrap();
-                file.write_all_at(&[1; 10], 0).unwrap();
-            }
+        // flush with changes
+        {
+            let backend = backend_open_fn(path.as_path(), options.clone()).unwrap();
+            backend.write_all_at(&[1; 10], 0).unwrap();
+            backend.flush().unwrap();
 
             let mut file = File::open(path.as_path()).unwrap();
             assert_eq!(file.metadata().unwrap().len(), 10);
@@ -545,116 +484,124 @@ mod tests {
         }
     }
 
-    #[test]
-    fn len_returns_file_length() {
+    #[rstest_reuse::apply(open_backend)]
+    fn drop_flushes_file_and_sets_length(#[case] backend_open_fn: OpenBackendFn) {
         let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
-        let dir = tempdir.path();
+        let path = tempdir.path().join("test_file.bin");
 
         let mut options = OpenOptions::new();
         options.create(true).read(true).write(true);
 
-        for (i, backend) in open_backends().enumerate() {
-            let path = dir.join(format!("test_file_{i}.bin"));
-
-            let file = backend(path.as_path(), options.clone()).unwrap();
-            file.write_all_at(&[1; 10], 0).unwrap();
-            assert_eq!(file.len().unwrap(), 10);
+        {
+            let backend = backend_open_fn(path.as_path(), options.clone()).unwrap();
+            backend.write_all_at(&[1; 10], 0).unwrap();
         }
+
+        let mut file = File::open(path.as_path()).unwrap();
+        assert_eq!(file.metadata().unwrap().len(), 10);
+        let mut buf = [0; 10];
+        file.read_exact(&mut buf).unwrap();
+        assert_eq!(buf, [1; 10]);
     }
 
-    #[test]
-    fn set_len_sets_length() {
+    #[rstest_reuse::apply(open_backend)]
+    fn len_returns_file_length(#[case] backend_open_fn: OpenBackendFn) {
         let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
-        let dir = tempdir.path();
+        let path = tempdir.path().join("test_file.bin");
 
         let mut options = OpenOptions::new();
         options.create(true).read(true).write(true);
 
-        for (i, backend) in open_backends().enumerate() {
-            let path = dir.join(format!("test_file_{i}.bin"));
-
-            let file = backend(path.as_path(), options.clone()).unwrap();
-            file.write_all_at(&[1; 200], 0).unwrap();
-            file.set_len(100).unwrap();
-
-            let check_file = File::open(path.as_path()).unwrap();
-            assert_eq!(check_file.metadata().unwrap().len(), 100);
-        }
+        let backend = backend_open_fn(path.as_path(), options.clone()).unwrap();
+        backend.write_all_at(&[1; 10], 0).unwrap();
+        assert_eq!(backend.len().unwrap(), 10);
     }
 
-    #[test]
-    fn read_observes_writes_of_other_threads() {
+    #[rstest_reuse::apply(open_backend)]
+    fn set_len_sets_length(#[case] backend_open_fn: OpenBackendFn) {
         let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
-        let dir = tempdir.path();
+        let path = tempdir.path().join("test_file.bin");
 
         let mut options = OpenOptions::new();
         options.create(true).read(true).write(true);
 
-        for (i, backend) in open_backends().enumerate() {
-            let path = dir.join(format!("test_file_{i}.bin"));
+        let backend = backend_open_fn(path.as_path(), options.clone()).unwrap();
+        backend.write_all_at(&[1; 200], 0).unwrap();
+        backend.set_len(100).unwrap();
 
-            let file = backend(path.as_path(), options.clone()).unwrap();
+        let check_file = File::open(path.as_path()).unwrap();
+        assert_eq!(check_file.metadata().unwrap().len(), 100);
+    }
 
-            let iteration = AtomicU64::new(0);
+    #[rstest_reuse::apply(open_backend)]
+    fn read_observes_writes_of_other_threads(#[case] backend_open_fn: OpenBackendFn) {
+        let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
+        let path = tempdir.path().join("test_file.bin");
 
-            let max_iterations = 1_000;
+        let mut options = OpenOptions::new();
+        options.create(true).read(true).write(true);
 
-            std::thread::scope(|s| {
-                s.spawn(|| {
-                    let mut buf = [0; 32];
-                    loop {
-                        if iteration.load(Ordering::Relaxed) > max_iterations {
-                            break;
-                        }
+        let backend = backend_open_fn(path.as_path(), options.clone()).unwrap();
 
-                        // wait until it is thread1's turn
-                        while iteration.load(Ordering::Relaxed) % 2 != 0 {}
+        let iteration = AtomicU64::new(0);
 
-                        let offset = iteration.load(Ordering::Relaxed) * 32;
-                        if offset >= 32 {
-                            // check that the previous write of thread2 is visible
-                            file.read_exact_at(&mut buf, offset - 32).unwrap();
-                            assert_eq!(buf, [2; 32]);
-                        }
+        let max_iterations = 1_000;
 
-                        // write data
-                        file.write_all_at([1; 32].as_slice(), offset).unwrap();
-
-                        // check that thread1 observes its own write
-                        file.read_exact_at(&mut buf, offset).unwrap();
-                        assert_eq!(buf, [1; 32]);
-
-                        iteration.fetch_add(1, Ordering::Relaxed);
+        std::thread::scope(|s| {
+            s.spawn(|| {
+                let mut buf = [0; 32];
+                loop {
+                    if iteration.load(Ordering::Relaxed) > max_iterations {
+                        break;
                     }
-                });
-                s.spawn(|| {
-                    let mut buf = [0; 32];
-                    loop {
-                        if iteration.load(Ordering::Relaxed) > max_iterations {
-                            break;
-                        }
 
-                        // wait until it is thread2's turn
-                        while iteration.load(Ordering::Relaxed) % 2 == 0 {}
+                    // wait until it is thread1's turn
+                    while !iteration.load(Ordering::Relaxed).is_multiple_of(2) {}
 
-                        let offset = iteration.load(Ordering::Relaxed) * 32;
-                        if offset >= 32 {
-                            // check that the previous write of thread1 is visible
-                            file.read_exact_at(&mut buf, offset - 32).unwrap();
-                            assert_eq!(buf, [1; 32]);
-                        }
-
-                        // write data
-                        file.write_all_at([2; 32].as_slice(), offset).unwrap();
-
-                        // check that thread2 observes its own write
-                        file.read_exact_at(&mut buf, offset).unwrap();
+                    let offset = iteration.load(Ordering::Relaxed) * 32;
+                    if offset >= 32 {
+                        // check that the previous write of thread2 is visible
+                        backend.read_exact_at(&mut buf, offset - 32).unwrap();
                         assert_eq!(buf, [2; 32]);
-
-                        iteration.fetch_add(1, Ordering::Relaxed);
                     }
-                });
+
+                    // write data
+                    backend.write_all_at([1; 32].as_slice(), offset).unwrap();
+
+                    // check that thread1 observes its own write
+                    backend.read_exact_at(&mut buf, offset).unwrap();
+                    assert_eq!(buf, [1; 32]);
+
+                    iteration.fetch_add(1, Ordering::Relaxed);
+                }
             });
-        }
+            s.spawn(|| {
+                let mut buf = [0; 32];
+                loop {
+                    if iteration.load(Ordering::Relaxed) > max_iterations {
+                        break;
+                    }
+
+                    // wait until it is thread2's turn
+                    while iteration.load(Ordering::Relaxed).is_multiple_of(2) {}
+
+                    let offset = iteration.load(Ordering::Relaxed) * 32;
+                    if offset >= 32 {
+                        // check that the previous write of thread1 is visible
+                        backend.read_exact_at(&mut buf, offset - 32).unwrap();
+                        assert_eq!(buf, [1; 32]);
+                    }
+
+                    // write data
+                    backend.write_all_at([2; 32].as_slice(), offset).unwrap();
+
+                    // check that thread2 observes its own write
+                    backend.read_exact_at(&mut buf, offset).unwrap();
+                    assert_eq!(buf, [2; 32]);
+
+                    iteration.fetch_add(1, Ordering::Relaxed);
+                }
+            });
+        });
     }
 }


### PR DESCRIPTION
This PR uses [rstest](https://crates.io/crates/rstest) and [rstest_reuse](https://crates.io/crates/rstest_reuse) for the file backend tests.

`rstest` allows creating parameterized test, so that instead of having a test function which loops over all cases, the macro generates one test for each case. This makes debugging easier, because if a test fails, the test name already includes the case which failed.

`restes_reuse` can be used if multiple test operate on the same cases. By using it, the cases have to be written only once and can be reused for many tests.

Because we use very long and descriptive test names, I think it would be useful to allow non-snake-case names for easier reading. We should still use consistent formatting, though. I would suggest staying with all lower case but allowing double `__`.