### PR TITLE
Prepare interfaces for checkpoints

### DIFF
--- a/rust/src/storage/file/file_storage_manager.rs
+++ b/rust/src/storage/file/file_storage_manager.rs
@@ -192,7 +192,7 @@ mod tests {
         for sub_dir in &sub_dirs {
             fs::create_dir_all(dir.join(sub_dir)).unwrap();
             // because we are not writing any nodes, the node type does not matter
-            NodeFileStorage::<InnerNode, SeekFile>::create_files_for_nodes(&dir, &[]).unwrap();
+            NodeFileStorage::<InnerNode, SeekFile>::create_files_for_nodes(&dir, &[], &[]).unwrap();
         }
 
         let storage = FileStorageManager::open(&dir);

--- a/rust/src/storage/file/metadata_file.rs
+++ b/rust/src/storage/file/metadata_file.rs
@@ -24,9 +24,10 @@ use crate::storage::Error;
 pub struct Metadata {
     /// The checkpoint number.
     pub checkpoint: u64,
-    /// The number of frozen nodes that can not be modified.
+    /// The number of frozen nodes that can not be modified because they are part of a checkpoint.
     pub frozen_nodes: u64,
-    /// The number of frozen reuse indices that can not be reused.
+    /// The number of frozen reuse indices that can not be reused because they are part of a
+    /// checkpoint.
     pub frozen_reuse_indices: u64,
 }
 

--- a/rust/src/storage/file/metadata_file.rs
+++ b/rust/src/storage/file/metadata_file.rs
@@ -9,8 +9,9 @@
 // this software will be governed by the GNU Lesser General Public License v3.
 
 use std::{
-    fs::File,
-    io::{Read, Seek, SeekFrom, Write},
+    fs::{self, File},
+    io::Read,
+    path::Path,
 };
 
 use zerocopy::{FromBytes, Immutable, IntoBytes};
@@ -18,55 +19,42 @@ use zerocopy::{FromBytes, Immutable, IntoBytes};
 use crate::storage::Error;
 
 /// Metadata stored in the metadata file.
-#[derive(Debug, Default, PartialEq, Eq, FromBytes, IntoBytes, Immutable)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, FromBytes, IntoBytes, Immutable)]
 #[repr(C)]
 pub struct Metadata {
-    pub node_count: u64,
-    pub reuse_frozen_count: u64,
+    pub checkpoint: u64,
+    pub frozen_nodes: u64,
+    pub frozen_reuse_indices: u64,
 }
 
-/// A file that stores metadata about the data of the
-/// [`NodeFileStorage`](crate::storage::file::NodeFileStorage) store for a certain node type.
-#[derive(Debug)]
-pub struct MetadataFile {
-    file: File,
-}
-
-impl MetadataFile {
-    /// Creates a new [`MetadataFile`] instance.
-    pub fn new(file: File) -> Self {
-        Self { file }
-    }
-
-    /// Reads the metadata from the file or returns [`Metadata::default`] if the file is empty.
-    pub fn read(&self) -> Result<Metadata, Error> {
-        let len = self.file.metadata().unwrap().len();
-        if len == 0 {
-            return Ok(Metadata::default());
-        } else if len != size_of::<Metadata>() as u64 {
-            return Err(Error::DatabaseCorruption);
+impl Metadata {
+    /// Reads the metadata from the file. It the file does not exit, it is initialized with
+    /// [`Metadata::default`].
+    pub fn read(path: impl AsRef<Path>) -> Result<Self, Error> {
+        let path = path.as_ref();
+        if !fs::exists(path)? {
+            fs::write(path, Self::default().as_bytes())?;
         }
         let mut metadata = Metadata::default();
-        (&self.file).seek(SeekFrom::Start(0)).unwrap();
-        (&self.file).read_exact(metadata.as_mut_bytes())?;
-        Ok(metadata)
+        let mut file = File::open(path)?;
+        match file.read_exact(metadata.as_mut_bytes()) {
+            Ok(_) => Ok(metadata),
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                Err(Error::DatabaseCorruption)
+            }
+            Err(e) => Err(Error::Io(e)),
+        }
     }
 
     /// Writes the metadata to the file.
-    pub fn write(&self, metadata: &Metadata) -> Result<(), Error> {
-        let mut file = &self.file;
-        file.seek(SeekFrom::Start(0))?;
-        file.write_all(metadata.as_bytes())?;
-        file.sync_all()?;
-
+    pub fn write(&self, path: impl AsRef<Path>) -> Result<(), Error> {
+        fs::write(path.as_ref(), self.as_bytes())?;
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::fs::{self, File, OpenOptions};
-
     use zerocopy::IntoBytes;
 
     use super::*;
@@ -77,27 +65,26 @@ mod tests {
         let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
         let path = tempdir.join("metadata");
 
-        let node_count: u64 = 1;
-        let reuse_frozen_count: u64 = 2;
+        let checkpoint: u64 = 1;
+        let node_count: u64 = 2;
+        let reuse_frozen_count: u64 = 3;
 
-        let data = [node_count, reuse_frozen_count];
+        let data = [checkpoint, node_count, reuse_frozen_count];
         fs::write(path.as_path(), data.as_bytes()).unwrap();
 
-        let metadata_file = MetadataFile::new(File::open(path).unwrap());
-        let metadata = metadata_file.read().unwrap();
-        assert_eq!(metadata.node_count, node_count);
-        assert_eq!(metadata.reuse_frozen_count, reuse_frozen_count);
+        let metadata = Metadata::read(path).unwrap();
+        assert_eq!(metadata.frozen_nodes, node_count);
+        assert_eq!(metadata.frozen_reuse_indices, reuse_frozen_count);
     }
 
     #[test]
-    fn read_returns_zeroed_metadata_for_empty_file() {
+    fn read_returns_default_metadata_if_file_does_not_exist() {
         let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
         let path = tempdir.join("metadata");
 
-        let metadata_file = MetadataFile::new(File::create(path).unwrap());
-        let metadata = metadata_file.read().unwrap();
-        assert_eq!(metadata.node_count, 0);
-        assert_eq!(metadata.reuse_frozen_count, 0);
+        let metadata = Metadata::read(path).unwrap();
+        assert_eq!(metadata.frozen_nodes, 0);
+        assert_eq!(metadata.frozen_reuse_indices, 0);
     }
 
     #[test]
@@ -107,8 +94,7 @@ mod tests {
 
         fs::write(&path, [0u8; 10]).unwrap();
 
-        let metadata_file = MetadataFile::new(File::open(path).unwrap());
-        let result = metadata_file.read();
+        let result = Metadata::read(path);
         assert!(matches!(result, Err(Error::DatabaseCorruption)));
     }
 
@@ -117,11 +103,11 @@ mod tests {
         let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
         let path = tempdir.join("metadata");
 
-        // this is needed so that the file is not empty and actually has to be read
-        fs::write(path.as_path(), [0u8; 16]).unwrap();
+        // create the file so make sue Metadata::read tries to open it
+        fs::write(&path, []).unwrap();
+        tempdir.set_permissions(Permissions::WriteOnly).unwrap();
 
-        let metadata_file = MetadataFile::new(OpenOptions::new().write(true).open(path).unwrap());
-        let result = metadata_file.read();
+        let result = Metadata::read(&path);
         assert!(matches!(result, Err(Error::Io(_))));
     }
 
@@ -130,23 +116,21 @@ mod tests {
         let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
         let path = tempdir.join("metadata");
 
-        let node_count: u64 = 1;
-        let reuse_frozen_count: u64 = 2;
+        let checkpoint: u64 = 1;
+        let frozen_nodes: u64 = 2;
+        let frozen_reuse_indices: u64 = 3;
 
-        {
-            let metadata_file = MetadataFile::new(File::create(path.as_path()).unwrap());
-            let metadata = Metadata {
-                node_count,
-                reuse_frozen_count,
-            };
-            metadata_file.write(&metadata).unwrap();
-        }
+        let metadata = Metadata {
+            checkpoint,
+            frozen_nodes,
+            frozen_reuse_indices,
+        };
+        metadata.write(&path).unwrap();
 
         let mut file = File::open(path).unwrap();
-        let mut data = [0; 2];
+        let mut data = [0; 3];
         file.read_exact(data.as_mut_bytes()).unwrap();
-        assert_eq!(data[0], node_count);
-        assert_eq!(data[1], reuse_frozen_count);
+        assert_eq!(data, [checkpoint, frozen_nodes, frozen_reuse_indices]);
     }
 
     #[test]
@@ -154,14 +138,7 @@ mod tests {
         let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
         let path = tempdir.join("metadata");
 
-        File::create(path.as_path()).unwrap();
-
-        let metadata_file = MetadataFile::new(File::open(path).unwrap());
-        let metadata = Metadata {
-            node_count: 1,
-            reuse_frozen_count: 2,
-        };
-        let result = metadata_file.write(&metadata);
+        let result = Metadata::default().write(&path);
         assert!(matches!(result, Err(Error::Io(_))));
     }
 
@@ -170,20 +147,12 @@ mod tests {
         let dir = TestDir::try_new(Permissions::ReadWrite).unwrap();
         let path = dir.join("metadata");
 
-        let file = OpenOptions::new()
-            .create(true)
-            .truncate(false)
-            .read(true)
-            .write(true)
-            .open(path.as_path())
-            .unwrap();
-
-        let metadata_file = MetadataFile::new(file);
         let metadata = Metadata {
-            node_count: 1,
-            reuse_frozen_count: 2,
+            checkpoint: 1,
+            frozen_nodes: 2,
+            frozen_reuse_indices: 3,
         };
-        metadata_file.write(&metadata).unwrap();
-        assert_eq!(metadata_file.read().unwrap(), metadata);
+        metadata.write(&path).unwrap();
+        assert_eq!(Metadata::read(&path).unwrap(), metadata);
     }
 }

--- a/rust/src/storage/file/metadata_file.rs
+++ b/rust/src/storage/file/metadata_file.rs
@@ -22,13 +22,16 @@ use crate::storage::Error;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, FromBytes, IntoBytes, Immutable)]
 #[repr(C)]
 pub struct Metadata {
+    /// The checkpoint number.
     pub checkpoint: u64,
+    /// The number of frozen nodes that can not be modified.
     pub frozen_nodes: u64,
+    /// The number of frozen reuse indices that can not be reused.
     pub frozen_reuse_indices: u64,
 }
 
 impl Metadata {
-    /// Reads the metadata from the file. It the file does not exit, it is initialized with
+    /// Reads the metadata from the file. It the file does not exist, it is initialized with
     /// [`Metadata::default`].
     pub fn read(path: impl AsRef<Path>) -> Result<Self, Error> {
         let path = path.as_ref();
@@ -83,8 +86,7 @@ mod tests {
         let path = tempdir.join("metadata");
 
         let metadata = Metadata::read(path).unwrap();
-        assert_eq!(metadata.frozen_nodes, 0);
-        assert_eq!(metadata.frozen_reuse_indices, 0);
+        assert_eq!(metadata, Metadata::default());
     }
 
     #[test]
@@ -103,7 +105,7 @@ mod tests {
         let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
         let path = tempdir.join("metadata");
 
-        // create the file so make sue Metadata::read tries to open it
+        // Create the file so make sure Metadata::read tries to open it.
         fs::write(&path, []).unwrap();
         tempdir.set_permissions(Permissions::WriteOnly).unwrap();
 
@@ -135,7 +137,7 @@ mod tests {
 
     #[test]
     fn write_fails_if_file_cannot_be_written() {
-        let tempdir = TestDir::try_new(Permissions::ReadWrite).unwrap();
+        let tempdir = TestDir::try_new(Permissions::ReadOnly).unwrap();
         let path = tempdir.join("metadata");
 
         let result = Metadata::default().write(&path);

--- a/rust/src/storage/file/node_file_storage.rs
+++ b/rust/src/storage/file/node_file_storage.rs
@@ -9,11 +9,11 @@
 // this software will be governed by the GNU Lesser General Public License v3.
 
 use std::{
-    fs::OpenOptions,
+    fs::{self, OpenOptions},
     marker::PhantomData,
-    path::Path,
+    path::{Path, PathBuf},
     sync::{
-        Mutex,
+        Mutex, RwLock,
         atomic::{AtomicU64, Ordering},
     },
 };
@@ -22,11 +22,7 @@ use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 use crate::storage::{
     Error, Storage,
-    file::{
-        FileBackend,
-        metadata_file::{Metadata, MetadataFile},
-        reuse_list_file::ReuseListFile,
-    },
+    file::{FileBackend, metadata_file::Metadata, reuse_list_file::ReuseListFile},
 };
 
 /// A file-based storage backend for elements of type `T`.
@@ -39,10 +35,15 @@ where
     T: FromBytes + IntoBytes + Immutable + 'static,
     F: FileBackend + 'static,
 {
+    checkpoint: AtomicU64,
+    metadata: RwLock<Metadata>,
+    metadata_file: PathBuf,
+
     node_file: F,
-    reuse_list_file: Mutex<ReuseListFile>,
-    metadata_file: MetadataFile,
     next_idx: AtomicU64,
+
+    reuse_list_file: Mutex<ReuseListFile>,
+
     _node_type: PhantomData<T>,
 }
 
@@ -69,7 +70,9 @@ where
     /// If the files do not exist, they will be created.
     /// If the files exist, they will be opened and their data verified.
     fn open(dir: &Path) -> Result<Self, Error> {
-        std::fs::create_dir_all(dir)?;
+        fs::create_dir_all(dir)?;
+
+        let metadata = Metadata::read(dir.join(Self::METADATA_FILE))?;
 
         let mut file_opts = OpenOptions::new();
         file_opts
@@ -78,32 +81,32 @@ where
             .read(true)
             .write(true);
 
-        let metadata_file = MetadataFile::new(file_opts.open(dir.join(Self::METADATA_FILE))?);
-        let metadata = metadata_file.read()?;
-
         let reuse_file = file_opts.open(dir.join(Self::REUSE_LIST_FILE))?;
-        let reuse_list_file = ReuseListFile::new(reuse_file, metadata.reuse_frozen_count)?;
+        let reuse_list_file = ReuseListFile::new(reuse_file, metadata.frozen_reuse_indices)?;
         if reuse_list_file
             .as_slice()
             .iter()
-            .any(|&idx| idx >= metadata.node_count)
+            .any(|&idx| idx >= metadata.frozen_nodes)
         {
             return Err(Error::DatabaseCorruption);
         }
 
         let node_file = F::open(dir.join(Self::NODE_STORE_FILE).as_path(), file_opts)?;
         let len = node_file.len()?;
-        if len < metadata.node_count * size_of::<T>() as u64 {
+        if len < metadata.frozen_nodes * size_of::<T>() as u64 {
             return Err(Error::DatabaseCorruption);
         }
 
-        let next_idx = AtomicU64::new(metadata.node_count);
-
         Ok(Self {
+            checkpoint: AtomicU64::new(metadata.checkpoint),
+            metadata: RwLock::new(metadata),
+            metadata_file: dir.join(Self::METADATA_FILE),
+
             node_file,
+            next_idx: AtomicU64::new(metadata.frozen_nodes),
+
             reuse_list_file: Mutex::new(reuse_list_file),
-            metadata_file,
-            next_idx,
+
             _node_type: PhantomData,
         })
     }
@@ -149,15 +152,17 @@ where
 
         let mut reuse_file = self.reuse_list_file.lock().unwrap();
         reuse_file.write()?;
-        let reuse_frozen_count = reuse_file.len();
+        let reuse_frozen_count = reuse_file.count();
         reuse_file.set_frozen_count(reuse_frozen_count);
         drop(reuse_file);
 
-        let metadata = Metadata {
-            node_count: self.next_idx.load(Ordering::Relaxed),
-            reuse_frozen_count: reuse_frozen_count as u64,
+        let mut metadata = self.metadata.write().unwrap();
+        *metadata = Metadata {
+            checkpoint: self.checkpoint.load(Ordering::Acquire),
+            frozen_nodes: self.next_idx.load(Ordering::Acquire),
+            frozen_reuse_indices: reuse_frozen_count as u64,
         };
-        self.metadata_file.write(&metadata)?;
+        metadata.write(&self.metadata_file)?;
 
         Ok(())
     }
@@ -219,7 +224,7 @@ mod tests {
         // files have valid sizes
         {
             let dir = TestDir::try_new(Permissions::ReadWrite).unwrap();
-            write_metadata(&dir, 1, 1);
+            write_metadata(&dir, 0, 1, 1);
             write_reuse_list(&dir, &[0]);
             write_nodes(&dir, &[[0; 32]]);
 
@@ -228,7 +233,7 @@ mod tests {
         // metadata contains larger node count that node file sizes allows
         {
             let dir = TestDir::try_new(Permissions::ReadWrite).unwrap();
-            write_metadata(&dir, 2, 0);
+            write_metadata(&dir, 0, 2, 0);
             write_reuse_list(&dir, &[0]);
             write_nodes(&dir, &[[0; 32]]);
 
@@ -240,7 +245,7 @@ mod tests {
         // metadata contains larger frozen count that reuse list file sizes allows
         {
             let dir = TestDir::try_new(Permissions::ReadWrite).unwrap();
-            write_metadata(&dir, 0, 2);
+            write_metadata(&dir, 0, 0, 2);
             write_reuse_list(&dir, &[0]);
             write_nodes(&dir, &[[0; 32]]);
 
@@ -252,7 +257,7 @@ mod tests {
         // reuse list contains indices which are larger than node count in metadata
         {
             let dir = TestDir::try_new(Permissions::ReadWrite).unwrap();
-            write_metadata(&dir, 0, 0);
+            write_metadata(&dir, 0, 0, 0);
             write_reuse_list(&dir, &[1]);
             write_nodes(&dir, &[]);
 
@@ -274,7 +279,7 @@ mod tests {
     fn get_reads_data_if_index_in_bounds() {
         let dir = TestDir::try_new(Permissions::ReadWrite).unwrap();
 
-        write_metadata(&dir, 2, 0);
+        write_metadata(&dir, 0, 2, 0);
         write_reuse_list(&dir, &[]);
         write_nodes(&dir, &[[0; 32], [1; 32]]);
 
@@ -289,7 +294,7 @@ mod tests {
     fn reserve_returns_last_index_from_reuse_list() {
         let dir = TestDir::try_new(Permissions::ReadWrite).unwrap();
 
-        write_metadata(&dir, 3, 0);
+        write_metadata(&dir, 0, 3, 0);
         write_reuse_list(&dir, &[0, 2]);
         write_nodes(&dir, &[[0; 32], [1; 32], [2; 32]]);
 
@@ -305,7 +310,7 @@ mod tests {
         let dir = TestDir::try_new(Permissions::ReadWrite).unwrap();
 
         // create a single node -> index 0 is used
-        write_metadata(&dir, 1, 0);
+        write_metadata(&dir, 0, 1, 0);
         write_reuse_list(&dir, &[]);
         write_nodes(&dir, &[[0; 32]]);
 
@@ -319,7 +324,7 @@ mod tests {
         let dir = TestDir::try_new(Permissions::ReadWrite).unwrap();
 
         // prepare file: write some nodes into the file
-        write_metadata(&dir, 2, 0);
+        write_metadata(&dir, 0, 2, 0);
         write_reuse_list(&dir, &[]);
         write_nodes(&dir, &[[0; 32], [1; 32]]);
 
@@ -371,7 +376,7 @@ mod tests {
     fn delete_adds_index_to_reuse_list() {
         let dir = TestDir::try_new(Permissions::ReadWrite).unwrap();
 
-        write_metadata(&dir, 2, 0);
+        write_metadata(&dir, 0, 2, 0);
         write_reuse_list(&dir, &[]);
         write_nodes(&dir, &[[0; 32], [1; 32]]);
 
@@ -425,39 +430,40 @@ mod tests {
         F: FileBackend + 'static,
     {
         /// Creates all files for a file-based node storage in the specified directory
-        /// and populates them with the provided nodes.
+        /// and populates them with the provided nodes and reusable indices.
+        /// Both the nodes and the reusable indices are frozen, as [`NodeFileStorage::open`] only
+        /// considers frozen data to exist.
         pub fn create_files_for_nodes(path: impl AsRef<Path>, nodes: &[T]) -> Result<(), Error> {
-            use std::{fs::File, io::Write};
-
             let path = path.as_ref();
 
-            std::fs::create_dir_all(path)?;
+            fs::create_dir_all(path)?;
 
-            let metadata_file = MetadataFile::new(File::create(path.join(Self::METADATA_FILE))?);
-            metadata_file
-                .write(&Metadata {
-                    node_count: nodes.len() as u64,
-                    reuse_frozen_count: 0,
-                })
-                .unwrap();
-
-            let mut node_file = File::create(path.join(Self::NODE_STORE_FILE))?;
-            for node in nodes {
-                node_file.write_all(node.as_bytes())?;
+            Metadata {
+                checkpoint: 0,
+                frozen_nodes: nodes.len() as u64,
+                frozen_reuse_indices: 0,
             }
-            node_file.flush()?;
+            .write(path.join(Self::METADATA_FILE))?;
+            fs::write(path.join(Self::REUSE_LIST_FILE), [])?;
+            fs::write(path.join(Self::NODE_STORE_FILE), nodes.as_bytes())?;
 
             Ok(())
         }
     }
 
-    fn write_metadata(dir: impl AsRef<Path>, node_count: u64, reuse_frozen_count: u64) {
-        MetadataFile::new(File::create(dir.as_ref().join(NodeFileStorage::METADATA_FILE)).unwrap())
-            .write(&Metadata {
-                node_count,
-                reuse_frozen_count,
-            })
-            .unwrap();
+    fn write_metadata(
+        dir: impl AsRef<Path>,
+        checkpoint: u64,
+        frozen_nodes: u64,
+        frozen_reuse_indices: u64,
+    ) {
+        Metadata {
+            checkpoint,
+            frozen_nodes,
+            frozen_reuse_indices,
+        }
+        .write(dir.as_ref().join(NodeFileStorage::METADATA_FILE))
+        .unwrap();
     }
 
     fn write_reuse_list(dir: impl AsRef<Path>, indices: &[u64]) {

--- a/rust/src/storage/file/reuse_list_file.rs
+++ b/rust/src/storage/file/reuse_list_file.rs
@@ -62,6 +62,18 @@ impl ReuseListFile {
         Ok(())
     }
 
+    /// Freezes all currently cached indices.
+    pub fn freeze_all(&mut self) {
+        self.frozen_count = self.cache.len();
+    }
+
+    /// Returns the number of frozen indices.
+    #[cfg(test)]
+    pub fn frozen_count(&self) -> usize {
+        self.frozen_count
+    }
+
+    /// Sets the number of frozen indices.
     pub fn set_frozen_count(&mut self, frozen_count: usize) {
         self.frozen_count = frozen_count;
     }
@@ -85,7 +97,7 @@ impl ReuseListFile {
     }
 
     /// Returns the number of cached indices.
-    pub fn len(&self) -> usize {
+    pub fn count(&self) -> usize {
         self.cache.len()
     }
 }
@@ -178,7 +190,37 @@ mod tests {
     }
 
     #[test]
-    fn update_fronzen_count_changes_value() {
+    fn freeze_all_sets_frozen_count_to_current_length() {
+        let dir = TestDir::try_new(Permissions::ReadWrite).unwrap();
+        let path = dir.path().join("reuse_list");
+
+        let mut cached_file = ReuseListFile {
+            file: File::create(path).unwrap(),
+            cache: vec![1, 2, 3, 4],
+            frozen_count: 2,
+        };
+
+        assert_eq!(cached_file.frozen_count, 2);
+        cached_file.freeze_all();
+        assert_eq!(cached_file.frozen_count, 4);
+    }
+
+    #[test]
+    fn frozen_count_returns_number_of_frozen_elements() {
+        let dir = TestDir::try_new(Permissions::ReadWrite).unwrap();
+        let path = dir.path().join("reuse_list");
+
+        let cached_file = ReuseListFile {
+            file: File::create(path).unwrap(),
+            cache: vec![1, 2, 3, 4],
+            frozen_count: 2,
+        };
+
+        assert_eq!(cached_file.frozen_count(), 2);
+    }
+
+    #[test]
+    fn set_frozen_count_updates_value() {
         let dir = TestDir::try_new(Permissions::ReadWrite).unwrap();
         let path = dir.join("reuse_list");
 
@@ -248,7 +290,7 @@ mod tests {
     }
 
     #[test]
-    fn len_returns_number_of_cached_elements() {
+    fn count_returns_number_of_cached_elements() {
         let dir = TestDir::try_new(Permissions::ReadWrite).unwrap();
         let path = dir.join("reuse_list");
 
@@ -258,6 +300,6 @@ mod tests {
             frozen_count: 2,
         };
 
-        assert_eq!(cached_file.len(), 4);
+        assert_eq!(cached_file.count(), 4);
     }
 }


### PR DESCRIPTION
This PR adjusts a few interfaces in preparation for checkpoint support in #135.

The `Metadata` now also contains the checkpoint number. Because when doing checkpoints, metadata files are created and renamed on the fly, it is not desirable to hold an opened metadata file. Therefore, `MetadataFile` is removed, and `Metadata` now has the methods `read` and `write`.

For `ReuseListFile`, it is now possible to freeze all currently stored items (needed for preparing a checkpoint) and setting the frozen count (needed for aborting a checkpoint). Also, `len` was renamed to `count` so make it more obvious that this is the number of elements in the file and not the file length.

Lastly, `NodeFileStorage` now stores the current checkpoint, the current metadata and the metadata file path.