### PR TITLE
Update go to 1.26.0

### DIFF
--- a/CI/Dockerfile.jenkins
+++ b/CI/Dockerfile.jenkins
@@ -1,4 +1,4 @@
-FROM golang:1.25
+FROM golang:1.26
 
 ENV RUST_VERSION=1.89.0
 

--- a/go/go.mod
+++ b/go/go.mod
@@ -10,7 +10,7 @@
 
 module github.com/0xsoniclabs/carmen/go
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/0xsoniclabs/tracy v0.0.0-20251027125423-00a5ab7968fb


### PR DESCRIPTION
This updates the minimum go version to 1.26, as in Sonic, Bertha, Aida, and Norma