### PR TITLE
Fix synchronization issue in EndBlock test

### DIFF
--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -4985,6 +4985,8 @@ func TestStateDB_EndBlock_CollectsMultipleSyncErrorsInIssueTracker(t *testing.T)
 	// simulating the state finishing the update with an error.
 	applyDone <- injectedError2
 	close(applyDone)
+	// Wait for the archive error goroutine to register the error in the issue tracker.
+	<-done
 
 	err := db.Check()
 	if !errors.Is(err, injectedError1) || !errors.Is(err, injectedError2) {


### PR DESCRIPTION
This PR replicates the same fix of https://github.com/0xsoniclabs/carmen/pull/390 in `TestStateDB_EndBlock_CollectsMultipleSyncErrorsInIssueTracker`, which exhibits the same synchronization issue.