### PR TITLE
Test that externalstate configurations are added to global list

### DIFF
--- a/go/carmen/experimental/configurations_test.go
+++ b/go/carmen/experimental/configurations_test.go
@@ -12,40 +12,11 @@ package experimental_test
 
 import (
 	"slices"
-	"strings"
 	"testing"
 
 	"github.com/0xsoniclabs/carmen/go/carmen"
 	"github.com/0xsoniclabs/carmen/go/carmen/experimental"
 )
-
-func TestConfigurations_ContainGoAndCppImplementations(t *testing.T) {
-	goSeen := false
-	cppSeen := false
-	goS6seen := false
-
-	for _, config := range experimental.GetDatabaseConfigurations() {
-		if strings.HasPrefix(string(config.Variant), "go") {
-			goSeen = true
-			if config.Schema == 6 {
-				goS6seen = true
-			}
-		}
-		if strings.HasPrefix(string(config.Variant), "cpp") {
-			cppSeen = true
-		}
-
-	}
-	if !goSeen {
-		t.Errorf("missing Go based implementations")
-	}
-	if !cppSeen {
-		t.Errorf("missing C++ based implementations")
-	}
-	if !goS6seen {
-		t.Errorf("missing Go based Verkle Trie (schema 6) implementation")
-	}
-}
 
 func TestConfigurations_ConfigurationsAreRegisteredGlobally(t *testing.T) {
 	registeredConfigs := carmen.GetAllConfigurations()

--- a/go/state/externalstate/cpp_connector.go
+++ b/go/state/externalstate/cpp_connector.go
@@ -23,6 +23,7 @@ package externalstate
 */
 import "C"
 import (
+	"maps"
 	"unsafe"
 
 	"github.com/0xsoniclabs/carmen/go/database/flat"
@@ -122,7 +123,7 @@ func newCppLevelDbBasedState(params state.Parameters) (state.State, error) {
 	return newState("ldb", params, cppBindings{})
 }
 
-func init() {
+func getCppConfigurations() map[state.Configuration]state.StateFactory {
 	factories := map[state.Configuration]state.StateFactory{}
 
 	// Add all configuration options supported by the C++ implementation.
@@ -152,13 +153,19 @@ func init() {
 		}
 	}
 
-	// Register all experimental configurations.
+	flatFactories := map[state.Configuration]state.StateFactory{}
 	for config, factory := range factories {
-		state.RegisterStateFactory(config, factory)
-
-		// Also register flat database variants.
-		config := config
 		config.Variant += "-flat"
-		state.RegisterStateFactory(config, flat.WrapFactory(factory))
+		flatFactories[config] = flat.WrapFactory(factory)
+	}
+	maps.Copy(factories, flatFactories)
+
+	return factories
+}
+
+func init() {
+	// Register all C++ configurations.
+	for config, factory := range getCppConfigurations() {
+		state.RegisterStateFactory(config, factory)
 	}
 }

--- a/go/state/externalstate/cpp_connector_test.go
+++ b/go/state/externalstate/cpp_connector_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+//go:build carmen_cpp
+
+package externalstate
+
+import (
+	"testing"
+
+	"github.com/0xsoniclabs/carmen/go/state"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigurations_ContainsCppImplementations(t *testing.T) {
+	require := require.New(t)
+
+	allConfigs := state.GetAllRegisteredStateFactories()
+	for config := range getCppConfigurations() {
+		require.Contains(allConfigs, config)
+	}
+}

--- a/go/state/externalstate/rust_connector.go
+++ b/go/state/externalstate/rust_connector.go
@@ -23,6 +23,7 @@ package externalstate
 */
 import "C"
 import (
+	"maps"
 	"unsafe"
 
 	"github.com/0xsoniclabs/carmen/go/database/flat"
@@ -122,7 +123,7 @@ func newRustFileBasedState(params state.Parameters) (state.State, error) {
 	return newState("file", params, rustBindings{})
 }
 
-func init() {
+func getRustConfigurations() map[state.Configuration]state.StateFactory {
 	factories := map[state.Configuration]state.StateFactory{}
 
 	// Add all configuration options supported by the Rust implementation.
@@ -150,13 +151,19 @@ func init() {
 		Archive: "file",
 	}] = newRustFileBasedState
 
-	// Register all experimental configurations.
+	flatFactories := map[state.Configuration]state.StateFactory{}
 	for config, factory := range factories {
-		state.RegisterStateFactory(config, factory)
-
-		// Also register flat database variants.
-		config := config
 		config.Variant += "-flat"
-		state.RegisterStateFactory(config, flat.WrapFactory(factory))
+		flatFactories[config] = flat.WrapFactory(factory)
+	}
+	maps.Copy(factories, flatFactories)
+
+	return factories
+}
+
+func init() {
+	// Register all Rust configurations.
+	for config, factory := range getRustConfigurations() {
+		state.RegisterStateFactory(config, factory)
 	}
 }

--- a/go/state/externalstate/rust_connector_test.go
+++ b/go/state/externalstate/rust_connector_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+//go:build carmen_rust
+
+package externalstate
+
+import (
+	"testing"
+
+	"github.com/0xsoniclabs/carmen/go/state"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigurations_ContainsRustImplementations(t *testing.T) {
+	require := require.New(t)
+
+	allConfigs := state.GetAllRegisteredStateFactories()
+	for config := range getRustConfigurations() {
+		require.Contains(allConfigs, config)
+	}
+}


### PR DESCRIPTION
After the splitting of the External state, `TestConfigurations_ContainGoAndCppImplementations` was failing as it assumed that the external state implementations were automatically included if the external state package was added to the import list. However, I realized that there was no test to check if providing the build flags for c++ or rust actually included the configuration.

For such reasons, this PR substitutes the failing test with two tests, one for each external state implementation, checking if the external implementation configurations are added to the global configuration list when the build tags are provided