### PR TITLE
Fix protection of node reference cache hints

### DIFF
--- a/go/backend/stock/shadow/shadow.go
+++ b/go/backend/stock/shadow/shadow.go
@@ -13,6 +13,7 @@ package shadow
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"unsafe"
 
 	"github.com/0xsoniclabs/carmen/go/backend/stock"
@@ -52,7 +53,7 @@ func (s *shadowStock[I, V]) Get(index I) (V, error) {
 	if errA != nil || errB != nil {
 		return a, errors.Join(errA, errB)
 	}
-	if a != b {
+	if !reflect.DeepEqual(a, b) {
 		fmt.Printf("Retrieved for index %v:\nwant: %v\n got: %v\n", index, b, a)
 		panic("failed")
 	}

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -2001,7 +2001,8 @@ func TestArchiveTrie_DirectlyStoredRootsCanBeRestored(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to load roots: %v", err)
 	}
-	if !slices.Equal(roots, restored.roots) {
+
+	if !reflect.DeepEqual(roots, restored.roots) {
 		t.Errorf("failed to restore roots, wanted %v, got %v", roots, restored.roots)
 	}
 }

--- a/go/database/mpt/node_cache.go
+++ b/go/database/mpt/node_cache.go
@@ -30,15 +30,16 @@ import (
 // instance. Mixing references to nodes in different caches can lead to
 // failures and corrupted content.
 type NodeReference struct {
-	id  NodeId // the ID of the referenced node
-	pos uint32 // the position of the node within the cache
-	tag uint64 // a tag used to invalidate references on cache changes
+	id        NodeId // the ID of the referenced node
+	cacheHint *cacheHints
 }
 
 // NewNodeReference creates a new node reference pointing to the addressed
 // Node.
 func NewNodeReference(id NodeId) NodeReference {
-	return NodeReference{id: id, pos: uint32(unknownPosition)}
+	res := NodeReference{id: id, cacheHint: &cacheHints{}}
+	res.cacheHint.pos.Store(uint32(unknownPosition))
+	return res
 }
 
 func (r *NodeReference) Id() NodeId {
@@ -47,6 +48,41 @@ func (r *NodeReference) Id() NodeId {
 
 func (r *NodeReference) String() string {
 	return r.id.String()
+}
+
+// nodeReferenceSizeInBytes returns the size of a NodeReference instance in
+// bytes. This covers the reference itself plus extra data retained on the heap.
+func nodeReferenceSizeInBytes() uintptr {
+	return unsafe.Sizeof(NodeReference{}) + unsafe.Sizeof(cacheHints{})
+}
+
+type cacheHints struct {
+	pos atomic.Uint32 // the position of the node within the cache
+	tag atomic.Uint64 // a tag used to invalidate references on cache changes
+}
+
+func (r *NodeReference) getCacheHints() (pos uint32, tag uint64) {
+	pos = uint32(unknownPosition)
+	if r.cacheHint != nil {
+		pos = r.cacheHint.pos.Load()
+		tag = r.cacheHint.tag.Load()
+	}
+	return pos, tag
+}
+
+func (r *NodeReference) getCachedOwnerPosition() ownerPosition {
+	pos := unknownPosition
+	if r.cacheHint != nil {
+		pos = ownerPosition(r.cacheHint.pos.Load())
+	}
+	return pos
+}
+
+func (r *NodeReference) updateCacheHints(pos uint32, tag uint64) {
+	if r.cacheHint != nil {
+		r.cacheHint.pos.Store(pos)
+		r.cacheHint.tag.Store(tag)
+	}
 }
 
 // NodeCache is managing the life cycle of nodes in memory and limits the
@@ -128,8 +164,7 @@ func (c *nodeCache) Get(r *NodeReference) (*shared.Shared[Node], bool) {
 	// referenced node got evicted, an additional tag is stored. This tag is
 	// incremented every time an owner is recycled, allowing references to
 	// identify modifications.
-	pos := atomic.LoadUint32(&r.pos)
-	tag := atomic.LoadUint64(&r.tag)
+	pos, tag := r.getCacheHints()
 	for {
 		// Resolve the owner position if needed.
 		if pos >= uint32(len(c.owners)) {
@@ -141,8 +176,7 @@ func (c *nodeCache) Get(r *NodeReference) (*shared.Shared[Node], bool) {
 			}
 			pos = uint32(position)
 			tag = c.owners[pos].tag.Load()
-			atomic.StoreUint32(&r.pos, pos)
-			atomic.StoreUint64(&r.tag, tag)
+			r.updateCacheHints(pos, tag)
 			c.mutex.Unlock()
 		}
 		// Fetch the owner and check the tag.
@@ -173,8 +207,7 @@ func (c *nodeCache) GetOrSet(
 	if pos, found := c.index[ref.id]; found {
 		current := c.owners[pos].Node()
 		c.mutex.Unlock()
-		atomic.StoreUint32(&ref.pos, uint32(pos))
-		atomic.StoreUint64(&ref.tag, c.owners[pos].tag.Load())
+		ref.updateCacheHints(uint32(pos), c.owners[pos].tag.Load())
 		return current, true, NodeId(0), nil, false
 	}
 
@@ -215,8 +248,7 @@ func (c *nodeCache) GetOrSet(
 
 	c.index[ref.Id()] = pos
 	c.mutex.Unlock()
-	atomic.StoreUint32(&ref.pos, uint32(pos))
-	atomic.StoreUint64(&ref.tag, stable)
+	ref.updateCacheHints(uint32(pos), stable)
 	return node, false, evictedId, evictedNode, evicted
 }
 
@@ -224,7 +256,7 @@ func (c *nodeCache) Touch(r *NodeReference) {
 	// During a touch we need to update the double-linked list
 	// formed by owners such that the referenced node is at the
 	// head position.
-	pos := ownerPosition(atomic.LoadUint32(&r.pos))
+	pos := r.getCachedOwnerPosition()
 	if uint32(pos) >= uint32(len(c.owners)) {
 		// In this reference does not point to a valid owner; the
 		// reference is not extra resolved to perform a touch, and
@@ -254,7 +286,7 @@ func (c *nodeCache) Release(r *NodeReference) {
 	// During a release we need to update the double-linked list
 	// formed by owners such that the referenced node is at the
 	// tail position.
-	pos := ownerPosition(atomic.LoadUint32(&r.pos))
+	pos := r.getCachedOwnerPosition()
 	if uint32(pos) >= uint32(len(c.owners)) {
 		// This reference does not point to a valid owner; the
 		// reference is not extra resolved to perform a release, and

--- a/go/database/mpt/node_cache_test.go
+++ b/go/database/mpt/node_cache_test.go
@@ -37,7 +37,7 @@ func TestNodeCache_ElementsCanBeStoredAndRetrieved(t *testing.T) {
 	if got, found := cache.Get(&ref); !found || got != node {
 		t.Errorf("failed to retrieve element for %v, found %t, want %p, got %p", ref, found, node, got)
 	}
-	if ref.tag == 0 {
+	if ref.cacheHint.tag.Load() == 0 {
 		t.Errorf("reference has not been tagged during lookup")
 	}
 

--- a/go/database/mpt/state.go
+++ b/go/database/mpt/state.go
@@ -419,10 +419,10 @@ func (s *MptState) setHashes(hashes *NodeHashes) error {
 // sizes defined by the number of stored nodes.
 func EstimatePerNodeMemoryUsage() int {
 
-	// The largest node is the BranchNode with ~944 bytes, which is
-	// likely allocated into 1 KB memory slots. Thus, a memory usage
-	// of 1 KB is used for the notes
-	maxNodeSize := 1 << 10
+	// The largest node is the BranchNode with ~1072 bytes.
+	maxNodeSize := unsafe.Sizeof(BranchNode{}) -
+		16*unsafe.Sizeof(NodeReference{}) +
+		16*nodeReferenceSizeInBytes()
 
 	// Additionally, every node in the node cache needs a owner slot
 	// and a NodeID/ownerPosition entry pair in the index of the cache.
@@ -431,5 +431,5 @@ func EstimatePerNodeMemoryUsage() int {
 		unsafe.Sizeof(ownerPosition(0)) +
 		unsafe.Sizeof(shared.Shared[Node]{})
 
-	return maxNodeSize + int(nodeCacheSlotSize)
+	return int(maxNodeSize) + int(nodeCacheSlotSize)
 }

--- a/go/database/mpt/state.go
+++ b/go/database/mpt/state.go
@@ -419,10 +419,9 @@ func (s *MptState) setHashes(hashes *NodeHashes) error {
 // sizes defined by the number of stored nodes.
 func EstimatePerNodeMemoryUsage() int {
 
-	// The largest node is the BranchNode with ~1072 bytes.
-	maxNodeSize := unsafe.Sizeof(BranchNode{}) -
-		16*unsafe.Sizeof(NodeReference{}) +
-		16*nodeReferenceSizeInBytes()
+	// The largest node is the BranchNode with ~1072 bytes. We round this up
+	// to 1152 assuming some extra allocation overhead and padding.
+	maxNodeSize := 1024 + 128
 
 	// Additionally, every node in the node cache needs a owner slot
 	// and a NodeID/ownerPosition entry pair in the index of the cache.

--- a/go/database/mpt/state_test.go
+++ b/go/database/mpt/state_test.go
@@ -664,20 +664,26 @@ func TestState_Flush_WriteDirtyCodesOnly(t *testing.T) {
 
 func TestEstimatePerNodeMemoryUsage(t *testing.T) {
 
+	// branch nodes contain 16 node references with heap elements
+	branchNodeSize := unsafe.Sizeof(BranchNode{}) -
+		16*unsafe.Sizeof(NodeReference{}) +
+		16*nodeReferenceSizeInBytes()
+
+	// account nodes contain 1 node reference with a heap element
+	accountNodeSize := unsafe.Sizeof(AccountNode{}) -
+		1*unsafe.Sizeof(NodeReference{}) +
+		1*nodeReferenceSizeInBytes()
+
+	// extension nodes contain 1 node reference
+	extensionNodeSize := unsafe.Sizeof(ExtensionNode{}) -
+		1*unsafe.Sizeof(NodeReference{}) +
+		1*nodeReferenceSizeInBytes()
+
+	// value nodes contain 0 node references
+	valueNodeSize := unsafe.Sizeof(ValueNode{})
+
 	// Use the size of the largest node
-	var maxNodeSize uintptr
-	if cur := unsafe.Sizeof(BranchNode{}); cur > maxNodeSize {
-		maxNodeSize = cur
-	}
-	if cur := unsafe.Sizeof(AccountNode{}); cur > maxNodeSize {
-		maxNodeSize = cur
-	}
-	if cur := unsafe.Sizeof(ExtensionNode{}); cur > maxNodeSize {
-		maxNodeSize = cur
-	}
-	if cur := unsafe.Sizeof(ValueNode{}); cur > maxNodeSize {
-		maxNodeSize = cur
-	}
+	maxNodeSize := max(branchNodeSize, accountNodeSize, extensionNodeSize, valueNodeSize)
 
 	ownerSize := unsafe.Sizeof(nodeOwner{})
 	indexEntrySize := unsafe.Sizeof(NodeId(0)) + unsafe.Sizeof(ownerPosition(0))


### PR DESCRIPTION
This PR isolates the concurrently mutated parts of `NodeReference` instances into an internal data structure. 