### PR TITLE
Add simple in-memory Verkle trie implementation

### DIFF
--- a/rust/src/database/verkle/compute_commitment.rs
+++ b/rust/src/database/verkle/compute_commitment.rs
@@ -1,0 +1,50 @@
+use crate::{
+    database::verkle::crypto::{Commitment, Scalar},
+    types::Value,
+};
+
+/// Computes the commitment of a leaf node.
+///
+/// Since [`crate::database::verkle::crypto::Scalar`] cannot safely represent 32 bytes,
+/// the 256 32-bit values are split into two interleaved sets of 16 byte values, on which
+/// commitments C1 and C2 are computed separately:
+///
+///   C1 = Commit([  v[0][..16]),   v[0][16..]),   v[1][..16]),   v[1][16..]), ...])
+///   C2 = Commit([v[128][..16]), v[128][16..]), v[129][..16]), v[129][16..]), ...])
+///
+/// The final commitment of a leaf node is then computed as follows:
+///
+///    C = Commit([1, stem, C1, C2])
+///
+/// For details on the commitment procedure, see
+/// https://blog.ethereum.org/2021/12/02/verkle-tree-structure#commitment-to-the-values-leaf-nodes
+#[cfg_attr(not(test), expect(unused))]
+pub fn compute_leaf_node_commitment(
+    input_values: &[Value; 256],
+    used_bits: &[u8; 256 / 8],
+    stem: &[u8; 31],
+) -> Commitment {
+    let mut values = vec![vec![Commitment::default().to_scalar(); 256]; 2];
+    for (i, value) in input_values.iter().enumerate() {
+        let mut lower = Scalar::from_le_bytes(&value[..16]);
+        let upper = Scalar::from_le_bytes(&value[16..]);
+
+        if used_bits[i / 8] & (1 << (i % 8)) != 0 {
+            lower.set_bit128();
+        }
+
+        values[i / 128][(2 * i) % 256] = lower;
+        values[i / 128][(2 * i + 1) % 256] = upper;
+    }
+
+    let c1 = Commitment::new(&values[0]);
+    let c2 = Commitment::new(&values[1]);
+
+    let combined = vec![
+        Scalar::from(1),
+        Scalar::from_le_bytes(stem),
+        c1.to_scalar(),
+        c2.to_scalar(),
+    ];
+    Commitment::new(&combined)
+}

--- a/rust/src/database/verkle/mod.rs
+++ b/rust/src/database/verkle/mod.rs
@@ -8,7 +8,10 @@
 // On the date above, in accordance with the Business Source License, use of
 // this software will be governed by the GNU Lesser General Public License v3.
 
+mod compute_commitment;
 mod crypto;
 mod embedding;
 #[cfg(test)]
 mod test_utils;
+mod variants;
+mod verkle_trie;

--- a/rust/src/database/verkle/variants/mod.rs
+++ b/rust/src/database/verkle/variants/mod.rs
@@ -1,0 +1,1 @@
+mod simple;

