### PR TITLE
Use environment variable instead of flag for nightly tests

### DIFF
--- a/go/tests/nightly/nighly_configuration_test.go
+++ b/go/tests/nightly/nighly_configuration_test.go
@@ -26,7 +26,7 @@ func Test_IsNightlyIsEnabledWhenFlagIsProvided(t *testing.T) {
 
 func Test_IsNightly(t *testing.T) {
 	require := require.New(t)
-	stdout := execSubProcessTest(t, "Test_IsNightlyIsEnabledWhenFlagIsProvided", "-nightly=true")
+	stdout := execSubProcessTest(t, "Test_IsNightlyIsEnabledWhenFlagIsProvided", "CARMEN_NIGHTLY=true")
 	// Use contains as test output includes PASS and statement coverage info
 	require.Contains(stdout.String(), "Nightly flag is true")
 	stdout = execSubProcessTest(t, "Test_IsNightlyIsEnabledWhenFlagIsProvided", "")
@@ -34,13 +34,17 @@ func Test_IsNightly(t *testing.T) {
 }
 
 // execSubProcessTest executes the test with the given name in a subprocess with the provided flag and returns the stdout buffer.
-func execSubProcessTest(t *testing.T, execTestName string, flag string) bytes.Buffer {
+func execSubProcessTest(t *testing.T, execTestName string, envVar string) bytes.Buffer {
 	path, err := os.Executable()
 	if err != nil {
 		t.Fatalf("failed to resolve path to test binary: %v", err)
 	}
 
-	cmd := exec.Command(path, "-test.run", execTestName, flag)
+	cmd := exec.Command(path, "-test.run", execTestName)
+	cmd.Env = os.Environ()
+	if envVar != "" {
+		cmd.Env = append(cmd.Env, envVar)
+	}
 	errBuf := new(bytes.Buffer)
 	cmd.Stderr = errBuf
 	stdBuf := new(bytes.Buffer)

--- a/go/tests/nightly/nightly_configuration.go
+++ b/go/tests/nightly/nightly_configuration.go
@@ -10,11 +10,9 @@
 
 package nightly
 
-import "flag"
-
-var nightly = flag.Bool("nightly", false, "Enable nightly tests")
+import "os"
 
 // IsNightly returns whether the nightly tests should be run.
 func IsNightly() bool {
-	return *nightly
+	return os.Getenv("CARMEN_NIGHTLY") == "true"
 }


### PR DESCRIPTION
The current flag setup for nightly tests doesn't work, as flags are local to packages and go treats those as separate binaries, and passing a non-recognized flag. Go doesn't have a built-in way to skip unknown flags in tests.
This mean each package should import the nightly config package manually even if they don't use it, and manually run the tests to check if one forgot to add the import to a package.

For those reasons, I switched the implementation to use a simpler `CARMEN_NIGHTLY` environment variable.