### PR TITLE
Compile crypto crates with optimizations also in debug mode

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -113,8 +113,7 @@ jobs:
       with:
         workspaces: rust
     - name: cargo test
-      # Run tests with --release as some of the crypto primitives for Verkle tries are quite slow otherwise.
-      run: cargo test --release --all-features --all-targets --no-fail-fast
+      run: cargo test --all-features --all-targets --no-fail-fast
 
   miri:
     name: miri

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,6 +15,9 @@ edition = "2024"
 publish = false
 rust-version = "1.89"
 
+[profile.dev.package.banderwagon]
+opt-level = 3
+
 [lib]
 name = "carmen_rust"
 crate-type = ["rlib", "cdylib"]

--- a/rust/benches/file_backend.rs
+++ b/rust/benches/file_backend.rs
@@ -59,10 +59,10 @@ impl AccessPattern {
             AccessPattern::Random => {
                 // splitmix64
                 let rand = iter + 0x9e3779b97f4a7c15;
-                let rand = (rand ^ (rand >> 30)) * 0xbf58476d1ce4e5b9;
-                let rand = (rand ^ (rand >> 27)) * 0x94d049bb133111eb;
+                let rand = (rand ^ (rand >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
+                let rand = (rand ^ (rand >> 27)).wrapping_mul(0x94d049bb133111eb);
                 let rand = rand ^ (rand >> 31);
-                (rand * chunk_size as u64) % FILE_SIZE as u64
+                (rand.wrapping_mul(chunk_size as u64)) % FILE_SIZE as u64
             }
         }
     }


### PR DESCRIPTION
This PR configures cargo to compile the `banderwagon` crate in the `dev` profile (a.k.a. debug mode) with optimizations. This speeds up tests compiled in debug mode considerably (on my machine from 60s to 10s).

Node: In CI, the benchmarks are run as tests. Previously, we ran the tests in CI with the release profile, because otherwise they were too slow. Now that this is no longer necessary, the benchmarks are run in debug mode. The changes to the benchmarks are needed, because they are now compiled with overflow checks (default in debug mode) but we actually want to wrap here.