### PR TITLE
Update go version in libcarmen script to 1.25

### DIFF
--- a/go/lib/build_libcarmen.sh
+++ b/go/lib/build_libcarmen.sh
@@ -32,6 +32,6 @@ else
         -v $(pwd):/src \
         -w /src/go/lib \
         --entrypoint=/bin/bash \
-        golang:1.19 \
+        golang:1.25 \
         -c "go install github.com/bazelbuild/bazelisk@v1.15.0 && ln -s /go/bin/bazelisk /go/bin/bazel && apt update && apt install -y clang && ./build_libcarmen.sh"
 fi


### PR DESCRIPTION
Go Carmen required Go 1.25. This PR updates the libcarmen build script to use the same version. 
This also unify the clang version used with the Jenkins CI, as the go:1.25 image installs clang-19 instead of clang-14.