### PR TITLE
Cleanup build artifacts in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ pipeline {
     options {
         timestamps ()
         timeout(time: 2, unit: 'HOURS')
+        disableConcurrentBuilds(abortPrevious: true)
     }
 
     environment {
@@ -97,6 +98,11 @@ pipeline {
                     steps {
                         sh 'cd cpp && bazel test --test_output=errors //...'
                     }
+                }
+            }
+            post {
+                always {
+                    sh 'make clean'
                 }
             }
         }

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ clean:
 	rm -f lib/libcarmen.so ; \
 	cd ../cpp ; \
 	bazel clean ; \
+	cd ../rust ; \
+	cargo clean ; \
 
 .PHONY: license-check
 license-check:


### PR DESCRIPTION
This PR adds a call to `cargo clean` for the `make` job `clean` and calls `make clean` in Jenkins.
Additionally, Jenkins is configured to abort a build if the branch was pushed to again.