### PR TITLE
Mark account as non existing when empty in `flat` implementation

### DIFF
--- a/go/database/flat/flat.go
+++ b/go/database/flat/flat.go
@@ -176,8 +176,11 @@ func WrapFactory(innerFactory state.StateFactory) state.StateFactory {
 // --- State Interface Implementation ---
 
 func (s *State) Exists(address common.Address) (bool, error) {
-	_, found := s.accounts[address]
-	return found, nil
+	account, found := s.accounts[address]
+	accountEqual := account.balance == amount.Amount{}
+	nonceEqual := account.nonce == common.Nonce{}
+	codeHashEqual := account.codeHash == common.Hash(types.EmptyCodeHash)
+	return found && (!accountEqual || !nonceEqual || !codeHashEqual), nil
 }
 
 func (s *State) GetBalance(address common.Address) (amount.Amount, error) {
@@ -269,6 +272,7 @@ func (s *State) Apply(block uint64, data common.Update) (<-chan error, error) {
 			},
 		}
 	}
+
 	return done, nil
 }
 

--- a/go/database/flat/flat_test.go
+++ b/go/database/flat/flat_test.go
@@ -197,7 +197,9 @@ func TestState_Exists_ReturnsFromLocalMap(t *testing.T) {
 	addr := common.Address{0x01}
 	state := &State{
 		accounts: map[common.Address]account{
-			addr: {},
+			addr: {
+				balance: amount.New(10),
+			},
 		},
 	}
 
@@ -408,13 +410,18 @@ func TestState_Apply_DeletesAccounts(t *testing.T) {
 
 	_, err = state.Apply(1, common.Update{
 		CreatedAccounts: []common.Address{address},
+		Balances:        []common.BalanceUpdate{{Account: address, Balance: amount.New(10)}},
 	})
 	require.NoError(err)
 
 	require.True(state.Exists(address))
 
+	// Deleting an account usually resets also all its values
 	_, err = state.Apply(2, common.Update{
 		DeletedAccounts: []common.Address{address},
+		Balances:        []common.BalanceUpdate{{Account: address, Balance: amount.New(0)}},
+		Nonces:          []common.NonceUpdate{{Account: address, Nonce: common.Nonce{}}},
+		Codes:           []common.CodeUpdate{{Account: address, Code: []byte{}}},
 	})
 	require.NoError(err)
 

--- a/go/database/vt/geth/state.go
+++ b/go/database/vt/geth/state.go
@@ -131,7 +131,7 @@ func (s *verkleState) Exists(address common.Address) (bool, error) {
 		return false, err
 	}
 
-	return account != nil, nil
+	return account != nil && (!account.Balance.IsZero() || account.Nonce != 0 || common.Hash(account.CodeHash) != common.Hash(types.EmptyCodeHash)), nil
 }
 
 func (s *verkleState) GetBalance(address common.Address) (amount.Amount, error) {
@@ -229,10 +229,7 @@ func (s *verkleState) Apply(block uint64, update common.Update) (<-chan error, e
 		return &res, nil
 	}
 
-	// Process deleted accounts.
-	if len(update.DeletedAccounts) > 0 {
-		return nil, fmt.Errorf("not supported: verkle trie does not support deleting accounts")
-	}
+	// Deleted accounts are ignored.
 
 	// Process created accounts.
 	for _, newAccount := range update.CreatedAccounts {

--- a/go/state/externalstate/external_state_test.go
+++ b/go/state/externalstate/external_state_test.go
@@ -41,7 +41,7 @@ func TestAccountsAreInitiallyUnknown(t *testing.T) {
 
 func TestAccountsCanBeCreated(t *testing.T) {
 	runForEachExternalConfig(t, func(t *testing.T, state state.State, config state.Configuration) {
-		state.Apply(0, common.Update{CreatedAccounts: []common.Address{address1}})
+		state.Apply(0, common.Update{CreatedAccounts: []common.Address{address1}, Balances: []common.BalanceUpdate{{Account: address1, Balance: balance1}}})
 		account_state, _ := state.Exists(address1)
 		if account_state != true {
 			t.Errorf("Created account does not exist, got %v", account_state)

--- a/go/state/gostate/go_state_test.go
+++ b/go/state/gostate/go_state_test.go
@@ -219,6 +219,9 @@ func TestDeletingAccounts(t *testing.T) {
 			// delete account
 			update = common.Update{
 				DeletedAccounts: []common.Address{address1},
+				Balances:        []common.BalanceUpdate{{Account: address1, Balance: amount.New(0)}},
+				Nonces:          []common.NonceUpdate{{Account: address1, Nonce: common.Nonce{}}},
+				Codes:           []common.CodeUpdate{{Account: address1, Code: []byte{}}},
 			}
 			if _, err := state.Apply(2, update); err != nil {
 				t.Errorf("failed to apply update: %v", err)

--- a/go/state/state_db_and_state_test.go
+++ b/go/state/state_db_and_state_test.go
@@ -797,6 +797,56 @@ func TestStateDB_HasEmptyStorage_HandlesAccountSelfDestructCorrectly(t *testing.
 	}
 }
 
+func TestStateDB_CallingExistsAfterAccountIsDeletedReturnsFalse(t *testing.T) {
+	for _, config := range initStates() {
+		t.Run(config.name(), func(t *testing.T) {
+			t.Parallel()
+			require := require.New(t)
+			dir := t.TempDir()
+
+			s, err := config.createState(dir)
+			require.NoError(err)
+			defer func() {
+				require.NoError(s.Close())
+			}()
+
+			statedb := state.CreateStateDBUsing(s)
+
+			createAccountWithBalance := func(address common.Address, balance amount.Amount, blockNum uint64) {
+				statedb.BeginBlock()
+				statedb.CreateAccount(address)
+				statedb.AddBalance(address, balance)
+				statedb.EndTransaction()
+				statedb.EndBlock(blockNum)
+			}
+
+			// Case 1: deleted account because is empty
+			createAccountWithBalance(address1, balance1, 0)
+			statedb.BeginBlock()
+			statedb.BeginTransaction()
+			statedb.SubBalance(address1, balance1)
+			statedb.EndTransaction()
+			statedb.EndBlock(1)
+
+			exists, err := s.Exists(address1)
+			require.NoError(err)
+			require.False(exists)
+
+			// Case 2: deleted account because of suicide
+			createAccountWithBalance(address1, balance1, 2)
+			statedb.BeginBlock()
+			statedb.BeginTransaction()
+			require.True(statedb.Suicide(address1))
+			statedb.EndTransaction()
+			statedb.EndBlock(3)
+
+			exists, err = s.Exists(address1)
+			require.NoError(err)
+			require.False(exists)
+		})
+	}
+}
+
 func toVal(key uint64) common.Value {
 	keyBytes := make([]byte, 32)
 	binary.BigEndian.PutUint64(keyBytes, key)

--- a/go/state/state_test.go
+++ b/go/state/state_test.go
@@ -435,7 +435,7 @@ func TestDeleteNotExistingAccount(t *testing.T) {
 		if config.config.Schema == 6 {
 			t.Skipf("scheme %d not supported", config.config.Schema)
 		}
-		if _, err := s.Apply(0, common.Update{CreatedAccounts: []common.Address{address1}}); err != nil {
+		if _, err := s.Apply(0, common.Update{CreatedAccounts: []common.Address{address1}, Balances: []common.BalanceUpdate{{Account: address1, Balance: balance1}}}); err != nil {
 			t.Fatalf("Error: %s", err)
 		}
 		if _, err := s.Apply(1, common.Update{DeletedAccounts: []common.Address{address2}}); err != nil { // deleting never-existed account
@@ -690,12 +690,18 @@ func TestLastArchiveBlock(t *testing.T) {
 
 			if _, err := s.Apply(0, common.Update{
 				CreatedAccounts: []common.Address{address1},
+				Balances: []common.BalanceUpdate{
+					{Account: address1, Balance: balance1},
+				},
 			}); err != nil {
 				t.Fatalf("failed to add block 0; %s", err)
 			}
 
 			if _, err := s.Apply(1, common.Update{
 				CreatedAccounts: []common.Address{address2},
+				Balances: []common.BalanceUpdate{
+					{Account: address2, Balance: balance2},
+				},
 			}); err != nil {
 				t.Fatalf("failed to add block 1; %s", err)
 			}

--- a/rust/src/database/verkle/state.rs
+++ b/rust/src/database/verkle/state.rs
@@ -132,7 +132,14 @@ impl<T: VerkleTrie> IsArchive for VerkleTrieCarmenState<T> {
 
 impl<T: VerkleTrie> CarmenState for VerkleTrieCarmenState<T> {
     fn account_exists(&self, addr: &Address) -> BTResult<bool, Error> {
-        Ok(self.get_code_hash(addr)? != Hash::default())
+        let key = self.embedding.get_basic_data_key(addr);
+        let value = self.trie.lookup(&key)?;
+        let balance = &value[16..32];
+        let nonce = &value[8..16];
+        Ok(value != Value::default()
+            && (balance != U256::default()
+                || nonce != Nonce::default()
+                || self.get_code_hash(addr)? != EMPTY_CODE_HASH))
     }
 
     fn get_balance(&self, addr: &Address) -> BTResult<U256, Error> {

--- a/rust/src/database/verkle/variants/managed/mod.rs
+++ b/rust/src/database/verkle/variants/managed/mod.rs
@@ -293,7 +293,7 @@ mod tests {
         trie.accept(&mut mock_visitor).unwrap();
     }
 
-    struct TestNodeWrapper {
+    pub struct TestNodeWrapper {
         node: VerkleNode,
     }
 


### PR DESCRIPTION
This PR marks an account as empty in the `flat` implementation when empty to fix [TestStress_CanHandleDeleteOfLargeAccount](https://github.com/0xsoniclabs/carmen/blob/798f63f6b76bc87ed5674d3ba4d75053938cc2a9/go/state/stress_test.go#L64).
This because deleting an account also requires resetting all the fields, which implicitly inserts the account in the in-memory implementation.
Tests deleting account are also updated to submit account fields reset alongside the delete operation.