### PR TITLE
Refactor tests

### DIFF
--- a/rust/src/ffi/exported.rs
+++ b/rust/src/ffi/exported.rs
@@ -1163,6 +1163,8 @@ const _COMPILE_TIME_CHECK_THAT_WRAPPERS_HAVE_DOUBLE_THE_SIZE_OF_VOID_POINTERS: (
 )]
 #[cfg(test)]
 mod tests {
+    use mockall::predicate::{always, eq};
+
     use super::*;
     use crate::{MockCarmenDb, MockCarmenState};
 
@@ -1405,7 +1407,7 @@ mod tests {
             move |mock_db| {
                 mock_db
                     .expect_get_archive_state()
-                    .withf(move |b| *b == block)
+                    .with(eq(block))
                     .returning(|_| Ok(Box::new(MockCarmenState::new())));
             },
             move |db| {
@@ -1445,7 +1447,7 @@ mod tests {
             move |mock_db| {
                 mock_db
                     .expect_get_archive_state()
-                    .withf(move |b| *b == block)
+                    .with(eq(block))
                     .returning(|_| Err(crate::Error::UnsupportedOperation("some error".into())));
             },
             move |db| {
@@ -1470,7 +1472,7 @@ mod tests {
             move |mock_db| {
                 mock_db
                     .expect_account_exists()
-                    .withf(move |a| a == &addr)
+                    .with(eq(addr))
                     .returning(move |_| Ok(expected_account_state));
             },
             move |state| {
@@ -1527,7 +1529,7 @@ mod tests {
             move |mock_db| {
                 mock_db
                     .expect_account_exists()
-                    .withf(move |a| a == &addr)
+                    .with(eq(addr))
                     .returning(|_| Err(crate::Error::UnsupportedOperation("some error".into())));
             },
             move |state| {
@@ -1553,7 +1555,7 @@ mod tests {
             move |mock_db| {
                 mock_db
                     .expect_get_balance()
-                    .withf(move |a| a == &addr)
+                    .with(eq(addr))
                     .returning(move |_| Ok(expected_balance));
             },
             move |state| {
@@ -1610,7 +1612,7 @@ mod tests {
             move |mock_db| {
                 mock_db
                     .expect_get_balance()
-                    .withf(move |a| a == &addr)
+                    .with(eq(addr))
                     .returning(|_| Err(crate::Error::UnsupportedOperation("some error".into())));
             },
             move |state| {
@@ -1636,7 +1638,7 @@ mod tests {
             move |mock_db| {
                 mock_db
                     .expect_get_nonce()
-                    .withf(move |a| a == &addr)
+                    .with(eq(addr))
                     .returning(move |_| Ok(expected_nonce));
             },
             move |state| {
@@ -1693,7 +1695,7 @@ mod tests {
             move |mock_db| {
                 mock_db
                     .expect_get_nonce()
-                    .withf(move |a| a == &addr)
+                    .with(eq(addr))
                     .returning(|_| Err(crate::Error::UnsupportedOperation("some error".into())));
             },
             move |state| {
@@ -1720,7 +1722,7 @@ mod tests {
             move |mock_db| {
                 mock_db
                     .expect_get_storage_value()
-                    .withf(move |a, k| a == &addr && k == &key)
+                    .with(eq(addr), eq(key))
                     .returning(move |_, _| Ok(expected_value));
             },
             move |state| {
@@ -1794,7 +1796,7 @@ mod tests {
             move |mock_db| {
                 mock_db
                     .expect_get_storage_value()
-                    .withf(move |a, k| a == &addr && k == &key)
+                    .with(eq(addr), eq(key))
                     .returning(|_, _| Err(crate::Error::UnsupportedOperation("some error".into())));
             },
             move |state| {
@@ -1822,7 +1824,7 @@ mod tests {
             move |mock_db| {
                 mock_db
                     .expect_get_code()
-                    .withf(move |a, _| a == &addr)
+                    .with(eq(addr), always())
                     .returning(move |_, code_buf| {
                         for i in 0..expected_code.len() {
                             code_buf[i].write(expected_code[i]);
@@ -1903,7 +1905,7 @@ mod tests {
             move |mock_db| {
                 mock_db
                     .expect_get_code()
-                    .withf(move |a, _| a == &addr)
+                    .with(eq(addr), always())
                     .returning(|_, _| Err(crate::Error::UnsupportedOperation("some error".into())));
             },
             move |state| {
@@ -1931,7 +1933,7 @@ mod tests {
             move |mock_db| {
                 mock_db
                     .expect_get_code_hash()
-                    .withf(move |a| a == &addr)
+                    .with(eq(addr))
                     .returning(move |_| Ok(expected_hash));
             },
             move |state| {
@@ -1988,7 +1990,7 @@ mod tests {
             move |mock_db| {
                 mock_db
                     .expect_get_code_hash()
-                    .withf(move |a| a == &addr)
+                    .with(eq(addr))
                     .returning(|_| Err(crate::Error::UnsupportedOperation("some error".into())));
             },
             move |state| {
@@ -2014,7 +2016,7 @@ mod tests {
             move |mock_db| {
                 mock_db
                     .expect_get_code_len()
-                    .withf(move |a| a == &addr)
+                    .with(eq(addr))
                     .returning(move |_| Ok(expected_size));
             },
             move |state| {
@@ -2071,7 +2073,7 @@ mod tests {
             move |mock_db| {
                 mock_db
                     .expect_get_code_len()
-                    .withf(move |a| a == &addr)
+                    .with(eq(addr))
                     .returning(|_| Err(crate::Error::UnsupportedOperation("some error".into())));
             },
             move |state| {
@@ -2097,7 +2099,7 @@ mod tests {
             move |mock_db| {
                 mock_db
                     .expect_apply_block_update()
-                    .withf(move |b, _| *b == block)
+                    .with(eq(block), always())
                     .returning(|_, _| Ok(()));
             },
             move |state| {
@@ -2173,7 +2175,7 @@ mod tests {
             move |mock_db| {
                 mock_db
                     .expect_apply_block_update()
-                    .withf(move |b, _| *b == block)
+                    .with(eq(block), always())
                     .returning(|_, _| Err(crate::Error::UnsupportedOperation("some error".into())));
             },
             move |state| {

--- a/rust/src/node_manager/cached_node_manager.rs
+++ b/rust/src/node_manager/cached_node_manager.rs
@@ -570,10 +570,10 @@ mod tests {
             storage
                 .expect_set()
                 .times(1)
-                .withf(move |idx, value| {
-                    *idx == NodeId::from_idx_and_node_type(i, NodeType::Empty)
-                        && value == &Node::Empty
-                })
+                .with(
+                    eq(NodeId::from_idx_and_node_type(i, NodeType::Empty)),
+                    eq(Node::Empty),
+                )
                 .returning(move |_, _| Ok(()));
         }
         storage.expect_flush().times(1).returning(|| Ok(()));
@@ -644,9 +644,10 @@ mod tests {
         storage
             .expect_set()
             .times(1)
-            .withf(move |idx, value| {
-                *idx == NodeId::from_idx_and_node_type(0, NodeType::Empty) && value == &Node::Empty
-            })
+            .with(
+                eq(NodeId::from_idx_and_node_type(0, NodeType::Empty)),
+                eq(Node::Empty),
+            )
             .returning(|_, _| Ok(()));
 
         // With unit-size cache, each item is immediately evicted

--- a/rust/src/storage/file/file_backend.rs
+++ b/rust/src/storage/file/file_backend.rs
@@ -278,7 +278,7 @@ mod tests {
 
     #[rstest_reuse::apply(open_backend)]
     fn write_all_at_can_write_across_pages(#[case] open_backend_fn: OpenBackendFn) {
-        let tempdir = tempfile::tempdir().unwrap();
+        let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
         let path = tempdir.path().join("test_file.bin");
 
         let mut options = OpenOptions::new();
@@ -301,7 +301,7 @@ mod tests {
 
     #[rstest_reuse::apply(open_backend)]
     fn write_all_at_can_write_data_to_different_pages(#[case] open_backend_fn: OpenBackendFn) {
-        let tempdir = tempfile::tempdir().unwrap();
+        let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
         let path = tempdir.path().join("test_file.bin");
 
         let mut options = OpenOptions::new();
@@ -358,7 +358,7 @@ mod tests {
 
     #[rstest_reuse::apply(open_backend)]
     fn read_exact_at_can_read_across_pages(#[case] open_backend_fn: OpenBackendFn) {
-        let tempdir = tempfile::tempdir().unwrap();
+        let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
         let path = tempdir.path().join("test_file.bin");
 
         let mut options = OpenOptions::new();
@@ -380,7 +380,7 @@ mod tests {
 
     #[rstest_reuse::apply(open_backend)]
     fn read_exact_at_can_read_data_from_different_pages(#[case] open_backend_fn: OpenBackendFn) {
-        let tempdir = tempfile::tempdir().unwrap();
+        let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
         let path = tempdir.path().join("test_file.bin");
 
         let mut options = OpenOptions::new();
@@ -430,7 +430,7 @@ mod tests {
         const THREADS: usize = 128;
         const PAGES: usize = 100;
 
-        let tempdir = tempfile::tempdir().unwrap();
+        let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
         let path = tempdir.path().join("test_file.bin");
 
         let mut options = OpenOptions::new();

--- a/rust/src/utils/test_dir.rs
+++ b/rust/src/utils/test_dir.rs
@@ -65,6 +65,12 @@ impl TestDir {
     }
 }
 
+impl AsRef<Path> for TestDir {
+    fn as_ref(&self) -> &Path {
+        &self.dir
+    }
+}
+
 impl Drop for TestDir {
     /// Deletes the test directory and its contents
     fn drop(&mut self) {
@@ -169,7 +175,7 @@ mod tests {
         let non_existent_path = PathBuf::from("non_existent_dir");
         let result = set_permissions(&non_existent_path, Permissions::ReadWrite)
             .expect_err("set_permissions should fail for non-existent directory");
-        assert!(result.kind() == std::io::ErrorKind::NotFound);
+        assert_eq!(result.kind(), std::io::ErrorKind::NotFound);
     }
 
     #[test]
@@ -197,6 +203,12 @@ mod tests {
         let test_dir = TestDir::try_new(Permissions::ReadWrite).unwrap();
         let permissions = fs::metadata(test_dir.path()).unwrap().permissions();
         assert_eq!(permissions.mode() & 0o777, Permissions::ReadWrite.mode());
+    }
+
+    #[test]
+    fn as_ref_returns_path() {
+        let test_dir = TestDir::try_new(Permissions::ReadWrite).unwrap();
+        assert_eq!(test_dir.as_ref(), test_dir.path());
     }
 
     #[test]


### PR DESCRIPTION
This PR refactors tests, mostly in the `storage` module.
The changes are for the most part:
- use `mockall::predicate::eq` instead of writing closures by hand
- use `TestDir` instead of `tempdir`
- impl `AsRef<Path>` for `TestDir`