### PR TITLE
Fix nightly lint in rust

### DIFF
--- a/rust/src/database/verkle/variants/managed/mod.rs
+++ b/rust/src/database/verkle/variants/managed/mod.rs
@@ -293,7 +293,7 @@ mod tests {
         trie.accept(&mut mock_visitor).unwrap();
     }
 
-    struct TestNodeWrapper {
+    pub struct TestNodeWrapper {
         node: VerkleNode,
     }
 


### PR DESCRIPTION
A new lint has been added to the latest rust nightly version, which is used for miri in CI.
```rust
error[E0446]: private type `database::verkle::variants::managed::tests::TestNodeWrapper` in public interface
   --> src/database/verkle/variants/managed/mod.rs:340:22
    |
296 |     struct TestNodeWrapper {
    |     ---------------------- `database::verkle::variants::managed::tests::TestNodeWrapper` declared as private
...
340 |                 ) -> BTResult<RwLockReadGuard<'a, TestNodeWrapper>, Error>;
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
```
The lint forbids private types in public interfaces, and happens because the `TestNodeManager` is exported from its mock submodule.
This PR fixes it by just marking the `TestNodeWrapper` type as public too.