### PR TITLE
Use libstdc++-12 for C++ in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,8 @@ pipeline {
         GOMEMLIMIT = '5GiB'
         CC = 'clang-14'
         CXX = 'clang++-14'
+        CXXFLAGS="--gcc-toolchain=--gcc-toolchain=/usr/lib/gcc/x86_64-linux-gnu/12/include"
+        CPLUS_INCLUDE_PATH="/usr/include/c++/12:/usr/include/x86_64-linux-gnu/c++/12"
     }
 
     stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,8 +18,8 @@ pipeline {
 
     environment {
         GOMEMLIMIT = '5GiB'
-        CC = 'clang-19'
-        CXX = 'clang++-19'
+        CC = 'clang-14'
+        CXX = 'clang++-14'
     }
 
     stages {
@@ -52,7 +52,7 @@ pipeline {
 
                 stage('Check C++ sources formatting') {
                     steps {
-                        sh 'find cpp/ -iname *.h -o -iname *.cc | xargs clang-format-19 --dry-run -Werror '
+                        sh 'find cpp/ -iname *.h -o -iname *.cc | xargs clang-format-14 --dry-run -Werror '
                     }
                 }
 

--- a/cpp/archive/archive.h
+++ b/cpp/archive/archive.h
@@ -36,33 +36,33 @@ concept Archive = requires(A a, const A b) {
   // Adds the changes of the given block to this archive.
   {
     a.Add(std::declval<BlockId>(), std::declval<Update>())
-  } -> std::same_as<absl::Status>;
+    } -> std::same_as<absl::Status>;
 
   // Allows to test whether an account exists at the given block height.
   {
     a.Exists(std::declval<BlockId>(), std::declval<Address>())
-  } -> std::same_as<absl::StatusOr<bool>>;
+    } -> std::same_as<absl::StatusOr<bool>>;
 
   // Allows to fetch a historic balance values for a given account.
   {
     a.GetBalance(std::declval<BlockId>(), std::declval<Address>())
-  } -> std::same_as<absl::StatusOr<Balance>>;
+    } -> std::same_as<absl::StatusOr<Balance>>;
 
   // Allows to fetch a historic code values for a given account.
   {
     a.GetCode(std::declval<BlockId>(), std::declval<Address>())
-  } -> std::same_as<absl::StatusOr<Code>>;
+    } -> std::same_as<absl::StatusOr<Code>>;
 
   // Allows to fetch a historic nonce values for a given account.
   {
     a.GetNonce(std::declval<BlockId>(), std::declval<Address>())
-  } -> std::same_as<absl::StatusOr<Nonce>>;
+    } -> std::same_as<absl::StatusOr<Nonce>>;
 
   // Allows to fetch a historic value for a given slot.
   {
     a.GetStorage(std::declval<BlockId>(), std::declval<Address>(),
                  std::declval<Key>())
-  } -> std::same_as<absl::StatusOr<Value>>;
+    } -> std::same_as<absl::StatusOr<Value>>;
 
   // Computes a hash for the entire archive up until the given block.
   { a.GetHash(std::declval<BlockId>()) } -> std::same_as<absl::StatusOr<Hash>>;
@@ -70,7 +70,7 @@ concept Archive = requires(A a, const A b) {
   // Obtains a full list of addresses encountered up until the given block.
   {
     a.GetAccountList(std::declval<BlockId>())
-  } -> std::same_as<absl::StatusOr<std::vector<Address>>>;
+    } -> std::same_as<absl::StatusOr<std::vector<Address>>>;
 
   // Obtains the last block included in this archive, 0 if empty.
   { a.GetLatestBlock() } -> std::same_as<absl::StatusOr<BlockId>>;
@@ -78,13 +78,13 @@ concept Archive = requires(A a, const A b) {
   // Obtains a hash on the content of the given hash at the given block height.
   {
     a.GetAccountHash(std::declval<BlockId>(), std::declval<Address>())
-  } -> std::same_as<absl::StatusOr<Hash>>;
+    } -> std::same_as<absl::StatusOr<Hash>>;
 
   // Verifies that the content of this archive up until the given block.
   {
     a.Verify(std::declval<BlockId>(), std::declval<Hash>(),
              std::declval<absl::FunctionRef<void(std::string_view)>>())
-  } -> std::same_as<absl::Status>;
+    } -> std::same_as<absl::Status>;
 
   // An archive must have the basic properties of a structure, including Open,
   // Close, and Flush support.

