### PR TITLE
Register Rust in-memory S6 implementation in Go

### DIFF
--- a/go/state/externalstate/configurations.go
+++ b/go/state/externalstate/configurations.go
@@ -16,6 +16,8 @@ const (
 	VariantCppMemory  state.Variant = "cpp-memory"
 	VariantCppFile    state.Variant = "cpp-file"
 	VariantCppLevelDb state.Variant = "cpp-ldb"
+
+	VariantRustMemory state.Variant = "rust-memory"
 )
 
 func init() {
@@ -47,7 +49,7 @@ func init() {
 	}
 
 	state.RegisterStateFactory(state.Configuration{
-		Variant: "rust-memory",
+		Variant: VariantRustMemory,
 		Schema:  6,
 		Archive: state.NoArchive,
 	}, newRustInMemoryState)

--- a/go/state/externalstate/configurations.go
+++ b/go/state/externalstate/configurations.go
@@ -45,4 +45,10 @@ func init() {
 			}, newCppLevelDbBasedState)
 		}
 	}
+
+	state.RegisterStateFactory(state.Configuration{
+		Variant: "rust-memory",
+		Schema:  6,
+		Archive: state.NoArchive,
+	}, newRustInMemoryState)
 }

--- a/go/state/externalstate/external_state.go
+++ b/go/state/externalstate/external_state.go
@@ -463,16 +463,16 @@ func (s *ExternalState) Close() error {
 	if s.state != nil {
 		result := s.bindings.ReleaseState(s.state)
 		if result != C.kResult_Success {
-			return fmt.Errorf("failed to release C++ state (error code %v)", result)
+			return fmt.Errorf("failed to release external state (error code %v)", result)
 		}
 		s.state = nil
 		result = s.bindings.Close(s.database)
 		if result != C.kResult_Success {
-			return fmt.Errorf("failed to close C++ database (error code %v)", result)
+			return fmt.Errorf("failed to close external database (error code %v)", result)
 		}
 		result = s.bindings.ReleaseDatabase(s.database)
 		if result != C.kResult_Success {
-			return fmt.Errorf("failed to release C++ database (error code %v)", result)
+			return fmt.Errorf("failed to release external database (error code %v)", result)
 		}
 		s.database = nil
 	}
@@ -506,8 +506,8 @@ func (s *ExternalState) GetMemoryFootprint() *common.MemoryFootprint {
 	result := s.bindings.GetMemoryFootprint(s.database, &buffer, &size)
 	if result != C.kResult_Success {
 		res := common.NewMemoryFootprint(0)
-		res.SetNote(fmt.Sprintf("failed to get C++ memory footprint (error code %v)", result))
-		log.Printf("failed to get C++ memory footprint (error code %v)", result)
+		res.SetNote(fmt.Sprintf("failed to get external memory footprint (error code %v)", result))
+		log.Printf("failed to get external memory footprint (error code %v)", result)
 		return res
 	}
 	defer func() {

--- a/go/state/state_test.go
+++ b/go/state/state_test.go
@@ -298,8 +298,14 @@ func TestCanComputeNonEmptyMemoryFootprint(t *testing.T) {
 		if fp == nil {
 			t.Fatalf("state produces invalid footprint: %v", fp)
 		}
-		if fp.Total() <= 0 {
-			t.Errorf("memory footprint should not be empty")
+		if strings.HasPrefix(string(config.config.Variant), "rust-") {
+			if fp.Total() != 0 {
+				t.Errorf("expected rust memory footprint to be zero (not yet implemented)")
+			}
+		} else {
+			if fp.Total() <= 0 {
+				t.Errorf("memory footprint should not be empty")
+			}
 		}
 		if len(fp.ToString("top")) == 0 {
 			t.Errorf("footprint text empty: %v", fp.ToString("top"))

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -191,6 +191,8 @@ impl<LS: CarmenState + 'static> CarmenDb for CarmenS6Db<LS> {
     }
 
     fn get_memory_footprint(&self) -> Result<Box<str>, Error> {
-        unimplemented!()
+        Err(Error::UnsupportedOperation(
+            "get_memory_footprint is not yet implemented".to_string(),
+        ))
     }
 }


### PR DESCRIPTION
This is the last piece of the puzzle required to call into the Rust in-memory S6 implementation from the Go side. From now on, in addition to the Rust-side tests, all changes made to S6 will also be checked by the Go test suite.

Thankfully #80 got us basically 99% of the way to making the Go tests compatible with S6, the only thing remaining is to add a workaround for a test of the `GetMemoryFootprint` function, which is not yet implemented in Rust.

Depends on #130.
Closes https://github.com/0xsoniclabs/sonic-admin/issues/272.