### PR TITLE
Move Verkle node types to `database::verkle::variants::managed`

### DIFF
--- a/rust/src/database/mod.rs
+++ b/rust/src/database/mod.rs
@@ -8,6 +8,6 @@
 // On the date above, in accordance with the Business Source License, use of
 // this software will be governed by the GNU Lesser General Public License v3.
 
-mod verkle;
+pub mod verkle;
 
 pub use verkle::{SimpleInMemoryVerkleTrie, VerkleTrieCarmenState};

--- a/rust/src/database/verkle/mod.rs
+++ b/rust/src/database/verkle/mod.rs
@@ -14,7 +14,7 @@ mod embedding;
 mod state;
 #[cfg(test)]
 mod test_utils;
-mod variants;
+pub mod variants;
 mod verkle_trie;
 
 pub use state::VerkleTrieCarmenState;

--- a/rust/src/database/verkle/variants/managed/mod.rs
+++ b/rust/src/database/verkle/variants/managed/mod.rs
@@ -8,7 +8,8 @@
 // On the date above, in accordance with the Business Source License, use of
 // this software will be governed by the GNU Lesser General Public License v3.
 
-pub mod managed;
-mod simple;
+mod nodes;
 
-pub use simple::SimpleInMemoryVerkleTrie;
+pub use nodes::{
+    Node, NodeType, id::NodeId, inner::InnerNode, leaf::FullLeafNode, sparse_leaf::SparseLeafNode,
+};

--- a/rust/src/database/verkle/variants/managed/nodes/id.rs
+++ b/rust/src/database/verkle/variants/managed/nodes/id.rs
@@ -10,7 +10,7 @@
 
 use zerocopy::{FromBytes, Immutable, IntoBytes, Unaligned};
 
-use crate::types::{NodeSize, NodeType};
+use crate::{database::verkle::variants::managed::nodes::NodeType, types::NodeSize};
 
 /// An identifier for a node in a (file-based) Verkle trie.
 // NOTE: Changing the layout of this struct will break backwards compatibility of the

