### PR TITLE
Make error types PartialEq

### DIFF
--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -14,7 +14,7 @@ use crate::storage;
 
 /// The top level error type for Carmen .
 /// This type is returned to the ffi interface and converted there.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub enum Error {
     /// An unsupported schema version was provided.
     #[error("unsupported schema version: {0}")]

--- a/rust/src/storage/error.rs
+++ b/rust/src/storage/error.rs
@@ -24,3 +24,72 @@ pub enum Error {
     #[error("IO error in storage: {0}")]
     Io(#[from] std::io::Error),
 }
+
+impl PartialEq for Error {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Error::NotFound, Error::NotFound)
+            | (Error::IdNodeTypeMismatch, Error::IdNodeTypeMismatch)
+            | (Error::InvalidId, Error::InvalidId)
+            | (Error::DatabaseCorruption, Error::DatabaseCorruption) => true,
+            (Error::Io(a), Error::Io(b)) => {
+                a.kind() == b.kind()
+                    && a.raw_os_error() == b.raw_os_error()
+                    && a.to_string() == b.to_string()
+            }
+            (
+                Error::NotFound
+                | Error::IdNodeTypeMismatch
+                | Error::InvalidId
+                | Error::DatabaseCorruption
+                | Error::Io(_),
+                _,
+            ) => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn implements_partial_eq() {
+        let err1 = Error::NotFound;
+        let err2 = Error::NotFound;
+        let err3 = Error::IdNodeTypeMismatch;
+        let err4 = Error::InvalidId;
+        let err5 = Error::DatabaseCorruption;
+        assert_eq!(err1, err2);
+        assert_ne!(err1, err3);
+        assert_ne!(err1, err4);
+        assert_ne!(err1, err5);
+
+        let io_err1 = Error::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "file not found",
+        ));
+        let io_err2 = Error::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "file not found",
+        ));
+        let io_err3 = Error::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "another message",
+        ));
+        let io_err4 = Error::Io(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "permission denied",
+        ));
+        assert_ne!(io_err1, err1);
+        assert_eq!(io_err1, io_err2);
+        assert_ne!(io_err1, io_err3);
+        assert_ne!(io_err1, io_err4);
+
+        let io_err5 = Error::Io(std::io::Error::from_raw_os_error(3));
+        let io_err6 = Error::Io(std::io::Error::from_raw_os_error(4));
+        assert_ne!(io_err1, io_err5);
+        assert_ne!(io_err5, io_err6);
+        assert_ne!(io_err5, io_err6);
+    }
+}


### PR DESCRIPTION
This makes our top-level `Error` type and `storage::Error` `PartialEq`. For the latter the trait needs to be implemented manually, as `std::io::Error` is not `PartialEq`.