### PR TITLE
Doc private items and build all targets in Rust CI

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -79,7 +79,7 @@ jobs:
       env:
         # Treat warnings as errors
         RUSTDOCFLAGS: "-D warnings"
-      run: cargo doc --no-deps
+      run: cargo doc --no-deps --document-private-items
     - name: cargo test doc
       run: cargo test --doc
 
@@ -97,7 +97,7 @@ jobs:
       with:
         workspaces: rust
     - name: cargo build
-      run: cargo build
+      run: cargo build --all-features --all-targets
 
   test:
     name: test


### PR DESCRIPTION
This PR changes the Rust CI to also document private items. Without this, e.g. intra-doc links of private items are not checked and can be broken. Also, the build job now builds all targets for all features.