--- a/rust/src/database/verkle/variants/managed/nodes/inner.rs
+++ b/rust/src/database/verkle/variants/managed/nodes/inner.rs
@@ -1,0 +1,53 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+use zerocopy::{FromBytes, Immutable, IntoBytes, Unaligned};
+
+use crate::database::verkle::{
+    crypto::Commitment,
+    variants::managed::nodes::{NodeType, id::NodeId},
+};
+
+/// An inner node in a (file-based) Verkle trie.
+// NOTE: Changing the layout of this struct will break backwards compatibility of the
+// serialization format.
+#[derive(Debug, Clone, PartialEq, Eq, FromBytes, IntoBytes, Immutable, Unaligned)]
+#[repr(C)]
+pub struct InnerNode {
+    pub commitment: Commitment,
+    pub values: [NodeId; 256],
+}
+
+impl Default for InnerNode {
+    fn default() -> Self {
+        InnerNode {
+            commitment: Commitment::default(),
+            values: [NodeId::from_idx_and_node_type(0, NodeType::Empty); 256],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::database::verkle::{
+        crypto::Commitment,
+        variants::managed::nodes::{NodeType, id::NodeId, inner::InnerNode},
+    };
+
+    #[test]
+    fn inner_node_default_returns_inner_node_with_all_values_set_to_empty_node_id() {
+        let node: InnerNode = InnerNode::default();
+        assert_eq!(node.commitment, Commitment::default());
+        assert_eq!(
+            node.values,
+            [NodeId::from_idx_and_node_type(0, NodeType::Empty); 256]
+        );
+    }
+}

--- a/rust/src/database/verkle/variants/managed/nodes/leaf.rs
+++ b/rust/src/database/verkle/variants/managed/nodes/leaf.rs
@@ -1,0 +1,47 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+use zerocopy::{FromBytes, Immutable, IntoBytes};
+
+use crate::{database::verkle::crypto::Commitment, types::Value};
+
+/// A leaf node with 256 children in a (file-based) Verkle trie.
+// NOTE: Changing the layout of this struct will break backwards compatibility of the
+// serialization format.
+#[derive(Debug, Clone, PartialEq, Eq, FromBytes, IntoBytes, Immutable)]
+#[repr(C)]
+pub struct FullLeafNode {
+    pub commitment: Commitment,
+    pub stem: [u8; 31],
+    pub values: [Value; 256],
+}
+
+impl Default for FullLeafNode {
+    fn default() -> Self {
+        FullLeafNode {
+            commitment: Commitment::default(),
+            stem: [0; 31],
+            values: [Value::default(); 256],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_leaf_node_default_returns_leaf_node_with_all_values_set_to_default() {
+        let node: FullLeafNode = FullLeafNode::default();
+        assert_eq!(node.commitment, Commitment::default());
+        assert_eq!(node.stem, [0; 31]);
+        assert_eq!(node.values, [Value::default(); 256]);
+    }
+}

--- a/rust/src/database/verkle/variants/managed/nodes/mod.rs
+++ b/rust/src/database/verkle/variants/managed/nodes/mod.rs
@@ -8,91 +8,17 @@
 // On the date above, in accordance with the Business Source License, use of
 // this software will be governed by the GNU Lesser General Public License v3.
 
-use zerocopy::{FromBytes, Immutable, IntoBytes, Unaligned};
+use crate::{
+    database::verkle::variants::managed::nodes::{
+        inner::InnerNode, leaf::FullLeafNode, sparse_leaf::SparseLeafNode,
+    },
+    types::NodeSize,
+};
 
-use crate::types::{Commitment, NodeId, Value};
-
-/// A value of a leaf node in a (file-based) Verkle trie, together with its index.
-// NOTE: Changing the layout of this struct will break backwards compatibility of the
-// serialization format.
-#[derive(
-    Debug, Clone, Copy, Default, PartialEq, Eq, FromBytes, IntoBytes, Immutable, Unaligned,
-)]
-#[repr(C)]
-pub struct ValueWithIndex {
-    /// The index of the value in the leaf node.
-    pub index: u8,
-    /// The value stored in the leaf node.
-    pub value: Value,
-}
-
-/// A sparsely populated leaf node in a (file-based) Verkle trie.
-// NOTE: Changing the layout of this struct will break backwards compatibility of the
-// serialization format.
-#[derive(Debug, Clone, PartialEq, Eq, FromBytes, IntoBytes, Immutable)]
-#[repr(C)]
-pub struct SparseLeafNode<const N: usize> {
-    pub commitment: Commitment,
-    pub stem: [u8; 31],
-    pub values: [ValueWithIndex; N],
-}
-
-impl<const N: usize> Default for SparseLeafNode<N> {
-    fn default() -> Self {
-        let mut values = [ValueWithIndex::default(); N];
-        values.iter_mut().enumerate().for_each(|(i, v)| {
-            v.index = i as u8;
-        });
-
-        SparseLeafNode {
-            commitment: Commitment::default(),
-            stem: [0; 31],
-            values,
-        }
-    }
-}
-
-/// A leaf node with 256 children in a (file-based) Verkle trie.
-// NOTE: Changing the layout of this struct will break backwards compatibility of the
-// serialization format.
-#[derive(Debug, Clone, PartialEq, Eq, FromBytes, IntoBytes, Immutable)]
-#[repr(C)]
-pub struct FullLeafNode {
-    pub commitment: Commitment,
-    pub stem: [u8; 31],
-    pub values: [Value; 256],
-}
-
-impl Default for FullLeafNode {
-    fn default() -> Self {
-        FullLeafNode {
-            commitment: Commitment::default(),
-            stem: [0; 31],
-            values: [Value::default(); 256],
-        }
-    }
-}
-
-/// An inner node in a (file-based) Verkle trie.
-// NOTE: This type should NOT implement [`Clone`] because there is never be two instances
-// corresponding to the same logical node.
-// NOTE: Changing the layout of this struct will break backwards compatibility of the
-// serialization format.
-#[derive(Debug, Clone, PartialEq, Eq, FromBytes, IntoBytes, Immutable, Unaligned)]
-#[repr(C)]
-pub struct InnerNode {
-    pub commitment: Commitment,
-    pub values: [NodeId; 256],
-}
-
-impl Default for InnerNode {
-    fn default() -> Self {
-        InnerNode {
-            commitment: Commitment::default(),
-            values: [NodeId::from_idx_and_node_type(0, NodeType::Empty); 256],
-        }
-    }
-}
+pub mod id;
+pub mod inner;
+pub mod leaf;
+pub mod sparse_leaf;
 
 /// A node in a (file-based) Verkle trie.
 //
@@ -162,50 +88,9 @@ impl NodeSize for NodeType {
     }
 }
 
-/// A trait to determine the size of a node.
-pub trait NodeSize {
-    /// Returns the size of the node in bytes.
-    fn node_byte_size(&self) -> usize;
-
-    /// Returns the minimum size of a non-empty node in bytes.
-    fn min_non_empty_node_size() -> usize;
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn sparse_leaf_node_default_returns_leaf_node_with_default_values_and_unique_indices() {
-        const N: usize = 2;
-        let node: SparseLeafNode<N> = SparseLeafNode::default();
-
-        assert_eq!(node.commitment, Commitment::default());
-        assert_eq!(node.stem, [0; 31]);
-
-        for (i, value) in node.values.iter().enumerate() {
-            assert_eq!(value.index, i as u8);
-            assert_eq!(value.value, Value::default());
-        }
-    }
-
-    #[test]
-    fn full_leaf_node_default_returns_leaf_node_with_all_values_set_to_default() {
-        let node: FullLeafNode = FullLeafNode::default();
-        assert_eq!(node.commitment, Commitment::default());
-        assert_eq!(node.stem, [0; 31]);
-        assert_eq!(node.values, [Value::default(); 256]);
-    }
-
-    #[test]
-    fn inner_node_default_returns_inner_node_with_all_values_set_to_empty_node_id() {
-        let node: InnerNode = InnerNode::default();
-        assert_eq!(node.commitment, Commitment::default());
-        assert_eq!(
-            node.values,
-            [NodeId::from_idx_and_node_type(0, NodeType::Empty); 256]
-        );
-    }
 
     #[test]
     fn node_type_byte_size_returns_correct_size() {

--- a/rust/src/database/verkle/variants/managed/nodes/sparse_leaf.rs
+++ b/rust/src/database/verkle/variants/managed/nodes/sparse_leaf.rs
@@ -1,0 +1,72 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+use zerocopy::{FromBytes, Immutable, IntoBytes, Unaligned};
+
+use crate::{database::verkle::crypto::Commitment, types::Value};
+
+/// A value of a leaf node in a (file-based) Verkle trie, together with its index.
+// NOTE: Changing the layout of this struct will break backwards compatibility of the
+// serialization format.
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, FromBytes, IntoBytes, Immutable, Unaligned,
+)]
+#[repr(C)]
+pub struct ValueWithIndex {
+    /// The index of the value in the leaf node.
+    pub index: u8,
+    /// The value stored in the leaf node.
+    pub value: Value,
+}
+
+/// A sparsely populated leaf node in a (file-based) Verkle trie.
+// NOTE: Changing the layout of this struct will break backwards compatibility of the
+// serialization format.
+#[derive(Debug, Clone, PartialEq, Eq, FromBytes, IntoBytes, Immutable)]
+#[repr(C)]
+pub struct SparseLeafNode<const N: usize> {
+    pub commitment: Commitment,
+    pub stem: [u8; 31],
+    pub values: [ValueWithIndex; N],
+}
+
+impl<const N: usize> Default for SparseLeafNode<N> {
+    fn default() -> Self {
+        let mut values = [ValueWithIndex::default(); N];
+        values.iter_mut().enumerate().for_each(|(i, v)| {
+            v.index = i as u8;
+        });
+
+        SparseLeafNode {
+            commitment: Commitment::default(),
+            stem: [0; 31],
+            values,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sparse_leaf_node_default_returns_leaf_node_with_default_values_and_unique_indices() {
+        const N: usize = 2;
+        let node: SparseLeafNode<N> = SparseLeafNode::default();
+
+        assert_eq!(node.commitment, Commitment::default());
+        assert_eq!(node.stem, [0; 31]);
+
+        for (i, value) in node.values.iter().enumerate() {
+            assert_eq!(value.index, i as u8);
+            assert_eq!(value.value, Value::default());
+        }
+    }
+}

--- a/rust/src/node_manager/cached_node_manager.rs
+++ b/rust/src/node_manager/cached_node_manager.rs
@@ -22,7 +22,6 @@ use crate::{
     error::Error,
     node_manager::NodeManager,
     storage::{Checkpointable, Storage},
-    types::Node,
 };
 
 /// A wrapper which dereferences to [`Node`] and additionally stores its dirty status,
@@ -345,8 +344,8 @@ mod tests {
 
     use super::*;
     use crate::{
+        database::verkle::variants::managed::{Node, NodeId, NodeType},
         storage::{self},
-        types::{NodeId, NodeType},
     };
 
     #[test]

--- a/rust/src/storage/file/file_storage_manager.rs
+++ b/rust/src/storage/file/file_storage_manager.rs
@@ -18,8 +18,10 @@ use std::{
 use zerocopy::IntoBytes;
 
 use crate::{
+    database::verkle::variants::managed::{
+        FullLeafNode, InnerNode, Node, NodeId, NodeType, SparseLeafNode,
+    },
     storage::{CheckpointParticipant, Checkpointable, Error, Storage},
-    types::{FullLeafNode, InnerNode, Node, NodeId, NodeType, SparseLeafNode},
 };
 
 /// A storage manager for Verkle trie nodes for file based storage backends.
@@ -199,7 +201,6 @@ mod tests {
     use super::*;
     use crate::{
         storage::file::{NodeFileStorage, SeekFile},
-        types::NodeId,
         utils::test_dir::{Permissions, TestDir},
     };
 

--- a/rust/src/storage/storage_with_flush_buffer.rs
+++ b/rust/src/storage/storage_with_flush_buffer.rs
@@ -19,8 +19,8 @@ use std::{
 use dashmap::DashMap;
 
 use crate::{
+    database::verkle::variants::managed::{Node, NodeId},
     storage::{Checkpointable, Error, Storage},
-    types::{Node, NodeId},
 };
 
 /// A storage backend that uses a flush buffer to hold updates and deletions while they get
@@ -217,8 +217,8 @@ mod tests {
 
     use super::*;
     use crate::{
+        database::verkle::variants::managed::NodeType,
         storage::file::{FileStorageManager, NodeFileStorage, SeekFile},
-        types::NodeType,
         utils::test_dir::{Permissions, TestDir},
     };
 

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -9,13 +9,11 @@
 // this software will be governed by the GNU Lesser General Public License v3.
 
 pub use commitment::*;
-pub use id::*;
-pub use node::*;
+pub use node_size::*;
 pub use update::{BalanceUpdate, CodeUpdate, NonceUpdate, SlotUpdate, Update};
 
 mod commitment;
-mod id;
-mod node;
+mod node_size;
 mod update;
 
 /// The Carmen live state implementation.

--- a/rust/src/types/node_size.rs
+++ b/rust/src/types/node_size.rs
@@ -8,7 +8,11 @@
 // On the date above, in accordance with the Business Source License, use of
 // this software will be governed by the GNU Lesser General Public License v3.
 
-pub mod managed;
-mod simple;
+/// A trait to determine the size of a node in a trie.
+pub trait NodeSize {
+    /// Returns the size of the node in bytes.
+    fn node_byte_size(&self) -> usize;
 
-pub use simple::SimpleInMemoryVerkleTrie;
+    /// Returns the minimum size of a non-empty node in bytes.
+    fn min_non_empty_node_size() -> usize;
+}


### PR DESCRIPTION
Since we plan to support other trie types in the future, these should not live in the generic `types` module. This only moves the types, nothing else was changed.