### PR TITLE
Fix synchronization issue in EndBlock test 

### DIFF
--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -4951,6 +4951,8 @@ func TestStateDB_EndBlock_CollectsSyncErrorInIssueTracker_WhenApplyReturnsChanne
 	// simulating the state finishing the update with an error.
 	applyDone <- injectedError
 	close(applyDone)
+	// Wait for the archive error goroutine to register the error in the issue tracker.
+	<-done
 
 	err := db.Check()
 	if !errors.Is(err, injectedError) {


### PR DESCRIPTION
`TestStateDB_EndBlock_CollectsSyncErrorInIssueTracker_WhenApplyReturnsChannelWithError` checks that errors produced in the live and archive implementations are correctly reported from `state.Check()`. 
However, there was no synchronization between the call to Check() and the goroutine registering the error in the issue tracker, resulting in a flaky test.

This PR fixes it by waiting on the archive error channel to be closed, which happens after the archvie goroutine has processed the error.