### PR TITLE
Fix error reporting in hasher.go

### DIFF
--- a/go/database/mpt/hasher.go
+++ b/go/database/mpt/hasher.go
@@ -316,7 +316,7 @@ func (h ethHasher) updateHashesInternal(
 					// flags in parent nodes may not be valid even for child nodes with
 					// up-to-date hashes. Thus, whether the nodes is embedded or not
 					// needs to be computed for all child nodes.
-					if res, e := h.isEmbedded(handle.Get(), manager); err != nil {
+					if res, e := h.isEmbedded(handle.Get(), manager); e != nil {
 						cur.handle.Release()
 						err = e
 						break
@@ -366,7 +366,7 @@ func (h ethHasher) updateHashesInternal(
 			}
 
 			// Test whether this node is to be embedded.
-			if res, e := h.isEmbedded(cur.handle.Get(), manager); err != nil {
+			if res, e := h.isEmbedded(cur.handle.Get(), manager); e != nil {
 				cur.handle.Release()
 				err = e
 				break


### PR DESCRIPTION
In `updateHashesInternal`, the wrong error variable was checked, leading to an impossible condition.
This PR fixes it.

P.s. this was reported by golang-lint, which is disabled in carmen CI. It seems there aren't any semantic lint errors left. After release 2.2, I will submit a series of PR to fix the lints and add a check to CI 