### PR TITLE
Fix inconsistencies in Exists method for S6

### DIFF
--- a/go/database/vt/geth/state.go
+++ b/go/database/vt/geth/state.go
@@ -131,7 +131,8 @@ func (s *verkleState) Exists(address common.Address) (bool, error) {
 		return false, err
 	}
 
-	return account != nil, nil
+	return account != nil &&
+		(!account.Balance.IsZero() || account.Nonce != 0 || common.Hash(account.CodeHash) != common.Hash(types.EmptyCodeHash)), nil
 }
 
 func (s *verkleState) GetBalance(address common.Address) (amount.Amount, error) {
@@ -229,10 +230,7 @@ func (s *verkleState) Apply(block uint64, update common.Update) (<-chan error, e
 		return &res, nil
 	}
 
-	// Process deleted accounts.
-	if len(update.DeletedAccounts) > 0 {
-		return nil, fmt.Errorf("not supported: verkle trie does not support deleting accounts")
-	}
+	// Deleted accounts are ignored.
 
 	// Process created accounts.
 	for _, newAccount := range update.CreatedAccounts {

--- a/go/state/externalstate/external_state_test.go
+++ b/go/state/externalstate/external_state_test.go
@@ -41,7 +41,7 @@ func TestAccountsAreInitiallyUnknown(t *testing.T) {
 
 func TestAccountsCanBeCreated(t *testing.T) {
 	runForEachExternalConfig(t, func(t *testing.T, state state.State, config state.Configuration) {
-		state.Apply(0, common.Update{CreatedAccounts: []common.Address{address1}})
+		state.Apply(0, common.Update{CreatedAccounts: []common.Address{address1}, Balances: []common.BalanceUpdate{{Account: address1, Balance: balance1}}})
 		account_state, _ := state.Exists(address1)
 		if account_state != true {
 			t.Errorf("Created account does not exist, got %v", account_state)

--- a/go/state/gostate/go_state_test.go
+++ b/go/state/gostate/go_state_test.go
@@ -219,6 +219,9 @@ func TestDeletingAccounts(t *testing.T) {
 			// delete account
 			update = common.Update{
 				DeletedAccounts: []common.Address{address1},
+				Balances:        []common.BalanceUpdate{{Account: address1, Balance: amount.New(0)}},
+				Nonces:          []common.NonceUpdate{{Account: address1, Nonce: common.Nonce{}}},
+				Codes:           []common.CodeUpdate{{Account: address1, Code: []byte{}}},
 			}
 			if _, err := state.Apply(2, update); err != nil {
 				t.Errorf("failed to apply update: %v", err)

--- a/go/state/state_db_and_state_test.go
+++ b/go/state/state_db_and_state_test.go
@@ -801,7 +801,7 @@ func TestStateDB_CallingExistsAfterAccountIsDeletedReturnsFalse(t *testing.T) {
 	for _, config := range initStates() {
 		t.Run(config.name(), func(t *testing.T) {
 			t.Parallel()
-			if strings.Contains(config.name(), "-flat") || config.config.Schema == 0 || config.config.Schema == 6 {
+			if strings.Contains(config.name(), "-flat") || config.config.Schema == 0 {
 				t.Skip()
 			}
 			require := require.New(t)

--- a/go/state/state_db_and_state_test.go
+++ b/go/state/state_db_and_state_test.go
@@ -797,6 +797,59 @@ func TestStateDB_HasEmptyStorage_HandlesAccountSelfDestructCorrectly(t *testing.
 	}
 }
 
+func TestStateDB_CallingExistsAfterAccountIsDeletedReturnsFalse(t *testing.T) {
+	for _, config := range initStates() {
+		t.Run(config.name(), func(t *testing.T) {
+			t.Parallel()
+			if strings.Contains(config.name(), "-flat") || config.config.Schema == 0 || config.config.Schema == 6 {
+				t.Skip()
+			}
+			require := require.New(t)
+			dir := t.TempDir()
+
+			s, err := config.createState(dir)
+			require.NoError(err)
+			defer func() {
+				require.NoError(s.Close())
+			}()
+
+			statedb := state.CreateStateDBUsing(s)
+
+			createAccountWithBalance := func(address common.Address, balance amount.Amount, blockNum uint64) {
+				statedb.BeginBlock()
+				statedb.CreateAccount(address)
+				statedb.AddBalance(address, balance)
+				statedb.EndTransaction()
+				statedb.EndBlock(blockNum)
+			}
+
+			// Case 1: deleted account because is empty
+			createAccountWithBalance(address1, balance1, 0)
+			statedb.BeginBlock()
+			statedb.BeginTransaction()
+			statedb.SubBalance(address1, balance1)
+			statedb.EndTransaction()
+			statedb.EndBlock(1)
+
+			exists, err := s.Exists(address1)
+			require.NoError(err)
+			require.False(exists)
+
+			// Case 2: deleted account because of suicide
+			createAccountWithBalance(address1, balance1, 2)
+			statedb.BeginBlock()
+			statedb.BeginTransaction()
+			require.True(statedb.Suicide(address1))
+			statedb.EndTransaction()
+			statedb.EndBlock(3)
+
+			exists, err = s.Exists(address1)
+			require.NoError(err)
+			require.False(exists)
+		})
+	}
+}
+
 func toVal(key uint64) common.Value {
 	keyBytes := make([]byte, 32)
 	binary.BigEndian.PutUint64(keyBytes, key)

--- a/go/state/state_test.go
+++ b/go/state/state_test.go
@@ -690,12 +690,18 @@ func TestLastArchiveBlock(t *testing.T) {
 
 			if _, err := s.Apply(0, common.Update{
 				CreatedAccounts: []common.Address{address1},
+				Balances: []common.BalanceUpdate{
+					{Account: address1, Balance: balance1},
+				},
 			}); err != nil {
 				t.Fatalf("failed to add block 0; %s", err)
 			}
 
 			if _, err := s.Apply(1, common.Update{
 				CreatedAccounts: []common.Address{address2},
+				Balances: []common.BalanceUpdate{
+					{Account: address2, Balance: balance2},
+				},
 			}); err != nil {
 				t.Fatalf("failed to add block 1; %s", err)
 			}

--- a/go/state/stress_test.go
+++ b/go/state/stress_test.go
@@ -14,9 +14,11 @@
 package state_test
 
 import (
+	"strings"
+	"testing"
+
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/state"
-	"testing"
 )
 
 func TestStress_CanHandleLargeBlock(t *testing.T) {
@@ -62,12 +64,12 @@ func TestStress_CanHandleLargeBlock(t *testing.T) {
 
 func TestStress_CanHandleDeleteOfLargeAccount(t *testing.T) {
 	// the number of slots in the account (larger than what could be filled in a single block)
-	const N = 10_000_000
+	const N = 1_000_000
 	for _, config := range initStates() {
 		config := config
 		t.Run(config.name(), func(t *testing.T) {
 			// to safe processing time only S5 is tested
-			if config.config.Schema != 5 {
+			if config.config.Schema != 5 || strings.HasSuffix(string(config.config.Variant), "-flat") {
 				t.Skip()
 			}
 			t.Parallel()

--- a/rust/src/database/verkle/state.rs
+++ b/rust/src/database/verkle/state.rs
@@ -132,7 +132,14 @@ impl<T: VerkleTrie> IsArchive for VerkleTrieCarmenState<T> {
 
 impl<T: VerkleTrie> CarmenState for VerkleTrieCarmenState<T> {
     fn account_exists(&self, addr: &Address) -> BTResult<bool, Error> {
-        Ok(self.get_code_hash(addr)? != Hash::default())
+        let key = self.embedding.get_basic_data_key(addr);
+        let value = self.trie.lookup(&key)?;
+        let balance = &value[16..32];
+        let nonce = &value[8..16];
+        Ok(value != Value::default()
+            && (balance != U256::default()
+                || nonce != Nonce::default()
+                || self.get_code_hash(addr)? != EMPTY_CODE_HASH))
     }
 
     fn get_balance(&self, addr: &Address) -> BTResult<U256, Error> {

--- a/rust/src/database/verkle/variants/managed/mod.rs
+++ b/rust/src/database/verkle/variants/managed/mod.rs
@@ -293,7 +293,7 @@ mod tests {
         trie.accept(&mut mock_visitor).unwrap();
     }
 
-    struct TestNodeWrapper {
+    pub struct TestNodeWrapper {
         node: VerkleNode,
     }
 


### PR DESCRIPTION
This PR unifies the behavior of Verkle implementations when deleting accounts.
In `stateDB`, an account is deleted when is empty or suicided. In both cases, its state (balance, nonce, code) is reset.
Verkle tries do not support node deletion, therefore the existence of an account is defined as follows:
- The node is not in the trie
- The node is in the trie, but its fields are all empty (0 balance, 0 nonce, empty code hash)

This was already the behavior in `go-reference`, which originally matched the behavior of the old geth verkle reference implementation.

This has the implication that creating an account with the `CreatedAccount` field in the `Update` struct is not enough anymore to create an account, as it will be empty and therefore treated as non-existing. However, this is already not possible as the `stateDB` deletes every account that are touched but empty at the end of a transaction.

Additional note: [eip-158](https://eips.ethereum.org/EIPS/eip-158) specify when to delete an account. However, it mentions that the account should also have storage empty. This is not checked in the `stateDB` before marking the accounts as to be deleted [here](https://github.com/0xsoniclabs/carmen/blob/1fbc1d379dd2d46e57ad9012ee9b3eaefd1fc650/go/state/state_db.go#L1137) and [here](https://github.com/0xsoniclabs/carmen/blob/1fbc1d379dd2d46e57ad9012ee9b3eaefd1fc650/go/state/state_db.go#L639). Therefore, the verkle implementations also don't check for the emptiness of the storage, but I am not sure about why is it not done in the `stateDB` too.