### PR TITLE
Add memory capacity bound to `CachedNodeManager`

### DIFF
--- a/rust/src/node_manager/cached_node_manager.rs
+++ b/rust/src/node_manager/cached_node_manager.rs
@@ -107,7 +107,7 @@ where
             })
             .collect();
 
-        // TODO: Benchmark different shard size as the current value is overestimated.
+        // TODO: Benchmark different shard size as the default value is overestimated.
         let options = quick_cache::OptionsBuilder::new()
             .weight_capacity(cache_weight as u64)
             .estimated_items_capacity(num_nodes - 1)

--- a/rust/src/types/node.rs
+++ b/rust/src/types/node.rs
@@ -138,6 +138,17 @@ pub enum NodeType {
     Leaf256,
 }
 
+impl NodeType {
+    pub fn from_node(node: &Node) -> Self {
+        match node {
+            Node::Empty => NodeType::Empty,
+            Node::Inner(_) => NodeType::Inner,
+            Node::Leaf2(_) => NodeType::Leaf2,
+            Node::Leaf256(_) => NodeType::Leaf256,
+        }
+    }
+}
+
 impl NodeSize for NodeType {
     fn node_byte_size(&self) -> usize {
         let inner_size = match self {


### PR DESCRIPTION
This PR adds a memory upper bound to the memory used by the `CachedNodeManager` to better control the Carmen memory consumption.

The `CachedNodeManager::new` now gets a **bytes_capacity** parameter, which is used as the available memory budget to allocate all the internal components, i.e. the `nodes` slice and the internal cache. Every item is then weighted against their byte size, which is used to determine how much space they require in the cache.
The current algorithm works as follows:

1. Calculate the footprint of the **minimum size** element in the cache: this is `element_byte_size + sizeof(RwLock<Wrapper>) + cache_overhead_per_item`. The cache overhead formula is derived from [quick_cache docs](https://docs.rs/quick_cache/latest/quick_cache/#approximate-memory-usage). 
2. Allocate `bytes_capacity / minimum_element_footprint` elements: this covers the worst case of only inserting the smallest node in the manager. This would never happen in practice, and it's a quite big approximation.
3. Set the cache weight as `num_nodes * minimum_element_size`: this ensures that, in the worst case, the manager doesn't allocate more than the available slots in the `nodes` vector. 

This has an important drawback: the amount of memory wasted is proportional to the difference between the average size of the nodes stored in the manager and the theoretically minimum size, as the cache will quickly fill up and multiple positions in the `nodes` vector will be unused.

Another drawback is that the number of `quick_cache` shards is overestimated, as it's calculated against the worst case of just minimum sized nodes. This has a direct impact on parallelism and should be benchmarked to find the best balance.

Additional changes:
- The `evict` function now takes a slice, as inserting an element may require to evict multiple elements to make space for its weight.
- The `ItemLifecycle` component now returns a vector, as multiple elements may be evicted during a single operation

Depends on #138 #143 

Closes https://github.com/0xsoniclabs/sonic-admin/issues/382