### PR TITLE
Update clang in readme

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -3,8 +3,8 @@ This directory contains a C++ implementation of the Carmen storage system.
 
 # Needed Tools
 To build the C++ implementation you need the following tools:
- - a C++ compiler supporting C++20 (recommended clang 14+)
- - a matching C++ standard library (e.g., on Ubuntu `libc++-14-dev` and `libstdc++-12-dev`)
+ - a C++ compiler supporting C++20 (recommended clang 19+)
+ - a matching C++ standard library (e.g., on Ubuntu `libc++-19-dev` and `libstdc++-13-dev`)
  - the bazel build tool
  
 


### PR DESCRIPTION
This updates the C++ readme to recommend the correct clang version, as it now works with clang-19.