### PR TITLE
Show that `CreateAccount` and `Suicide` do not alter `State` in some conditions

### DIFF
--- a/go/state/state_db_and_state_test.go
+++ b/go/state/state_db_and_state_test.go
@@ -914,12 +914,12 @@ func executeOpOnClearStateDB(t *testing.T, config namedStateConfig, op func(stat
 }
 
 func TestStateDB_AccountsAreCreatedImplicitlyWhenSettingState(t *testing.T) {
-	funcList := map[string]func(s state.StateDB){
-		"SetState": func(s state.StateDB) {
-			s.SetState(address1, key1, val1)
-		},
+	ops := map[string]func(s state.StateDB){
 		"AddBalance": func(s state.StateDB) {
 			s.AddBalance(address1, amount.New(10))
+		},
+		"SetState": func(s state.StateDB) {
+			s.SetState(address1, key1, val1)
 		},
 		"SetNonce": func(s state.StateDB) {
 			s.SetNonce(address1, 10)
@@ -933,7 +933,7 @@ func TestStateDB_AccountsAreCreatedImplicitlyWhenSettingState(t *testing.T) {
 		if config.config.Schema < 4 {
 			continue
 		}
-		for name, fn := range funcList {
+		for name, fn := range ops {
 			t.Run(config.name()+"_"+name, func(t *testing.T) {
 				t.Parallel()
 				require := require.New(t)
@@ -948,6 +948,26 @@ func TestStateDB_AccountsAreCreatedImplicitlyWhenSettingState(t *testing.T) {
 
 			})
 		}
+	}
+}
+
+func TestStateDB_DeleteAccountCreatedInSameTransactionDoesNotChangeState(t *testing.T) {
+	for _, config := range initStates() {
+		if config.config.Schema < 4 {
+			continue
+		}
+		t.Run(config.name(), func(t *testing.T) {
+			t.Parallel()
+			require := require.New(t)
+			with := executeOpOnClearStateDB(t, config, func(s state.StateDB) {
+				s.CreateAccount(address1)
+				s.Suicide(address1)
+			})
+			without := executeOpOnClearStateDB(t, config, func(s state.StateDB) {
+				// Do nothing
+			})
+			require.Equal(without, with)
+		})
 	}
 }
 

--- a/go/state/state_db_and_state_test.go
+++ b/go/state/state_db_and_state_test.go
@@ -893,8 +893,8 @@ func TestStateDB_ArchiveIsSynchronizedWithLiveDB(t *testing.T) {
 	}
 }
 
-// executeOpOnClearStateDB executes the given operation on a clear stateDB in single transaction/block and returns the state root hash.
-func executeOpOnClearStateDB(t *testing.T, config namedStateConfig, op func(state.StateDB)) common.Hash {
+// executeOpOnClearStateDB executes the given operation on a clean stateDB in single transaction/block and returns the state root hash.
+func executeOpOnCleanStateDB(t *testing.T, config namedStateConfig, op func(state.StateDB)) common.Hash {
 	t.Helper()
 	require := require.New(t)
 	dir := t.TempDir()
@@ -918,6 +918,10 @@ func TestStateDB_AccountsAreCreatedImplicitlyWhenSettingState(t *testing.T) {
 		"AddBalance": func(s state.StateDB) {
 			s.AddBalance(address1, amount.New(10))
 		},
+		"SubBalance": func(s state.StateDB) {
+			s.AddBalance(address1, amount.New(20)) // Add some balance first to avoid negative balance error
+			s.SubBalance(address1, amount.New(10))
+		},
 		"SetState": func(s state.StateDB) {
 			s.SetState(address1, key1, val1)
 		},
@@ -937,11 +941,11 @@ func TestStateDB_AccountsAreCreatedImplicitlyWhenSettingState(t *testing.T) {
 			t.Run(config.name()+"_"+name, func(t *testing.T) {
 				t.Parallel()
 				require := require.New(t)
-				with := executeOpOnClearStateDB(t, config, func(s state.StateDB) {
+				with := executeOpOnCleanStateDB(t, config, func(s state.StateDB) {
 					s.CreateAccount(address1)
 					fn(s)
 				})
-				without := executeOpOnClearStateDB(t, config, func(s state.StateDB) {
+				without := executeOpOnCleanStateDB(t, config, func(s state.StateDB) {
 					fn(s)
 				})
 				require.Equal(without, with)
@@ -959,11 +963,11 @@ func TestStateDB_DeleteAccountCreatedInSameTransactionDoesNotChangeState(t *test
 		t.Run(config.name(), func(t *testing.T) {
 			t.Parallel()
 			require := require.New(t)
-			with := executeOpOnClearStateDB(t, config, func(s state.StateDB) {
+			with := executeOpOnCleanStateDB(t, config, func(s state.StateDB) {
 				s.CreateAccount(address1)
 				s.Suicide(address1)
 			})
-			without := executeOpOnClearStateDB(t, config, func(s state.StateDB) {
+			without := executeOpOnCleanStateDB(t, config, func(s state.StateDB) {
 				// Do nothing
 			})
 			require.Equal(without, with)

--- a/go/state/state_db_and_state_test.go
+++ b/go/state/state_db_and_state_test.go
@@ -893,6 +893,64 @@ func TestStateDB_ArchiveIsSynchronizedWithLiveDB(t *testing.T) {
 	}
 }
 
+// executeOpOnClearStateDB executes the given operation on a clear stateDB in single transaction/block and returns the state root hash.
+func executeOpOnClearStateDB(t *testing.T, config namedStateConfig, op func(state.StateDB)) common.Hash {
+	t.Helper()
+	require := require.New(t)
+	dir := t.TempDir()
+	s, err := config.createState(dir)
+	require.NoError(err)
+	defer func() {
+		require.NoError(s.Close())
+	}()
+
+	db := state.CreateStateDBUsing(s)
+	db.BeginBlock()
+	db.BeginTransaction()
+	op(db)
+	db.EndTransaction()
+	db.EndBlock(0)
+	return db.GetHash()
+}
+
+func TestStateDB_AccountsAreCreatedImplicitlyWhenSettingState(t *testing.T) {
+	funcList := map[string]func(s state.StateDB){
+		"SetState": func(s state.StateDB) {
+			s.SetState(address1, key1, val1)
+		},
+		"AddBalance": func(s state.StateDB) {
+			s.AddBalance(address1, amount.New(10))
+		},
+		"SetNonce": func(s state.StateDB) {
+			s.SetNonce(address1, 10)
+		},
+		"SetCode": func(s state.StateDB) {
+			s.SetCode(address1, []byte{0xAC})
+		},
+	}
+
+	for _, config := range initStates() {
+		if config.config.Schema < 4 {
+			continue
+		}
+		for name, fn := range funcList {
+			t.Run(config.name()+"_"+name, func(t *testing.T) {
+				t.Parallel()
+				require := require.New(t)
+				with := executeOpOnClearStateDB(t, config, func(s state.StateDB) {
+					s.CreateAccount(address1)
+					fn(s)
+				})
+				without := executeOpOnClearStateDB(t, config, func(s state.StateDB) {
+					fn(s)
+				})
+				require.Equal(without, with)
+
+			})
+		}
+	}
+}
+
 func toVal(key uint64) common.Value {
 	keyBytes := make([]byte, 32)
 	binary.BigEndian.PutUint64(keyBytes, key)

--- a/go/state/state_db_and_state_test.go
+++ b/go/state/state_db_and_state_test.go
@@ -963,14 +963,19 @@ func TestStateDB_DeleteAccountCreatedInSameTransactionDoesNotChangeState(t *test
 		t.Run(config.name(), func(t *testing.T) {
 			t.Parallel()
 			require := require.New(t)
-			with := executeOpOnCleanStateDB(t, config, func(s state.StateDB) {
+			explicitCreation := executeOpOnCleanStateDB(t, config, func(s state.StateDB) {
 				s.CreateAccount(address1)
 				s.Suicide(address1)
 			})
-			without := executeOpOnCleanStateDB(t, config, func(s state.StateDB) {
+			implicitCreation := executeOpOnCleanStateDB(t, config, func(s state.StateDB) {
+				s.SetNonce(address1, 1)
+				s.Suicide(address1)
+			})
+			emptyState := executeOpOnCleanStateDB(t, config, func(s state.StateDB) {
 				// Do nothing
 			})
-			require.Equal(without, with)
+			require.Equal(explicitCreation, implicitCreation)
+			require.Equal(explicitCreation, emptyState)
 		})
 	}
 }


### PR DESCRIPTION
This PR adds to tests for `CreateAccount` and `Suicide` to show how, under the current rules, they don't have any impact on the `State`.

- `TestStateDB_AccountsAreCreatedImplicitlyWhenSettingState` shows that accounts are always created implicitly, and the call to `CreateAccount` is superfluous
- `TestStateDB_DeleteAccountCreatedInSameTransactionDoesNotReachState` shows that deleting an account created in the current transaction is a no-op on the `State`. This is the only way to call `Suicide`.

This, in addition to the comments in https://github.com/0xsoniclabs/sonic-admin/issues/762, is to show that `CreateAccount` and `DeleteAccount` fields in Updates can be safely removed. 
Following PRs to remove those functions with the related tests will follow