--- a/rust/src/database/verkle/variants/simple/mod.rs
+++ b/rust/src/database/verkle/variants/simple/mod.rs
@@ -1,0 +1,170 @@
+mod node;
+#[cfg(test)]
+mod test_utils;
+
+use std::sync::Mutex;
+
+use crate::database::verkle::variants::simple::node::Node;
+#[cfg(test)]
+use crate::{
+    database::verkle::{crypto::Commitment, verkle_trie::VerkleTrie},
+    error::Error,
+    types::{Key, Value},
+};
+
+/// A simple in-memory implementation of the Verkle trie.
+///
+/// This implementation is not meant for production use, but rather as a reference,
+/// and for validation, prototyping and testing.
+///
+/// The implementation has several shortcomings:
+/// - Total tree size is limited by available memory.
+/// - No concurrency support (single lock on root node).
+/// - Not optimized for memory usage (all nodes store 256 children / values).
+pub struct SimpleInMemoryVerkleTrie {
+    #[cfg_attr(not(test), expect(unused))]
+    root: Mutex<Node>,
+}
+
+#[cfg_attr(not(test), expect(unused))]
+impl SimpleInMemoryVerkleTrie {
+    pub fn new() -> Self {
+        SimpleInMemoryVerkleTrie {
+            root: Mutex::new(Node::Empty),
+        }
+    }
+}
+
+#[cfg(test)]
+impl VerkleTrie for SimpleInMemoryVerkleTrie {
+    fn get(&self, key: &Key) -> Result<Value, Error> {
+        Ok(self.root.lock().unwrap().get(key, 0))
+    }
+
+    fn set(&self, key: &Key, value: &Value) -> Result<(), Error> {
+        let mut root_lock = self.root.lock().unwrap();
+        let root = std::mem::replace(&mut *root_lock, Node::Empty);
+        *root_lock = root.set(key, 0, value);
+        Ok(())
+    }
+
+    fn commit(&self) -> Commitment {
+        self.root.lock().unwrap().commit()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::verkle::variants::simple::test_utils::{
+        make_key, make_leaf_key, make_value,
+    };
+
+    #[test]
+    fn new_creates_empty_trie() {
+        let trie = SimpleInMemoryVerkleTrie::new();
+        assert_eq!(trie.get(&make_key(&[1])).unwrap(), Value::default());
+        assert_eq!(trie.get(&make_key(&[2])).unwrap(), Value::default());
+        assert_eq!(trie.get(&make_key(&[3])).unwrap(), Value::default());
+    }
+
+    #[test]
+    fn values_can_be_set_and_retrieved() {
+        let trie = SimpleInMemoryVerkleTrie::new();
+
+        assert_eq!(trie.get(&make_key(&[1])).unwrap(), Value::default());
+        assert_eq!(trie.get(&make_key(&[2])).unwrap(), Value::default());
+        assert_eq!(trie.get(&make_leaf_key(&[0], 1)).unwrap(), Value::default());
+        assert_eq!(trie.get(&make_leaf_key(&[0], 2)).unwrap(), Value::default());
+
+        trie.set(&make_key(&[1]), &make_value(1)).unwrap();
+
+        assert_eq!(trie.get(&make_key(&[1])).unwrap(), make_value(1));
+        assert_eq!(trie.get(&make_key(&[2])).unwrap(), Value::default());
+        assert_eq!(trie.get(&make_leaf_key(&[0], 1)).unwrap(), Value::default());
+        assert_eq!(trie.get(&make_leaf_key(&[0], 2)).unwrap(), Value::default());
+
+        trie.set(&make_key(&[2]), &make_value(2)).unwrap();
+
+        assert_eq!(trie.get(&make_key(&[1])).unwrap(), make_value(1));
+        assert_eq!(trie.get(&make_key(&[2])).unwrap(), make_value(2));
+        assert_eq!(trie.get(&make_leaf_key(&[0], 1)).unwrap(), Value::default());
+        assert_eq!(trie.get(&make_leaf_key(&[0], 2)).unwrap(), Value::default());
+
+        trie.set(&make_leaf_key(&[0], 1), &make_value(3)).unwrap();
+
+        assert_eq!(trie.get(&make_key(&[1])).unwrap(), make_value(1));
+        assert_eq!(trie.get(&make_key(&[2])).unwrap(), make_value(2));
+        assert_eq!(trie.get(&make_leaf_key(&[0], 1)).unwrap(), make_value(3));
+        assert_eq!(trie.get(&make_leaf_key(&[0], 2)).unwrap(), Value::default());
+
+        trie.set(&make_leaf_key(&[0], 2), &make_value(4)).unwrap();
+
+        assert_eq!(trie.get(&make_key(&[1])).unwrap(), make_value(1));
+        assert_eq!(trie.get(&make_key(&[2])).unwrap(), make_value(2));
+        assert_eq!(trie.get(&make_leaf_key(&[0], 1)).unwrap(), make_value(3));
+        assert_eq!(trie.get(&make_leaf_key(&[0], 2)).unwrap(), make_value(4));
+    }
+
+    #[test]
+    fn values_can_be_updated() {
+        let trie = SimpleInMemoryVerkleTrie::new();
+
+        let key = make_key(&[1]);
+        assert_eq!(trie.get(&key).unwrap(), Value::default());
+        trie.set(&key, &make_value(1)).unwrap();
+        assert_eq!(trie.get(&key).unwrap(), make_value(1));
+        trie.set(&key, &make_value(2)).unwrap();
+        assert_eq!(trie.get(&key).unwrap(), make_value(2));
+        trie.set(&key, &make_value(3)).unwrap();
+        assert_eq!(trie.get(&key).unwrap(), make_value(3));
+    }
+
+    #[test]
+    fn many_values_can_be_set_and_retrieved() {
+        const N: u32 = 1000;
+
+        let to_key = |i: u32| {
+            make_leaf_key(
+                &[(i >> 8 & 0x0F) as u8, (i >> 4 & 0x0F) as u8],
+                (i & 0x0F) as u8,
+            )
+        };
+
+        let trie = SimpleInMemoryVerkleTrie::new();
+
+        for i in 0..N {
+            for j in 0..N {
+                let want = if j < i {
+                    make_value(j as u64)
+                } else {
+                    Value::default()
+                };
+                let got = trie.get(&to_key(j)).unwrap();
+                assert_eq!(got, want, "mismatch for key: {:?}", to_key(j));
+            }
+            trie.set(&to_key(i), &make_value(i as u64)).unwrap();
+        }
+    }
+
+    #[test]
+    fn commitment_of_empty_trie_is_default_commitment() {
+        let trie = SimpleInMemoryVerkleTrie::new();
+        let have = trie.commit();
+        let want = Commitment::default();
+        assert_eq!(have, want);
+    }
+
+    #[test]
+    fn commitment_of_non_empty_trie_is_root_node_commitment() {
+        let trie = SimpleInMemoryVerkleTrie::new();
+        trie.set(&make_leaf_key(&[1], 1), &make_value(1)).unwrap();
+        trie.set(&make_leaf_key(&[2], 2), &make_value(2)).unwrap();
+        trie.set(&make_leaf_key(&[3], 3), &make_value(3)).unwrap();
+
+        let have = trie.commit();
+        let want = trie.root.lock().unwrap().commit();
+
+        assert_eq!(have, want);
+    }
+}

--- a/rust/src/database/verkle/variants/simple/node.rs
+++ b/rust/src/database/verkle/variants/simple/node.rs
@@ -1,0 +1,571 @@
+#[cfg(test)]
+use crate::{database::verkle::compute_commitment::compute_leaf_node_commitment, types::Key};
+use crate::{database::verkle::crypto::Commitment, types::Value};
+
+/// A node in the simple in-memory Verkle trie.
+#[cfg_attr(not(test), expect(unused))]
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+pub enum Node {
+    Empty,
+    Inner(InnerNode),
+    Leaf(LeafNode),
+}
+
+#[cfg(test)]
+impl Node {
+    /// Returns the value associated with the given key, or the default value if
+    /// the key does not exist.
+    pub fn get(&self, key: &Key, depth: u8) -> Value {
+        match self {
+            Node::Empty => Value::default(),
+            Node::Inner(inner) => inner.get(key, depth),
+            Node::Leaf(leaf) => leaf.get(key),
+        }
+    }
+
+    /// Sets the value for the given key.
+    /// Consumes the node and returns an updated version.
+    pub fn set(self, key: &Key, depth: u8, value: &Value) -> Node {
+        match self {
+            Node::Empty => {
+                // While conceptually it would suffice to create a leaf node here,
+                // Geth always creates an inner node (and we want to stay compatible).
+                let inner = InnerNode::new();
+                inner.set(key, depth, value)
+            }
+            Node::Inner(inner) => inner.set(key, depth, value),
+            Node::Leaf(leaf) => leaf.set(key, depth, value),
+        }
+    }
+
+    /// Computes and returns the commitment of this node.
+    ///
+    /// If the commitment is already up to date, it is returned without recomputation.
+    pub fn commit(&mut self) -> Commitment {
+        match self {
+            Node::Empty => Commitment::default(),
+            Node::Inner(inner) => inner.commit(),
+            Node::Leaf(leaf) => leaf.commit(),
+        }
+    }
+
+    /// Returns the current commitment of this node without recomputing it.
+    fn get_commitment(&self) -> Commitment {
+        match self {
+            Node::Empty => Commitment::default(),
+            Node::Inner(inner) => inner.commitment,
+            Node::Leaf(leaf) => leaf.commitment,
+        }
+    }
+
+    /// Returns true if the commitment of this node is dirty and needs to be recomputed.
+    fn commitment_is_dirty(&self) -> bool {
+        match self {
+            Node::Empty => false,
+            Node::Inner(inner) => inner.commitment_dirty,
+            Node::Leaf(leaf) => leaf.commitment_dirty,
+        }
+    }
+}
+
+/// An inner node in the simple in-memory Verkle trie, containing up to 256 children.
+#[cfg_attr(not(test), expect(unused))]
+#[derive(Debug)]
+pub struct InnerNode {
+    children: Vec<Node>,
+    commitment: Commitment,
+    commitment_dirty: bool,
+}
+
+#[cfg(test)]
+impl InnerNode {
+    /// Creates a new inner node without any children.
+    fn new() -> Self {
+        let mut children = Vec::with_capacity(256);
+        for _ in 0..256 {
+            children.push(Node::Empty);
+        }
+        InnerNode {
+            children,
+            commitment: Commitment::default(),
+            commitment_dirty: true,
+        }
+    }
+
+    /// Creates a new inner node with the given leaf node as child at the given position.
+    pub fn new_with_leaf(leaf: LeafNode, position: u8) -> Self {
+        let mut inner = Self::new();
+        inner.children[position as usize] = Node::Leaf(leaf);
+        inner
+    }
+
+    /// Returns the value associated with the given key, by forwarding the request to
+    /// the child at position `key[depth]`.
+    pub fn get(&self, key: &Key, depth: u8) -> Value {
+        self.children[key[depth as usize] as usize].get(key, depth + 1)
+    }
+
+    /// Sets the value for the given key by forwarding the request to the child at
+    /// position `key[depth]`.
+    ///
+    /// If no child exists at that position, a new leaf node is created.
+    ///
+    /// Consumes the node and returns an updated version.
+    pub fn set(mut self, key: &Key, depth: u8, value: &Value) -> Node {
+        self.commitment_dirty = true;
+
+        let pos = key[depth as usize];
+        if matches!(self.children[pos as usize], Node::Empty) {
+            self.children[pos as usize] = Node::Leaf(LeafNode::new(key));
+        }
+        let next = std::mem::replace(&mut self.children[pos as usize], Node::Empty);
+        self.children[pos as usize] = next.set(key, depth + 1, value);
+        Node::Inner(self)
+    }
+
+    /// Computes and returns the commitment of this node, by first updating the commitments
+    /// of all children that are dirty and then updating the respective positions within the
+    /// commitment of this node.
+    ///
+    /// If the commitment is already up to date, it is returned without recomputation.
+    pub fn commit(&mut self) -> Commitment {
+        if !self.commitment_dirty {
+            return self.commitment;
+        }
+
+        for (i, child) in self.children.iter_mut().enumerate() {
+            if child.commitment_is_dirty() {
+                let old_child_commitment = child.get_commitment();
+                let new_child_commitment = child.commit();
+                self.commitment.update(
+                    i as u8,
+                    old_child_commitment.to_scalar(),
+                    new_child_commitment.to_scalar(),
+                );
+            }
+        }
+
+        self.commitment_dirty = false;
+        self.commitment
+    }
+}
+
+/// A leaf node in the simple in-memory Verkle trie, containing 256 values.
+///
+/// Alongside the values and commitment, the leaf node also stores:
+/// - The 31-byte stem that is common to all keys in this leaf, required to distinguish from keys
+///   that share a common prefix, as well as for non-existence proofs.
+/// - A bitmap indicating which of the 256 values have been modified at some point, required for
+///   future state expiry schemes.
+#[cfg_attr(not(test), expect(unused))]
+#[derive(Debug)]
+pub struct LeafNode {
+    stem: [u8; 31],
+    values: [Value; 256],
+    used_bits: [u8; 256 / 8],
+    commitment: Commitment,
+    commitment_dirty: bool,
+}
+
+#[cfg(test)]
+impl LeafNode {
+    /// Creates a new leaf node for the given key, initializing all values to [`Value::default`].
+    pub fn new(key: &Key) -> Self {
+        LeafNode {
+            stem: key[..31].try_into().expect("slice should be 31 bytes"),
+            values: [Value::default(); 256],
+            used_bits: [0; 256 / 8],
+            commitment: Commitment::default(),
+            commitment_dirty: true,
+        }
+    }
+
+    /// Returns the value associated with the given key, or [`Value::default`] if the key does
+    /// not match the stem of this leaf.
+    pub fn get(&self, key: &Key) -> Value {
+        if key[..31] != self.stem[..] {
+            Value::default()
+        } else {
+            self.values[key[31] as usize]
+        }
+    }
+
+    /// Sets the value for the given key.
+    ///
+    /// If the stem of the key does not match the stem of this leaf, the leaf is split
+    /// into an inner node with two children (the existing leaf and a new leaf for the key).
+    pub fn set(mut self, key: &Key, depth: u8, value: &Value) -> Node {
+        if key[..31] == self.stem[..] {
+            let suffix = key[31];
+            self.values[suffix as usize] = *value;
+            self.used_bits[(suffix / 8) as usize] |= 1 << (suffix % 8);
+            self.commitment_dirty = true;
+            return Node::Leaf(self);
+        }
+
+        // This leaf needs to be split
+        let pos = self.stem[depth as usize];
+        let inner = InnerNode::new_with_leaf(self, pos);
+        inner.set(key, depth, value)
+    }
+
+    /// Computes and returns the commitment of this leaf node.
+    ///
+    /// If the commitment is already up to date, it is returned without recomputation.
+    pub fn commit(&mut self) -> Commitment {
+        if !self.commitment_dirty {
+            return self.commitment;
+        }
+        self.commitment = compute_leaf_node_commitment(&self.values, &self.used_bits, &self.stem);
+        self.commitment_dirty = false;
+        self.commitment
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::verkle::{
+        crypto::Scalar,
+        variants::simple::test_utils::{make_key, make_leaf_key, make_value},
+    };
+
+    #[test]
+    fn empty_node_set_creates_inner_node() {
+        let key = make_key(&[1, 2, 3]);
+        let value = make_value(42);
+        let node = Node::Empty.set(&key, 0, &value);
+        assert!(matches!(node, Node::Inner(_)));
+    }
+
+    #[test]
+    fn inner_node_new_creates_empty_node() {
+        let inner = InnerNode::new();
+        for child in inner.children {
+            assert!(matches!(child, Node::Empty));
+        }
+        assert_eq!(inner.commitment, Commitment::default());
+        assert!(inner.commitment_dirty);
+    }
+
+    #[test]
+    fn inner_node_new_with_leaf_creates_node_with_child() {
+        let key = make_key(&[9, 2, 3]);
+        let leaf = LeafNode::new(&key);
+        let position = key[0];
+        let inner = InnerNode::new_with_leaf(leaf, position);
+        for (i, child) in inner.children.iter().enumerate() {
+            if i == position as usize {
+                assert!(matches!(child, Node::Leaf(_)));
+            } else {
+                assert!(matches!(child, Node::Empty));
+            }
+        }
+        assert_eq!(inner.commitment, Commitment::default());
+        assert!(inner.commitment_dirty);
+    }
+
+    #[test]
+    fn inner_node_get_returns_default_value_if_there_is_no_next_node() {
+        let inner = InnerNode::new();
+        let key = [0; 32];
+        let value = inner.get(&key, 0);
+        assert_eq!(value, Value::default());
+    }
+
+    #[test]
+    fn inner_node_get_returns_value_from_next_node() {
+        let key1 = make_key(&[1, 2, 3]);
+        let key2 = make_key(&[1, 2, 4]);
+
+        let root = Node::Leaf(LeafNode::new(&key1));
+        let root = root.set(&key1, 2, &make_value(42));
+        let root = root.set(&key2, 2, &make_value(84));
+
+        assert!(
+            matches!(root, Node::Inner(_)),
+            "root should be an InnerNode"
+        );
+
+        assert_eq!(root.get(&key1, 2), make_value(42));
+        assert_eq!(root.get(&key2, 2), make_value(84));
+    }
+
+    #[test]
+    fn inner_node_set_creates_new_leaf_if_there_is_no_next_node() {
+        let key = make_key(&[1, 2, 3]);
+        let inner = InnerNode::new();
+        assert!(matches!(inner.children[key[2] as usize], Node::Empty));
+
+        let inner = inner.set(&key, 2, &make_value(42));
+        let Node::Inner(inner) = inner else {
+            panic!("expected InnerNode after set");
+        };
+        assert!(matches!(inner.children[key[2] as usize], Node::Leaf(_)));
+    }
+
+    #[test]
+    fn inner_node_commit_dirty_state_is_tracked() {
+        let inner = InnerNode::new();
+        assert!(inner.commitment_dirty);
+
+        // Setting a value should mark the commitment as dirty.
+        let key = make_key(&[1, 2, 3]);
+        let inner = inner.set(&key, 2, &make_value(42));
+        let Node::Inner(mut inner) = inner else {
+            panic!("expected InnerNode after set");
+        };
+        assert!(inner.commitment_dirty);
+
+        // Committing should clean the state.
+        let fist_commitment = inner.commit();
+        assert!(!inner.commitment_dirty);
+
+        // Committing again should return the same commitment.
+        let second_commitment = inner.commit();
+        assert!(!inner.commitment_dirty);
+        assert_eq!(fist_commitment, second_commitment);
+
+        // Setting another value should mark the commitment as dirty again.
+        let inner = inner.set(&make_key(&[1, 2, 4]), 2, &make_value(84));
+        let Node::Inner(inner) = inner else {
+            panic!("expected InnerNode after set");
+        };
+        assert!(inner.commitment_dirty);
+    }
+
+    #[test]
+    fn inner_node_commit_computes_commitment_from_children() {
+        let inner = InnerNode::new();
+        let key1 = make_key(&[1, 2, 3]);
+        let key2 = make_key(&[1, 2, 4]);
+
+        let inner = inner.set(&key1, 2, &make_value(42));
+        let inner = inner.set(&key2, 2, &make_value(84));
+        let Node::Inner(mut inner) = inner else {
+            panic!("expected InnerNode after set");
+        };
+
+        let commitment = inner.commit();
+
+        let mut child_commitments = vec![Scalar::zero(); 256];
+        child_commitments[key1[2] as usize] = inner.children[key1[2] as usize].commit().to_scalar();
+        child_commitments[key2[2] as usize] = inner.children[key2[2] as usize].commit().to_scalar();
+        let expected_commitment = Commitment::new(&child_commitments);
+        assert_eq!(commitment, expected_commitment);
+    }
+
+    #[test]
+    fn leaf_node_new_produces_empty_leaf_with_stem() {
+        let key = make_key(&[1, 2, 3, 4, 5]);
+        let leaf = LeafNode::new(&key);
+
+        assert_eq!(
+            &leaf.stem[..],
+            &key[..31],
+            "stem should match the first 31 bytes of the key"
+        );
+        assert_eq!(
+            leaf.values,
+            [Value::default(); 256],
+            "all values should be initialized to zero"
+        );
+        assert_eq!(leaf.used_bits, [0; 256 / 8], "used bitmap should be empty");
+    }
+
+    #[test]
+    fn leaf_node_get_returns_value_for_matching_stem() {
+        let key = make_leaf_key(&[1, 2, 3, 4, 5], 1);
+        let leaf = LeafNode::new(&key);
+
+        // Initially, the value for the key should be zero.
+        assert_eq!(leaf.get(&key), Value::default());
+
+        let leaf = leaf.set(&key, 0, &make_value(42));
+        let Node::Leaf(leaf) = leaf else {
+            panic!("expected LeafNode after set");
+        };
+        assert_eq!(leaf.get(&key), make_value(42),);
+    }
+
+    #[test]
+    fn leaf_node_get_returns_zero_for_non_matching_stem() {
+        let key1 = make_key(&[1, 2, 3]);
+        let key2 = make_key(&[4, 5, 6]);
+        let leaf = LeafNode::new(&key1);
+        let leaf = leaf.set(&key1, 0, &make_value(42));
+
+        assert_eq!(
+            leaf.get(&key2, 0),
+            Value::default(),
+            "value for non-matching key should be zero"
+        );
+    }
+
+    #[test]
+    fn leaf_node_set_splits_leaf_if_steam_does_not_match() {
+        let key1 = make_key(&[1, 2, 3]);
+        let key2 = make_key(&[1, 2, 4]);
+
+        let leaf = LeafNode::new(&key1);
+        let leaf = leaf.set(&key1, 0, &make_value(42));
+
+        let new_node = leaf.set(&key2, 2, &make_value(84));
+        let Node::Inner(inner) = new_node else {
+            panic!("expected InnerNode after set");
+        };
+
+        // Original leaf is now a child of the inner node.
+        let value = inner.children[key1[2] as usize].get(&key1, 2);
+        assert_eq!(value, make_value(42));
+    }
+
+    #[test]
+    fn leaf_node_can_set_and_get_values() {
+        fn is_used(leaf: &LeafNode, suffix: u8) -> bool {
+            leaf.used_bits[(suffix / 8) as usize] & (1 << (suffix % 8)) != 0
+        }
+
+        let key1 = make_leaf_key(&[1, 2, 3], 1);
+        let key2 = make_leaf_key(&[1, 2, 3], 2);
+        let key3 = make_leaf_key(&[1, 2, 3], 3);
+
+        let leaf = LeafNode::new(&key1);
+
+        assert!(!is_used(&leaf, key1[31]));
+        assert!(!is_used(&leaf, key2[31]));
+        assert!(!is_used(&leaf, key3[31]));
+
+        assert_eq!(leaf.get(&key1), Value::default());
+        assert_eq!(leaf.get(&key2), Value::default());
+        assert_eq!(leaf.get(&key3), Value::default());
+
+        // Setting a value for key 1 makes the value retrievable and marks the suffix as used.
+        let leaf = leaf.set(&key1, 0, &make_value(10));
+        let Node::Leaf(leaf) = leaf else {
+            panic!("expected LeafNode after set");
+        };
+
+        assert!(is_used(&leaf, key1[31]));
+        assert!(!is_used(&leaf, key2[31]));
+        assert!(!is_used(&leaf, key3[31]));
+
+        assert_eq!(leaf.get(&key1), make_value(10));
+        assert_eq!(leaf.get(&key2), Value::default());
+        assert_eq!(leaf.get(&key3), Value::default());
+
+        // Setting the value for key 2 to zero does not change the value but marks the suffix as
+        // used.
+        let leaf = leaf.set(&key2, 0, &Value::default());
+        let Node::Leaf(leaf) = leaf else {
+            panic!("expected LeafNode after set");
+        };
+
+        assert!(is_used(&leaf, key1[31]));
+        assert!(is_used(&leaf, key2[31]));
+        assert!(!is_used(&leaf, key3[31]));
+
+        assert_eq!(leaf.get(&key1), make_value(10));
+        assert_eq!(leaf.get(&key2), Value::default());
+        assert_eq!(leaf.get(&key3), Value::default());
+
+        // Resetting the value for key 1 to zero does not change the used bitmap.
+        let leaf = leaf.set(&key1, 0, &Value::default());
+        let Node::Leaf(leaf) = leaf else {
+            panic!("expected LeafNode after set");
+        };
+
+        assert!(is_used(&leaf, key1[31]));
+        assert!(is_used(&leaf, key2[31]));
+        assert!(!is_used(&leaf, key3[31]));
+
+        assert_eq!(leaf.get(&key1), Value::default());
+        assert_eq!(leaf.get(&key2), Value::default());
+        assert_eq!(leaf.get(&key3), Value::default());
+    }
+
+    #[test]
+    fn leaf_node_can_compute_commitment() {
+        let key1 = make_leaf_key(&[1, 2, 3], 1);
+        let key2 = make_leaf_key(&[1, 2, 3], 130);
+
+        let mut val1 = [0; 32];
+        val1[8..16].copy_from_slice(&42u64.to_be_bytes());
+        let mut val2 = [0; 32];
+        val2[8..16].copy_from_slice(&84u64.to_be_bytes());
+
+        let leaf = LeafNode::new(&key1);
+        let leaf = leaf.set(&key1, 0, &val1);
+        let leaf = leaf.set(&key2, 0, &val2);
+        let Node::Leaf(mut leaf) = leaf else {
+            panic!("expected LeafNode after set");
+        };
+
+        let have = leaf.commit();
+
+        let mut low1 = Scalar::from_le_bytes(&val1[..16]);
+        let mut low2 = Scalar::from_le_bytes(&val2[..16]);
+        let high1 = Scalar::from_le_bytes(&val1[16..]);
+        let high2 = Scalar::from_le_bytes(&val2[16..]);
+        low1.set_bit128();
+        low2.set_bit128();
+
+        let mut c1_values = vec![Scalar::zero(); 256];
+        let mut c2_values = vec![Scalar::zero(); 256];
+        c1_values[2] = low1;
+        c1_values[3] = high1;
+        c2_values[4] = low2;
+        c2_values[5] = high2;
+
+        let c1 = Commitment::new(&c1_values);
+        let c2 = Commitment::new(&c2_values);
+        let mut combined = vec![Scalar::zero(); 256];
+        combined[0] = Scalar::from(1);
+        combined[1] = Scalar::from_le_bytes(&key1[..31]);
+        combined[2] = c1.to_scalar();
+        combined[3] = c2.to_scalar();
+        let want = Commitment::new(&combined);
+
+        assert_eq!(have, want);
+    }
+
+    #[test]
+    fn leaf_node_commitment_dirty_state_is_tracked() {
+        let key1 = make_leaf_key(&[1, 2, 3], 1);
+        let key2 = make_leaf_key(&[1, 2, 3], 130);
+
+        let leaf = LeafNode::new(&key1);
+        assert!(leaf.commitment_dirty);
+
+        let leaf = leaf.set(&key1, 0, &make_value(10));
+        let Node::Leaf(leaf) = leaf else {
+            panic!("expected LeafNode after set");
+        };
+        assert!(leaf.commitment_dirty);
+
+        let leaf = leaf.set(&key2, 0, &make_value(20));
+        let Node::Leaf(mut leaf) = leaf else {
+            panic!("expected LeafNode after set");
+        };
+        assert!(leaf.commitment_dirty);
+
+        let first = leaf.commit();
+        assert!(!leaf.commitment_dirty);
+
+        let second = leaf.commit();
+        assert!(!leaf.commitment_dirty);
+        assert_eq!(first, second);
+
+        let leaf = leaf.set(&key1, 0, &make_value(30));
+        let Node::Leaf(mut leaf) = leaf else {
+            panic!("expected LeafNode after set");
+        };
+        assert!(leaf.commitment_dirty);
+
+        let third = leaf.commit();
+        assert!(!leaf.commitment_dirty);
+
+        assert_ne!(first, third);
+    }
+}

--- a/rust/src/database/verkle/variants/simple/test_utils.rs
+++ b/rust/src/database/verkle/variants/simple/test_utils.rs
@@ -1,0 +1,19 @@
+use crate::types::{Key, Value};
+
+pub fn make_key(prefix: &[u8]) -> Key {
+    let mut key = [0; 32];
+    key[..prefix.len()].copy_from_slice(prefix);
+    key
+}
+
+pub fn make_leaf_key(prefix: &[u8], suffix: u8) -> Key {
+    let mut key = make_key(prefix);
+    key[31] = suffix;
+    key
+}
+
+pub fn make_value(value: u64) -> Value {
+    let mut val = [0; 32];
+    val[0..8].copy_from_slice(&value.to_le_bytes());
+    val
+}


### PR DESCRIPTION
This adds a simple in-memory implementation of the *Verkle trie*, [proposed by Ethereum](https://blog.ethereum.org/2021/12/02/verkle-tree-structure) as a potential replacement for the Merkle-Patricia Trie (MPT).

The Verkle trie has several advantages compared to the MPT:
- Simpler structure: Only two types of nodes (inner and leaf)
- No RLP encoding
- Single unified tree for accounts, storage and contract codes
- 256 children per node, leading to a much shallower tree
- Smaller proofs based on vector commitments

The major potential downside of Verkle tries is that the underlying elliptic curve cryptographic operations are substantially more expensive than e.g. MPT's Keccak-256. We'll have to properly quantify this using extensive benchmarking.

The implementation provided in this PR is a very simple in-memory tree, i.e., it does not store any data on disk. It is not  meant for production use, but rather as a reference, and for validation, prototyping and testing.

The implementation has several shortcomings:
  - Total tree size is limited by available memory.
  - No concurrency support (single lock on root node).
  - Not optimized for memory usage (all nodes store 256 children / values).

Depends on #119.