### PR TITLE
Add NodeSize trait and implemetation for Node, NodeType and NodeId

### DIFF
--- a/rust/src/types/id.rs
+++ b/rust/src/types/id.rs
@@ -94,7 +94,7 @@ impl NodeId {
 
 impl NodeSize for NodeId {
     /// Returns the byte size of the [`NodeType`] it refers to.
-    /// This may panic if the [`NodeId`] is invalid
+    /// Panics if the ID does not refer to a valid node type.
     fn byte_size(&self) -> usize {
         self.to_node_type().unwrap().byte_size()
     }

--- a/rust/src/types/id.rs
+++ b/rust/src/types/id.rs
@@ -10,7 +10,7 @@
 
 use zerocopy::{FromBytes, Immutable, IntoBytes, Unaligned};
 
-use crate::types::NodeType;
+use crate::types::{NodeSize, NodeType};
 
 /// An identifier for a node in a (file-based) Verkle trie.
 // NOTE: Changing the layout of this struct will break backwards compatibility of the
@@ -92,6 +92,18 @@ impl NodeId {
     }
 }
 
+impl NodeSize for NodeId {
+    /// Returns the byte size of the [`NodeType`] it refers to.
+    fn byte_size(&self) -> usize {
+        self.to_node_type().unwrap().byte_size()
+    }
+
+    /// Returns the minimum byte size of [`NodeType`].
+    fn min_size() -> usize {
+        NodeType::min_size()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -166,5 +178,35 @@ mod tests {
     fn to_u64_converts_node_id_to_integer_with_lower_6_bytes() {
         let id = NodeId([0x12, 0x34, 0x56, 0x78, 0x90, 0xab]);
         assert_eq!(id.to_u64(), 0x1234_5678_90ab);
+    }
+
+    #[test]
+    fn node_id_byte_size_returns_byte_size_of_encoded_node_type() {
+        let cases = [
+            (
+                NodeId::from_idx_and_node_type(0, NodeType::Empty),
+                NodeType::Empty,
+            ),
+            (
+                NodeId::from_idx_and_node_type(0, NodeType::Inner),
+                NodeType::Inner,
+            ),
+            (
+                NodeId::from_idx_and_node_type(0, NodeType::Leaf2),
+                NodeType::Leaf2,
+            ),
+            (
+                NodeId::from_idx_and_node_type(0, NodeType::Leaf256),
+                NodeType::Leaf256,
+            ),
+        ];
+        for (node_id, node_type) in cases {
+            assert_eq!(node_id.byte_size(), node_type.byte_size());
+        }
+    }
+
+    #[test]
+    fn node_id_min_size_returns_min_byte_size_of_node_type() {
+        assert_eq!(NodeId::min_size(), NodeType::min_size());
     }
 }

--- a/rust/src/types/id.rs
+++ b/rust/src/types/id.rs
@@ -95,13 +95,13 @@ impl NodeId {
 impl NodeSize for NodeId {
     /// Returns the byte size of the [`NodeType`] it refers to.
     /// Panics if the ID does not refer to a valid node type.
-    fn byte_size(&self) -> usize {
-        self.to_node_type().unwrap().byte_size()
+    fn node_byte_size(&self) -> usize {
+        self.to_node_type().unwrap().node_byte_size()
     }
 
     /// Returns the minimum byte size of [`NodeType`].
-    fn min_size() -> usize {
-        NodeType::min_size()
+    fn min_non_empty_node_size() -> usize {
+        NodeType::min_non_empty_node_size()
     }
 }
 
@@ -202,12 +202,15 @@ mod tests {
             ),
         ];
         for (node_id, node_type) in cases {
-            assert_eq!(node_id.byte_size(), node_type.byte_size());
+            assert_eq!(node_id.node_byte_size(), node_type.node_byte_size());
         }
     }
 
     #[test]
-    fn node_id_min_size_returns_min_byte_size_of_node_type() {
-        assert_eq!(NodeId::min_size(), NodeType::min_size());
+    fn node_id_min_non_empty_node_size_returns_min_byte_size_of_node_type() {
+        assert_eq!(
+            NodeId::min_non_empty_node_size(),
+            NodeType::min_non_empty_node_size()
+        );
     }
 }

--- a/rust/src/types/id.rs
+++ b/rust/src/types/id.rs
@@ -94,6 +94,7 @@ impl NodeId {
 
 impl NodeSize for NodeId {
     /// Returns the byte size of the [`NodeType`] it refers to.
+    /// This may panic if the [`NodeId`] is invalid
     fn byte_size(&self) -> usize {
         self.to_node_type().unwrap().byte_size()
     }

--- a/rust/src/types/node.rs
+++ b/rust/src/types/node.rs
@@ -153,12 +153,12 @@ impl NodeSize for NodeType {
                 std::mem::size_of::<Box<FullLeafNode>>() + std::mem::size_of::<FullLeafNode>()
             }
         };
-        std::mem::size_of::<Self>() + inner_size
+        std::mem::size_of::<Node>() + inner_size
     }
 
     fn min_size() -> usize {
         // Because we don't store empty nodes, the minimum size is the smallest non-empty node.
-        size_of::<Self>() + size_of::<Box<SparseLeafNode<2>>>() + size_of::<SparseLeafNode<2>>()
+        size_of::<Node>() + size_of::<Box<SparseLeafNode<2>>>() + size_of::<SparseLeafNode<2>>()
     }
 }
 

--- a/rust/src/types/node.rs
+++ b/rust/src/types/node.rs
@@ -158,7 +158,7 @@ impl NodeSize for NodeType {
 
     fn min_size() -> usize {
         // Because we don't store empty nodes, the minimum size is the smallest non-empty node.
-        size_of::<Node>() + size_of::<Box<SparseLeafNode<2>>>() + size_of::<SparseLeafNode<2>>()
+        NodeType::Leaf2.byte_size()
     }
 }
 

--- a/rust/src/types/node.rs
+++ b/rust/src/types/node.rs
@@ -119,12 +119,12 @@ impl Node {
 }
 
 impl NodeSize for Node {
-    fn byte_size(&self) -> usize {
-        self.to_node_type().byte_size()
+    fn node_byte_size(&self) -> usize {
+        self.to_node_type().node_byte_size()
     }
 
-    fn min_size() -> usize {
-        NodeType::min_size()
+    fn min_non_empty_node_size() -> usize {
+        NodeType::min_non_empty_node_size()
     }
 }
 
@@ -139,7 +139,7 @@ pub enum NodeType {
 }
 
 impl NodeSize for NodeType {
-    fn byte_size(&self) -> usize {
+    fn node_byte_size(&self) -> usize {
         let inner_size = match self {
             NodeType::Empty => 0,
             NodeType::Inner => {
@@ -156,19 +156,19 @@ impl NodeSize for NodeType {
         std::mem::size_of::<Node>() + inner_size
     }
 
-    fn min_size() -> usize {
+    fn min_non_empty_node_size() -> usize {
         // Because we don't store empty nodes, the minimum size is the smallest non-empty node.
-        NodeType::Leaf2.byte_size()
+        NodeType::Leaf2.node_byte_size()
     }
 }
 
 /// A trait to determine the size of a node.
 pub trait NodeSize {
     /// Returns the size of the node in bytes.
-    fn byte_size(&self) -> usize;
+    fn node_byte_size(&self) -> usize;
 
-    /// Returns the minimum size of a node in bytes.
-    fn min_size() -> usize;
+    /// Returns the minimum size of a non-empty node in bytes.
+    fn min_non_empty_node_size() -> usize;
 }
 
 #[cfg(test)]
@@ -214,21 +214,21 @@ mod tests {
         let leaf2_node = NodeType::Leaf2;
         let leaf256_node = NodeType::Leaf256;
 
-        assert_eq!(empty_node.byte_size(), std::mem::size_of::<Node>());
+        assert_eq!(empty_node.node_byte_size(), std::mem::size_of::<Node>());
         assert_eq!(
-            inner_node.byte_size(),
+            inner_node.node_byte_size(),
             std::mem::size_of::<Node>()
                 + std::mem::size_of::<Box<InnerNode>>()
                 + std::mem::size_of::<InnerNode>()
         );
         assert_eq!(
-            leaf2_node.byte_size(),
+            leaf2_node.node_byte_size(),
             std::mem::size_of::<Node>()
                 + std::mem::size_of::<Box<SparseLeafNode<2>>>()
                 + std::mem::size_of::<SparseLeafNode<2>>()
         );
         assert_eq!(
-            leaf256_node.byte_size(),
+            leaf256_node.node_byte_size(),
             std::mem::size_of::<Node>()
                 + std::mem::size_of::<Box<FullLeafNode>>()
                 + std::mem::size_of::<FullLeafNode>()
@@ -236,10 +236,10 @@ mod tests {
     }
 
     #[test]
-    fn node_type_min_size_returns_size_of_smallest_non_empty_node() {
+    fn node_type_min_non_empty_node_size_returns_size_of_smallest_non_empty_node() {
         assert_eq!(
-            NodeType::min_size(),
-            Node::Leaf2(Box::default()).byte_size()
+            NodeType::min_non_empty_node_size(),
+            Node::Leaf2(Box::default()).node_byte_size()
         );
     }
 
@@ -250,14 +250,29 @@ mod tests {
         let leaf2_node = Node::Leaf2(Box::default());
         let leaf256_node = Node::Leaf256(Box::default());
 
-        assert_eq!(NodeType::Empty.byte_size(), empty_node.byte_size());
-        assert_eq!(NodeType::Inner.byte_size(), inner_node.byte_size());
-        assert_eq!(NodeType::Leaf2.byte_size(), leaf2_node.byte_size());
-        assert_eq!(NodeType::Leaf256.byte_size(), leaf256_node.byte_size());
+        assert_eq!(
+            NodeType::Empty.node_byte_size(),
+            empty_node.node_byte_size()
+        );
+        assert_eq!(
+            NodeType::Inner.node_byte_size(),
+            inner_node.node_byte_size()
+        );
+        assert_eq!(
+            NodeType::Leaf2.node_byte_size(),
+            leaf2_node.node_byte_size()
+        );
+        assert_eq!(
+            NodeType::Leaf256.node_byte_size(),
+            leaf256_node.node_byte_size()
+        );
     }
 
     #[test]
-    fn node_min_size_returns_node_type_min_size() {
-        assert_eq!(NodeType::min_size(), Node::min_size());
+    fn node_min_non_empty_node_size_returns_node_type_min_size() {
+        assert_eq!(
+            NodeType::min_non_empty_node_size(),
+            Node::min_non_empty_node_size()
+        );
     }
 }


### PR DESCRIPTION
> In preparation of the Weighted Cached Node Manager

Adds a new `NodeSize` trait, which can be used to get information about the byte size and minimum size of a Node type.
This will be used in subsequent PR to calculate the weight of nodes in the CachedNodeManager.

In addition to Node, the trait is also implemented for `NodeType` and `NodeId`. The former allows querying a node size without instantiating a Node, while the latter is useful to retrieve the size of the pointed node without having access to the node itself.