### PR TITLE
Add Synchronous Archive updates.

### DIFF
--- a/go/database/flat/flat.go
+++ b/go/database/flat/flat.go
@@ -105,6 +105,8 @@ type update struct {
 	data  common.Update
 }
 
+// NewState creates a new flat State instance that wraps the provided backend state.
+// The resulting state is wrapped into a synced state for thread-safe access.
 func NewState(path string, backend state.State) (state.State, error) {
 	newState, err := _newState(path, backend, nil)
 	if err != nil {
@@ -113,8 +115,6 @@ func NewState(path string, backend state.State) (state.State, error) {
 	return state.WrapIntoSyncedState(newState), nil
 }
 
-// NewState creates a new flat State instance that wraps the provided backend state.
-// The resulting state is wrapped into a synced state for thread-safe access.
 func _newState(path string, backend state.State, testingApplyDone chan testingPingOrigin) (*State, error) {
 	// Unwrap the backend from any synced state to avoid double synchronization.
 	// The flat state will handle synchronization itself.

--- a/go/database/flat/flat.go
+++ b/go/database/flat/flat.go
@@ -672,7 +672,7 @@ func (s *State) load(r io.Reader) error {
 // and the test code.
 type testingPingOrigin int8
 
-var (
-	fromUpdate testingPingOrigin = 0
-	fromApply  testingPingOrigin = 1
+const (
+	fromUpdate testingPingOrigin = iota
+	fromApply
 )

--- a/go/database/vt/geth/state.go
+++ b/go/database/vt/geth/state.go
@@ -245,6 +245,11 @@ func (s *verkleState) Apply(block uint64, update common.Update) error {
 	return nil
 }
 
+func (s *verkleState) ApplySync(block uint64, update common.Update) error {
+	// update.ApplyTo is already synchronous
+	return s.Apply(block, update)
+}
+
 //
 //		Witness Proof features -- not supported at the moment
 //

--- a/go/database/vt/reference/state.go
+++ b/go/database/vt/reference/state.go
@@ -171,6 +171,11 @@ func (s *State) Apply(block uint64, update common.Update) error {
 	return nil
 }
 
+func (s *State) ApplySync(block uint64, update common.Update) error {
+	// Apply is already synchronous
+	return s.Apply(block, update)
+}
+
 func (s *State) GetHash() (common.Hash, error) {
 	return s.GetCommitment().Await().Get()
 }

--- a/go/state/externalstate/external_state.go
+++ b/go/state/externalstate/external_state.go
@@ -456,6 +456,11 @@ func (s *ExternalState) Apply(block uint64, update common.Update) error {
 	return nil
 }
 
+func (s *ExternalState) ApplySync(block uint64, update common.Update) error {
+	// Apply is already synchronous
+	return s.Apply(block, update)
+}
+
 func (s *ExternalState) Flush() error {
 	result := s.bindings.Flush(s.database)
 	if result != C.kResult_Success {

--- a/go/state/gostate/archive_state.go
+++ b/go/state/gostate/archive_state.go
@@ -141,6 +141,10 @@ func (s *ArchiveState) Apply(block uint64, update common.Update) error {
 	panic("ArchiveState does not support Apply operation")
 }
 
+func (s *ArchiveState) ApplySync(block uint64, update common.Update) error {
+	panic("ArchiveState does not support ApplySync operation")
+}
+
 func (s *ArchiveState) GetHash() (common.Hash, error) {
 	return s.GetCommitment().Await().Get()
 }

--- a/go/state/gostate/go_state.go
+++ b/go/state/gostate/go_state.go
@@ -46,7 +46,7 @@ type GoState struct {
 	testingPing chan testingPingOrigin
 }
 
-// testingPingOrigin is an enum used for testing to identify the source of a ping on the testingDone channel.
+// testingPingOrigin is an enum used for testing to identify the source of a ping on the testingPing channel.
 type testingPingOrigin int8
 
 var (
@@ -93,7 +93,7 @@ func _newGoState(live state.LiveDB, archive archive.Archive, cleanup []func()) *
 						err <- issue
 					}
 					if res.testingPing != nil {
-						// signal that the update was processed,
+						// signal that the update was processed
 						res.testingPing <- fromUpdate
 					}
 					if update.sync != nil {
@@ -121,7 +121,7 @@ type archiveUpdate = struct {
 	block       uint64
 	update      *common.Update  // nil to signal a flush
 	updateHints common.Releaser // an optional field for passing update hints from the LiveDB to the Archive
-	sync        chan struct{}   // whether to signal when done
+	sync        chan struct{}   // an optional channel which gets closed when the update was processed
 }
 
 func (s *GoState) Exists(address common.Address) (bool, error) {

--- a/go/state/gostate/go_state.go
+++ b/go/state/gostate/go_state.go
@@ -49,9 +49,9 @@ type GoState struct {
 // testingPingOrigin is an enum used for testing to identify the source of a ping on the testingPing channel.
 type testingPingOrigin int8
 
-var (
-	fromUpdate testingPingOrigin = 0
-	fromApply  testingPingOrigin = 1
+const (
+	fromUpdate testingPingOrigin = iota
+	fromApply
 )
 
 func newGoState(live state.LiveDB, archive archive.Archive, cleanup []func()) state.State {

--- a/go/state/state.go
+++ b/go/state/state.go
@@ -56,6 +56,11 @@ type State interface {
 	// Apply applies the provided updates to the state content.
 	Apply(block uint64, update common.Update) error
 
+	// ApplySync applies the provided updates to the state content synchronously.
+	// Each implementation may have a different mechanism, but all must ensure the
+	// updates are fully applied when the method returns.
+	ApplySync(block uint64, update common.Update) error
+
 	// GetHash hashes the state.
 	// Deprecated: use GetCommitment instead.
 	GetHash() (common.Hash, error)

--- a/go/state/state_db_mock.go
+++ b/go/state/state_db_mock.go
@@ -805,6 +805,18 @@ func (mr *MockStateDBMockRecorder) EndBlock(number any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EndBlock", reflect.TypeOf((*MockStateDB)(nil).EndBlock), number)
 }
 
+// EndBlockSync mocks base method.
+func (m *MockStateDB) EndBlockSync(number uint64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "EndBlockSync", number)
+}
+
+// EndBlockSync indicates an expected call of EndBlockSync.
+func (mr *MockStateDBMockRecorder) EndBlockSync(number any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EndBlockSync", reflect.TypeOf((*MockStateDB)(nil).EndBlockSync), number)
+}
+
 // EndEpoch mocks base method.
 func (m *MockStateDB) EndEpoch(number uint64) {
 	m.ctrl.T.Helper()

--- a/go/state/state_mock.go
+++ b/go/state/state_mock.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -source state.go -destination state_mock.go -package state
 //
+
 // Package state is a generated GoMock package.
 package state
 
@@ -25,6 +26,7 @@ import (
 type MockState struct {
 	ctrl     *gomock.Controller
 	recorder *MockStateMockRecorder
+	isgomock struct{}
 }
 
 // MockStateMockRecorder is the mock recorder for MockState.
@@ -56,6 +58,20 @@ func (m *MockState) Apply(block uint64, update common.Update) error {
 func (mr *MockStateMockRecorder) Apply(block, update any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockState)(nil).Apply), block, update)
+}
+
+// ApplySync mocks base method.
+func (m *MockState) ApplySync(block uint64, update common.Update) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplySync", block, update)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplySync indicates an expected call of ApplySync.
+func (mr *MockStateMockRecorder) ApplySync(block, update any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplySync", reflect.TypeOf((*MockState)(nil).ApplySync), block, update)
 }
 
 // Check mocks base method.
@@ -333,6 +349,7 @@ func (mr *MockStateMockRecorder) HasEmptyStorage(addr any) *gomock.Call {
 type MockLiveDB struct {
 	ctrl     *gomock.Controller
 	recorder *MockLiveDBMockRecorder
+	isgomock struct{}
 }
 
 // MockLiveDBMockRecorder is the mock recorder for MockLiveDB.

--- a/go/state/synced_state.go
+++ b/go/state/synced_state.go
@@ -108,6 +108,12 @@ func (s *syncedState) Apply(block uint64, update common.Update) error {
 	return s.state.Apply(block, update)
 }
 
+func (s *syncedState) ApplySync(block uint64, update common.Update) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state.ApplySync(block, update)
+}
+
 func (s *syncedState) GetHash() (common.Hash, error) {
 	return s.GetCommitment().Await().Get()
 }


### PR DESCRIPTION
This PR introduces the ability to apply block changes to the live state while ensuring the operation waits until the archive state has also applied those changes. This is critical for processes that require strict consistency between the live state and the archive before proceeding.

#### Key Contributions
1. `StateDB.EndBlockSync`
Introduces `EndBlockSync` to the `StateDB` interface. This method shares the logic of the existing `EndBlock` but utilizes the internal `State.ApplySync` newly introduced function to ensure synchronous completion across different state layers.

2. `State.ApplySync` Interface Expansion
Added `ApplySync` to the State interface.

#### Specialized Behaviour
While many implementations may default to standard `Apply` logic, this method allows for implementations to use blocking wait-logic for archival confirmation when needed.

#### Testing
Added unit tests for the two implementations where `ApplySync` introduces distinct behaviour compared to the standard `Apply` method.

- [x] Verified that the synchronous wait-cycle correctly holds the caller until the archive state is updated.
- [x] Verified that synchronous and asynchronous can be interleaved and order is maintained.
- [x] Verified that synchronous calls wait for archive to be written.
- [x] Verified that asynchronous calls do not wait for archive to be written but trigger it.