--- a/cpp/archive/leveldb/archive.cc
+++ b/cpp/archive/leveldb/archive.cc
@@ -726,7 +726,7 @@ class Archive {
 LevelDbArchive::LevelDbArchive(LevelDbArchive&&) = default;
 
 LevelDbArchive::LevelDbArchive(std::unique_ptr<internal::Archive> archive)
-    : impl_(std::move(archive)) {};
+    : impl_(std::move(archive)){};
 
 LevelDbArchive& LevelDbArchive::operator=(LevelDbArchive&&) = default;
 

--- a/cpp/archive/leveldb/encoding.h
+++ b/cpp/archive/leveldb/encoding.h
@@ -28,8 +28,8 @@ void Write(std::uint32_t value, std::span<char, 4> trg);
 // Writes the given trivial value (e.g. Balance, Nonce, Value) into the provided
 // target span. Trivial values are encoded as is.
 template <Trivial T>
-requires(!std::is_integral_v<T>)
-void Write(const T& value, std::span<char, sizeof(T)> trg) {
+requires(!std::is_integral_v<T>) void Write(const T& value,
+                                            std::span<char, sizeof(T)> trg) {
   std::memcpy(trg.data(), &value, sizeof(T));
 }
 
@@ -39,15 +39,14 @@ std::uint32_t ReadUint32(std::span<const char, 4> src);
 
 // Interprets the provided data span as a trivial value.
 template <Trivial T>
-requires(!std::is_integral_v<T>)
-T& Read(std::span<char, sizeof(T)> trg) {
+requires(!std::is_integral_v<T>) T& Read(std::span<char, sizeof(T)> trg) {
   return *reinterpret_cast<T*>(trg.data());
 }
 
 // Interprets the provided data span as a constant trivial value.
 template <Trivial T>
-requires(!std::is_integral_v<T>)
-const T& Read(std::span<const char, sizeof(T)> trg) {
+requires(!std::is_integral_v<T>) const T& Read(
+    std::span<const char, sizeof(T)> trg) {
   return *reinterpret_cast<const T*>(trg.data());
 }
 

--- a/cpp/backend/common/btree/entry.h
+++ b/cpp/backend/common/btree/entry.h
@@ -28,8 +28,8 @@ struct Unit {};
 template <Trivial Key, Trivial Value = Unit>
 struct ABSL_ATTRIBUTE_PACKED Entry {
   Entry() = default;
-  Entry(Key key) : key(key) {};
-  Entry(Key key, Value value) : key(key), value(value) {};
+  Entry(Key key) : key(key){};
+  Entry(Key key, Value value) : key(key), value(value){};
 
   bool operator==(const Entry&) const = default;
 

--- a/cpp/backend/common/btree/nodes_test.cc
+++ b/cpp/backend/common/btree/nodes_test.cc
@@ -226,8 +226,7 @@ struct Tree<0> {
 
 // A factory for leaf-level Trees.
 template <typename... Ints>
-requires(std::same_as<Ints, int> && ...)
-Tree<0> Node(Ints&&... args) {
+requires(std::same_as<Ints, int>&&...) Tree<0> Node(Ints&&... args) {
   return Tree<0>{std::vector<int>{args...}};
 }
 

--- a/cpp/backend/common/eviction_policy.h
+++ b/cpp/backend/common/eviction_policy.h
@@ -24,7 +24,7 @@ namespace carmen::backend {
 template <typename P>
 concept EvictionPolicy = requires(P a) {
   // Policies must be initializable by the pool size.
-  { P(std::size_t{}) };
+  {P(std::size_t{})};
   // Informs the policy that a page slot has been read.
   { a.Read(std::size_t{}) } -> std::same_as<void>;
   // Informs the policy that a page slot has been updated.

--- a/cpp/backend/common/file.cc
+++ b/cpp/backend/common/file.cc
@@ -268,7 +268,7 @@ absl::StatusOr<PosixFile> PosixFile::Open(const std::filesystem::path& path) {
   int fd;
 #ifdef O_DIRECT
   // When using O_DIRECT, all read/writes must use aligned memory locations!
-  fd = open(path.string().c_str(), O_CREAT | O_DIRECT | O_RDWR, 0600);
+  fd = open(path.string().c_str(), O_CREAT | O_DIRECT | O_RDWR);
 #else
   fd = open(path.string().c_str(), O_CREAT | O_RDWR);
 #endif

--- a/cpp/backend/common/file.h
+++ b/cpp/backend/common/file.h
@@ -50,7 +50,7 @@ concept File = requires(F a) {
   // All files must be open-able through a static factory function.
   {
     F::Open(std::declval<const std::filesystem::path&>())
-  } -> std::same_as<absl::StatusOr<F>>;
+    } -> std::same_as<absl::StatusOr<F>>;
 
   // Each file implementation must support the extraction of the number of
   // pages.
@@ -58,12 +58,12 @@ concept File = requires(F a) {
   // LoadPage is intended to be used for fetching a single page from the file.
   {
     a.LoadPage(PageId{}, std::declval<std::span<std::byte, F::kPageSize>>())
-  } -> std::same_as<absl::Status>;
+    } -> std::same_as<absl::Status>;
   // StorePage is intended to be used for fetching a single page from the file.
   {
     a.StorePage(PageId{},
                 std::declval<std::span<const std::byte, F::kPageSize>>())
-  } -> std::same_as<absl::Status>;
+    } -> std::same_as<absl::Status>;
   // Each file has to support a flush operation after which data previously
   // written must be persisted on disk.
   { a.Flush() } -> std::same_as<absl::Status>;

--- a/cpp/backend/common/page.h
+++ b/cpp/backend/common/page.h
@@ -31,10 +31,10 @@ concept Page =
     alignof(P) % kFileSystemPageSize == 0 &&
     // To be used in page pools, pages must also be trivially default
     // constructable and destructible.
-    std::is_trivially_default_constructible_v<P> &&
-    std::is_trivially_destructible_v<P> &&
-    std::is_convertible_v<P, std::span<std::byte, sizeof(P)>> &&
-    std::is_convertible_v<const P, std::span<const std::byte, sizeof(P)>>;
+    std::is_trivially_default_constructible_v<P>&& std::
+        is_trivially_destructible_v<P>&& std::is_convertible_v<
+            P, std::span<std::byte, sizeof(P)>>&& std::
+            is_convertible_v<const P, std::span<const std::byte, sizeof(P)>>;
 
 // Computes the required page size based on a use case specific needed page
 // size. The required page size is the smallest multiple of the file system's

--- a/cpp/backend/common/sqlite/sqlite.h
+++ b/cpp/backend/common/sqlite/sqlite.h
@@ -97,7 +97,7 @@ class Sqlite {
   MemoryFootprint GetMemoryFootprint() const;
 
  private:
-  Sqlite(std::shared_ptr<internal::SqliteDb> db) : db_(std::move(db)) {};
+  Sqlite(std::shared_ptr<internal::SqliteDb> db) : db_(std::move(db)){};
 
   // The actual DB connection state wich shared ownership between this instance
   // and all derived statements.
@@ -281,7 +281,7 @@ class SqlQueryResult {
   absl::Status Consume(absl::FunctionRef<void(const SqlRow& row)> consumer);
 
  private:
-  SqlQueryResult(SqlStatement stmt) : stmt_(std::move(stmt)) {};
+  SqlQueryResult(SqlStatement stmt) : stmt_(std::move(stmt)){};
   SqlStatement stmt_;
 };
 

--- a/cpp/backend/depot/depot.h
+++ b/cpp/backend/depot/depot.h
@@ -26,31 +26,29 @@ namespace carmen::backend::depot {
 // Defines the interface expected for a Depot D mapping integral keys to
 // byte array values of various lengths.
 template <typename D>
-concept Depot =
-    requires(D a, const D b) {
-      // A depot must expose a key type.
-      std::integral<typename D::key_type>;
+concept Depot = requires(D a, const D b) {
+  // A depot must expose a key type.
+  std::integral<typename D::key_type>;
 
-      // Depots must be movable.
-      std::is_move_constructible_v<D>;
-      std::is_move_assignable_v<D>;
+  // Depots must be movable.
+  std::is_move_constructible_v<D>;
+  std::is_move_assignable_v<D>;
 
-      // Set data for given key.
-      {
-        a.Set(std::declval<typename D::key_type>(),
-              std::declval<std::span<const std::byte>>())
-      } -> std::same_as<absl::Status>;
-      // Retrieves data from Depot. Not found status is returned when not found.
-      {
-        b.Get(std::declval<typename D::key_type>())
-      } -> std::same_as<absl::StatusOr<std::span<const std::byte>>>;
-      // Retrieves size of data from Depot. Not found status is returned when
-      // not
-      {
-        b.GetSize(std::declval<typename D::key_type>())
-      } -> std::same_as<absl::StatusOr<std::uint32_t>>;
-    }
-    // Depots must satisfy the requirements for backend data structures.
-    && HashableStructure<D>;
+  // Set data for given key.
+  {
+    a.Set(std::declval<typename D::key_type>(),
+          std::declval<std::span<const std::byte>>())
+    } -> std::same_as<absl::Status>;
+  // Retrieves data from Depot. Not found status is returned when not found.
+  {
+    b.Get(std::declval<typename D::key_type>())
+    } -> std::same_as<absl::StatusOr<std::span<const std::byte>>>;
+  // Retrieves size of data from Depot. Not found status is returned when not
+  {
+    b.GetSize(std::declval<typename D::key_type>())
+    } -> std::same_as<absl::StatusOr<std::uint32_t>>;
+}
+// Depots must satisfy the requirements for backend data structures.
+&&HashableStructure<D>;
 
 }  // namespace carmen::backend::depot

--- a/cpp/backend/index/file/stable_hash.h
+++ b/cpp/backend/index/file/stable_hash.h
@@ -56,8 +56,7 @@ class StableHashState {
 
   // The fall-back support for types implementing the Absl hashing interface.
   template <typename T>
-  requires(!std::is_integral_v<T>)
-  static std::size_t hash(const T& value) {
+  requires(!std::is_integral_v<T>) static std::size_t hash(const T& value) {
     return AbslHashValue(internal::StableHashState(), value).state_;
   }
 

--- a/cpp/backend/index/index.h
+++ b/cpp/backend/index/index.h
@@ -46,26 +46,23 @@ class IndexSnapshot {
 // Defines the interface expected for an Index I, mapping keys of type K to
 // integral values of type V.
 template <typename I>
-concept Index =
-    requires(I a, const I b) {
-      // An index must expose a key type.
-      typename I::key_type;
-      // An index must expose an integral value type.
-      std::integral<typename I::value_type>;
-      // Looks up the given key and adds it to the index if not present. Returns
-      // the status of operation. On success returns associated value and a
-      // boolean set to true if the provided key was new, false otherwise.
-      {
-        a.GetOrAdd(std::declval<typename I::key_type>())
-      }
-      -> std::same_as<absl::StatusOr<std::pair<typename I::value_type, bool>>>;
-      // Retrieves the key from the index if present, not found status
-      // otherwise.
-      {
-        b.Get(std::declval<typename I::key_type>())
-      } -> std::same_as<absl::StatusOr<typename I::value_type>>;
-    }
-    // Indexes must satisfy the requirements for backend data structures.
-    && HashableStructure<I>;
+concept Index = requires(I a, const I b) {
+  // An index must expose a key type.
+  typename I::key_type;
+  // An index must expose an integral value type.
+  std::integral<typename I::value_type>;
+  // Looks up the given key and adds it to the index if not present. Returns the
+  // status of operation. On success returns associated value and a boolean
+  // set to true if the provided key was new, false otherwise.
+  {
+    a.GetOrAdd(std::declval<typename I::key_type>())
+    } -> std::same_as<absl::StatusOr<std::pair<typename I::value_type, bool>>>;
+  // Retrieves the key from the index if present, not found status otherwise.
+  {
+    b.Get(std::declval<typename I::key_type>())
+    } -> std::same_as<absl::StatusOr<typename I::value_type>>;
+}
+// Indexes must satisfy the requirements for backend data structures.
+&&HashableStructure<I>;
 
 }  // namespace carmen::backend::index

--- a/cpp/backend/index/index_handler.h
+++ b/cpp/backend/index/index_handler.h
@@ -62,7 +62,7 @@ class IndexHandler : public IndexHandlerBase<typename Index::key_type,
   IndexHandler(Context ctx, TempDir dir, Index idx)
       : ctx_(std::move(ctx)),
         temp_dir_(std::move(dir)),
-        index_(std::move(idx)) {};
+        index_(std::move(idx)){};
 
   Context ctx_;
   TempDir temp_dir_;
@@ -86,7 +86,7 @@ class IndexHandler<LevelDbKeySpace<K, I>> : public IndexHandlerBase<K, I> {
 
  private:
   IndexHandler(TempDir dir, LevelDbKeySpace<K, I> idx)
-      : temp_dir_(std::move(dir)), index_(std::move(idx)) {};
+      : temp_dir_(std::move(dir)), index_(std::move(idx)){};
 
   TempDir temp_dir_;
   LevelDbKeySpace<K, I> index_;

--- a/cpp/backend/multimap/memory/multimap_test.cc
+++ b/cpp/backend/multimap/memory/multimap_test.cc
@@ -27,8 +27,9 @@ using ::testing::UnorderedElementsAre;
 template <typename K, typename V>
 std::vector<std::pair<K, V>> Enumerate(const InMemoryMultiMap<K, V>& map) {
   std::vector<std::pair<K, V>> res;
-  map.ForEach(
-      [&](const K& key, const V& value) { res.push_back({key, value}); });
+  map.ForEach([&](const K& key, const V& value) {
+    res.push_back({key, value});
+  });
   return res;
 }
 
@@ -36,7 +37,10 @@ template <typename K, typename V>
 std::vector<std::pair<K, V>> Enumerate(const K& key,
                                        const InMemoryMultiMap<K, V>& map) {
   std::vector<std::pair<K, V>> res;
-  map.ForEach(key, [&](const V& value) { res.push_back({key, value}); })
+  map.ForEach(key,
+              [&](const V& value) {
+                res.push_back({key, value});
+              })
       .IgnoreError();
   return res;
 }

--- a/cpp/backend/multimap/multimap.h
+++ b/cpp/backend/multimap/multimap.h
@@ -19,38 +19,37 @@ namespace carmen::backend::multimap {
 // values. It serves as a specialized index structure enabling the fast
 // accessing of a set of values associated to a given key.
 template <typename M>
-concept MultiMap =
-    requires(M a, const M b) {
-      // A multi map must expose its key type.
-      typename M::key_type;
-      // A multi map must expose its value type.
-      typename M::value_type;
-      // Insert a new Key/Value pair in the multimap. Duplicates are ignored.
-      // Returns true if pair was not present before, false if it was, and an
-      // error if the operation failed.
-      {
-        a.Insert(std::declval<typename M::key_type>(),
-                 std::declval<typename M::value_type>())
-      } -> std::same_as<absl::StatusOr<bool>>;
-      // Erases a single Key/Value pair from the multimap. Returns true if the
-      // element was present and is gone, false if it was not present, and an
-      // error if the operation failed.
-      {
-        a.Erase(std::declval<typename M::key_type>(),
-                std::declval<typename M::value_type>())
-      } -> std::same_as<absl::StatusOr<bool>>;
-      // Erases all Key/Value pairs with the given key from the multimap.
-      // Returns an error if the operation failed.
-      {
-        a.Erase(std::declval<typename M::key_type>())
-      } -> std::same_as<absl::Status>;
-      // Applies the given function to every value associated to the given key.
-      {
-        b.ForEach(std::declval<typename M::key_type>(),
-                  [](const typename M::value_type&) {})
-      } -> std::same_as<absl::Status>;
-    }
-    // Indexes must satisfy the requirements for backend data structures.
-    && Structure<M>;
+concept MultiMap = requires(M a, const M b) {
+  // A multi map must expose its key type.
+  typename M::key_type;
+  // A multi map must expose its value type.
+  typename M::value_type;
+  // Insert a new Key/Value pair in the multimap. Duplicates are ignored.
+  // Returns true if pair was not present before, false if it was, and an error
+  // if the operation failed.
+  {
+    a.Insert(std::declval<typename M::key_type>(),
+             std::declval<typename M::value_type>())
+    } -> std::same_as<absl::StatusOr<bool>>;
+  // Erases a single Key/Value pair from the multimap. Returns true if the
+  // element was present and is gone, false if it was not present, and an error
+  // if the operation failed.
+  {
+    a.Erase(std::declval<typename M::key_type>(),
+            std::declval<typename M::value_type>())
+    } -> std::same_as<absl::StatusOr<bool>>;
+  // Erases all Key/Value pairs with the given key from the multimap. Returns
+  // an error if the operation failed.
+  {
+    a.Erase(std::declval<typename M::key_type>())
+    } -> std::same_as<absl::Status>;
+  // Applies the given function to every value associated to the given key.
+  {
+    b.ForEach(std::declval<typename M::key_type>(),
+              [](const typename M::value_type&) {})
+    } -> std::same_as<absl::Status>;
+}
+// Indexes must satisfy the requirements for backend data structures.
+&&Structure<M>;
 
 }  // namespace carmen::backend::multimap

--- a/cpp/backend/store/file/store.h
+++ b/cpp/backend/store/file/store.h
@@ -189,10 +189,10 @@ class FileStoreBase {
 template <typename K, Trivial V, template <std::size_t> class F,
           std::size_t page_size, bool eager_hashing>
 requires File<F<sizeof(ArrayPage<V, page_size / sizeof(V)>)>>
-absl::StatusOr<FileStoreBase<K, V, F, page_size, eager_hashing>>
-FileStoreBase<K, V, F, page_size, eager_hashing>::Open(
-    Context&, const std::filesystem::path& directory,
-    std::size_t hash_branching_factor) {
+    absl::StatusOr<FileStoreBase<K, V, F, page_size, eager_hashing>>
+    FileStoreBase<K, V, F, page_size, eager_hashing>::Open(
+        Context&, const std::filesystem::path& directory,
+        std::size_t hash_branching_factor) {
   // Make sure the directory exists.
   RETURN_IF_ERROR(CreateDirectory(directory));
   ASSIGN_OR_RETURN(auto file, F<kFilePageSize>::Open(directory / "data.dat"));
@@ -221,9 +221,8 @@ FileStoreBase<K, V, F, page_size, eager_hashing>::FileStoreBase(
 
 template <typename K, Trivial V, template <std::size_t> class F,
           std::size_t page_size, bool eager_hashing>
-requires File<F<sizeof(ArrayPage<V, page_size / sizeof(V)>)>>
-absl::Status FileStoreBase<K, V, F, page_size, eager_hashing>::Set(const K& key,
-                                                                   V value) {
+requires File<F<sizeof(ArrayPage<V, page_size / sizeof(V)>)>> absl::Status
+FileStoreBase<K, V, F, page_size, eager_hashing>::Set(const K& key, V value) {
   num_pages_ = std::max(num_pages_, key / kNumElementsPerPage + 1);
   ASSIGN_OR_RETURN(Page & page,
                    pool_->template Get<Page>(key / kNumElementsPerPage));
@@ -238,9 +237,9 @@ absl::Status FileStoreBase<K, V, F, page_size, eager_hashing>::Set(const K& key,
 
 template <typename K, Trivial V, template <std::size_t> class F,
           std::size_t page_size, bool eager_hashing>
-requires File<F<sizeof(ArrayPage<V, page_size / sizeof(V)>)>>
-absl::StatusOr<V> FileStoreBase<K, V, F, page_size, eager_hashing>::Get(
-    const K& key) const {
+requires File<F<sizeof(ArrayPage<V, page_size / sizeof(V)>)>> absl::StatusOr<V>
+FileStoreBase<K, V, F, page_size, eager_hashing>::Get(const K& key)
+const {
   static const V kDefault{};
   auto page_id = key / kNumElementsPerPage;
   if (page_id >= num_pages_) {
@@ -254,15 +253,14 @@ absl::StatusOr<V> FileStoreBase<K, V, F, page_size, eager_hashing>::Get(
 template <typename K, Trivial V, template <std::size_t> class F,
           std::size_t page_size, bool eager_hashing>
 requires File<F<sizeof(ArrayPage<V, page_size / sizeof(V)>)>>
-absl::StatusOr<Hash> FileStoreBase<K, V, F, page_size, eager_hashing>::GetHash()
-    const {
-  return hashes_->GetHash();
-}
+    absl::StatusOr<Hash>
+    FileStoreBase<K, V, F, page_size, eager_hashing>::GetHash()
+const { return hashes_->GetHash(); }
 
 template <typename K, Trivial V, template <std::size_t> class F,
           std::size_t page_size, bool eager_hashing>
-requires File<F<sizeof(ArrayPage<V, page_size / sizeof(V)>)>>
-absl::Status FileStoreBase<K, V, F, page_size, eager_hashing>::Flush() {
+requires File<F<sizeof(ArrayPage<V, page_size / sizeof(V)>)>> absl::Status
+FileStoreBase<K, V, F, page_size, eager_hashing>::Flush() {
   if (pool_) {
     RETURN_IF_ERROR(pool_->Flush());
   }
@@ -274,8 +272,8 @@ absl::Status FileStoreBase<K, V, F, page_size, eager_hashing>::Flush() {
 
 template <typename K, Trivial V, template <std::size_t> class F,
           std::size_t page_size, bool eager_hashing>
-requires File<F<sizeof(ArrayPage<V, page_size / sizeof(V)>)>>
-absl::Status FileStoreBase<K, V, F, page_size, eager_hashing>::Close() {
+requires File<F<sizeof(ArrayPage<V, page_size / sizeof(V)>)>> absl::Status
+FileStoreBase<K, V, F, page_size, eager_hashing>::Close() {
   RETURN_IF_ERROR(Flush());
   if (pool_) {
     RETURN_IF_ERROR(pool_->Close());
@@ -285,9 +283,9 @@ absl::Status FileStoreBase<K, V, F, page_size, eager_hashing>::Close() {
 
 template <typename K, Trivial V, template <std::size_t> class F,
           std::size_t page_size, bool eager_hashing>
-requires File<F<sizeof(ArrayPage<V, page_size / sizeof(V)>)>>
-MemoryFootprint
-FileStoreBase<K, V, F, page_size, eager_hashing>::GetMemoryFootprint() const {
+requires File<F<sizeof(ArrayPage<V, page_size / sizeof(V)>)>> MemoryFootprint
+FileStoreBase<K, V, F, page_size, eager_hashing>::GetMemoryFootprint()
+const {
   MemoryFootprint res(*this);
   res.Add("pool", pool_->GetMemoryFootprint());
   res.Add("hashes", hashes_->GetMemoryFootprint());

--- a/cpp/backend/store/hash_tree.h
+++ b/cpp/backend/store/hash_tree.h
@@ -28,7 +28,7 @@ namespace carmen::backend::store {
 // An interface for a source of page data if needed by the HashTree.
 class PageSource {
  public:
-  virtual ~PageSource() {};
+  virtual ~PageSource(){};
   // Requests a view on the data of the given page.
   virtual absl::StatusOr<std::span<const std::byte>> GetPageData(PageId id) = 0;
 };

--- a/cpp/backend/store/store.h
+++ b/cpp/backend/store/store.h
@@ -46,26 +46,25 @@ class StoreSnapshot {
 // Defines the interface expected for a Store S providing an unbound array-like
 // data structure.
 template <typename S>
-concept Store =
-    requires(S a, const S b) {
-      // A store must expose an integral key type.
-      std::integral<typename S::key_type>;
-      // A store must expose a trivial value type.
-      Trivial<typename S::value_type>;
-      // Updates the value associated to the given key.
-      {
-        a.Set(std::declval<typename S::key_type>(),
-              std::declval<typename S::value_type>())
-      } -> std::same_as<absl::Status>;
-      // Retrieves the value associated to the given key. If no values has
-      // been previously set using the Set(..) function above, a
-      // zero-initialized value is returned. The returned reference might only
-      // be valid until the next operation on the store.
-      {
-        b.Get(std::declval<typename S::key_type>())
-      } -> std::same_as<absl::StatusOr<typename S::value_type>>;
-    }
-    // Stores must satisfy the requirements for backend data structures.
-    && HashableStructure<S>;
+concept Store = requires(S a, const S b) {
+  // A store must expose an integral key type.
+  std::integral<typename S::key_type>;
+  // A store must expose a trivial value type.
+  Trivial<typename S::value_type>;
+  // Updates the value associated to the given key.
+  {
+    a.Set(std::declval<typename S::key_type>(),
+          std::declval<typename S::value_type>())
+    } -> std::same_as<absl::Status>;
+  // Retrieves the value associated to the given key. If no values has
+  // been previously set using the Set(..) function above, a zero-initialized
+  // value is returned. The returned reference might only be valid until the
+  // next operation on the store.
+  {
+    b.Get(std::declval<typename S::key_type>())
+    } -> std::same_as<absl::StatusOr<typename S::value_type>>;
+}
+// Stores must satisfy the requirements for backend data structures.
+&&HashableStructure<S>;
 
 }  // namespace carmen::backend::store

--- a/cpp/backend/structure.h
+++ b/cpp/backend/structure.h
@@ -55,22 +55,20 @@ class Context {
 
 // Defines universal requirements for all data structure implementations.
 template <typename S>
-concept Structure =
-    requires(S a) {
-      // All data structures must be open-able through a static factory
-      // function. The provided context can be used to share elements between
-      // structures.
-      {
-        S::Open(std::declval<Context&>(),
-                std::declval<const std::filesystem::path&>())
-      } -> std::same_as<absl::StatusOr<S>>;
-      // Structures must be flushable.
-      { a.Flush() } -> std::same_as<absl::Status>;
-      // Structures must be closeable.
-      { a.Close() } -> std::same_as<absl::Status>;
-    }
-    // All structures must be movable.
-    && std::is_move_constructible_v<S>
+concept Structure = requires(S a) {
+  // All data structures must be open-able through a static factory function.
+  // The provided context can be used to share elements between structures.
+  {
+    S::Open(std::declval<Context&>(),
+            std::declval<const std::filesystem::path&>())
+    } -> std::same_as<absl::StatusOr<S>>;
+  // Structures must be flushable.
+  { a.Flush() } -> std::same_as<absl::Status>;
+  // Structures must be closeable.
+  { a.Close() } -> std::same_as<absl::Status>;
+}
+// All structures must be movable.
+&&std::is_move_constructible_v<S>
     // Structures must provide memory-footprint information.
     && MemoryFootprintProvider<S>;
 

--- a/cpp/common/benchmark.h
+++ b/cpp/common/benchmark.h
@@ -64,7 +64,7 @@ struct NamedType {
 #define _INTERNAL_TO_NAMED_TYPE(TYPE)                          \
   ::carmen::common::internal::NamedType<                       \
       ::carmen::common::internal::ArgType<void(TYPE)>::type> { \
-    #TYPE                                                      \
+#TYPE                                                      \
   }
 
 // Defines a list of types that can be used to instantiate a generic benchmark

--- a/cpp/common/file_util_test.cc
+++ b/cpp/common/file_util_test.cc
@@ -68,9 +68,7 @@ TEST(TempFile, TheTemporaryFileCanBeRemovedAndRecreatedManually) {
   EXPECT_TRUE(std::filesystem::exists(a.GetPath()));
   std::filesystem::remove(a.GetPath());
   EXPECT_FALSE(std::filesystem::exists(a.GetPath()));
-  {
-    std::fstream out(a.GetPath(), std::ios::out);
-  }
+  { std::fstream out(a.GetPath(), std::ios::out); }
   EXPECT_TRUE(std::filesystem::exists(a.GetPath()));
 }
 
@@ -142,9 +140,7 @@ TEST(TempDir, ContentOfTemporaryDirectoryIsAutomaticallyRemoved) {
     EXPECT_TRUE(std::filesystem::exists(path));
     file = a.GetPath() / "file.dat";
     ASSERT_FALSE(std::filesystem::exists(file));
-    {
-      std::fstream out(file, std::ios::out);
-    }
+    { std::fstream out(file, std::ios::out); }
     EXPECT_TRUE(std::filesystem::exists(file));
   }
   EXPECT_FALSE(std::filesystem::exists(path));

--- a/cpp/common/type.h
+++ b/cpp/common/type.h
@@ -25,8 +25,7 @@
 namespace carmen {
 
 template <typename T>
-concept Trivial =
-    std::is_trivially_default_constructible_v<T> &&
+concept Trivial = std::is_trivially_default_constructible_v<T> &&
     std::is_trivially_copyable_v<T> && std::is_trivially_destructible_v<T>;
 
 constexpr int kHashLength = 32;

--- a/cpp/state/state.h
+++ b/cpp/state/state.h
@@ -36,27 +36,27 @@ concept State = requires(S s, const S c) {
   {
     S::Open(std::declval<std::filesystem::path>(),
             /*with_archive=*/std::declval<bool>())
-  } -> std::same_as<absl::StatusOr<S>>;
+    } -> std::same_as<absl::StatusOr<S>>;
 
   // Obtains the current state of the given account.
   {
     c.GetAccountState(std::declval<Address>())
-  } -> std::same_as<absl::StatusOr<AccountState>>;
+    } -> std::same_as<absl::StatusOr<AccountState>>;
 
   // Obtains the current balance of the given account.
   {
     c.GetBalance(std::declval<Address>())
-  } -> std::same_as<absl::StatusOr<Balance>>;
+    } -> std::same_as<absl::StatusOr<Balance>>;
 
   // Obtains the current nonce of the given account.
   {
     c.GetNonce(std::declval<Address>())
-  } -> std::same_as<absl::StatusOr<Nonce>>;
+    } -> std::same_as<absl::StatusOr<Nonce>>;
 
   // Obtains the current value of the given storage slot.
   {
     c.GetStorageValue(std::declval<Address>(), std::declval<Key>())
-  } -> std::same_as<absl::StatusOr<Value>>;
+    } -> std::same_as<absl::StatusOr<Value>>;
 
   // Obtains the current code of the given account.
   { c.GetCode(std::declval<Address>()) } -> std::same_as<absl::StatusOr<Code>>;
@@ -64,17 +64,17 @@ concept State = requires(S s, const S c) {
   // Obtains the size of the current code of the given account.
   {
     c.GetCodeSize(std::declval<Address>())
-  } -> std::same_as<absl::StatusOr<std::uint32_t>>;
+    } -> std::same_as<absl::StatusOr<std::uint32_t>>;
 
   // Obtains the hash of the current code of the given account.
   {
     c.GetCodeHash(std::declval<Address>())
-  } -> std::same_as<absl::StatusOr<Hash>>;
+    } -> std::same_as<absl::StatusOr<Hash>>;
 
   // Applies the given block updates to this state.
   {
     s.Apply(std::declval<BlockId>(), std::declval<Update>())
-  } -> std::same_as<absl::Status>;
+    } -> std::same_as<absl::Status>;
 
   // Obtains a state hash providing a unique cryptographic fingerprint of the
   // entire maintained current state (does not include archive data).

--- a/cpp/state/state_test.cc
+++ b/cpp/state/state_test.cc
@@ -10,7 +10,7 @@
 
 #include "archive/leveldb/archive.h"
 #include "state/configurations.h"
-// #include "state/state_test_suite.h"
+//#include "state/state_test_suite.h"
 
 namespace carmen {
 namespace {


### PR DESCRIPTION
Currently, the C++ implementation requires clang-14 in `sonic_2.1`, but it fails to build on the Jenkins runners because of a known incompatibility between clang 14 and libstdc++-13 with some C++20 features.
This PR forces Clang to pick gcc-12, and therefore libstdc++-12.

This also halts the process of updating to clang-19, and therefore ed207be3ea7bb9ce44a46d21e073f6c3e3d9a864 is reverted for consistency.