### PR TITLE
Remove `CreateAccount` from `State` implementations

### DIFF
--- a/go/backend/archive/archive_test.go
+++ b/go/backend/archive/archive_test.go
@@ -72,7 +72,6 @@ func TestAddGet(t *testing.T) {
 			defer a.Close()
 
 			if err := a.Add(1, common.Update{
-				CreatedAccounts: []common.Address{addr1},
 				Balances: []common.BalanceUpdate{
 					{Account: addr1, Balance: balance1},
 				},
@@ -162,7 +161,6 @@ func TestAccountDeleteCreate(t *testing.T) {
 			defer a.Close()
 
 			if err := a.Add(1, common.Update{
-				CreatedAccounts: []common.Address{addr1},
 				Balances: []common.BalanceUpdate{
 					{Account: addr1, Balance: balance1},
 				},
@@ -186,14 +184,16 @@ func TestAccountDeleteCreate(t *testing.T) {
 			}
 
 			if err := a.Add(9, common.Update{
-				CreatedAccounts: []common.Address{addr1},
+				Balances: []common.BalanceUpdate{
+					{Account: addr1, Balance: balance1},
+				},
 			}, nil); err != nil {
 				t.Fatalf("failed to add block 9; %s", err)
 			}
 
 			if err := a.Add(11, common.Update{
 				DeletedAccounts: []common.Address{addr1},
-				CreatedAccounts: []common.Address{addr1},
+				Balances:        []common.BalanceUpdate{{Account: addr1, Balance: balance1}},
 			}, nil); err != nil {
 				t.Fatalf("failed to add block 11; %s", err)
 			}
@@ -247,7 +247,6 @@ func TestArchive_CreateWitnessProof(t *testing.T) {
 			}()
 
 			if err := a.Add(1, common.Update{
-				CreatedAccounts: []common.Address{{1}},
 				Balances: []common.BalanceUpdate{
 					{Account: common.Address{1}, Balance: amount.New(12)},
 				},
@@ -311,7 +310,6 @@ func TestArchive_HasEmptyStorage(t *testing.T) {
 			const blocks = 10
 			for i := uint64(1); i <= blocks; i++ {
 				if err := a.Add(i, common.Update{
-					CreatedAccounts: []common.Address{{1, 2}},
 					Balances: []common.BalanceUpdate{
 						{Account: common.Address{1}, Balance: amount.New(12)},
 						{Account: common.Address{2}, Balance: amount.New(12)},
@@ -350,7 +348,7 @@ func TestAccountStatusOnly(t *testing.T) {
 			defer a.Close()
 
 			if err := a.Add(1, common.Update{
-				CreatedAccounts: []common.Address{addr1},
+				Balances: []common.BalanceUpdate{{Account: addr1, Balance: balance1}},
 			}, nil); err != nil {
 				t.Fatalf("failed to add block 1; %s", err)
 			}
@@ -375,7 +373,6 @@ func TestBalanceOnly(t *testing.T) {
 			defer a.Close()
 
 			if err := a.Add(1, common.Update{
-				CreatedAccounts: []common.Address{addr1},
 				Balances: []common.BalanceUpdate{
 					{Account: addr1, Balance: balance1},
 				},
@@ -413,7 +410,9 @@ func TestStorageOnly(t *testing.T) {
 			defer a.Close()
 
 			if err := a.Add(1, common.Update{
-				CreatedAccounts: []common.Address{addr1},
+				Balances: []common.BalanceUpdate{
+					{Account: addr1, Balance: balance1},
+				},
 				Slots: []common.SlotUpdate{
 					{Account: addr1, Key: common.Key{0x37}, Value: common.Value{0x12}},
 				},
@@ -422,6 +421,9 @@ func TestStorageOnly(t *testing.T) {
 			}
 
 			if err := a.Add(2, common.Update{
+				Balances: []common.BalanceUpdate{
+					{Account: addr1, Balance: balance1},
+				},
 				Slots: []common.SlotUpdate{
 					{Account: addr1, Key: common.Key{0x37}, Value: common.Value{0x34}},
 				},
@@ -451,7 +453,6 @@ func TestPreventingBlockOverrides(t *testing.T) {
 			}
 
 			if err := a.Add(1, common.Update{
-				CreatedAccounts: []common.Address{addr1},
 				Slots: []common.SlotUpdate{
 					{Account: addr1, Key: common.Key{0x37}, Value: common.Value{0x12}},
 				},
@@ -474,13 +475,14 @@ func TestPreventingBlockOutOfOrder(t *testing.T) {
 			defer a.Close()
 
 			if err := a.Add(2, common.Update{
-				CreatedAccounts: []common.Address{addr1},
+				Balances: []common.BalanceUpdate{
+					{Account: addr1, Balance: balance1},
+				},
 			}, nil); err != nil {
 				t.Fatalf("failed to add block 2; %s", err)
 			}
 
 			if err := a.Add(1, common.Update{
-				CreatedAccounts: []common.Address{addr1},
 				Slots: []common.SlotUpdate{
 					{Account: addr1, Key: common.Key{0x37}, Value: common.Value{0x12}},
 				},
@@ -510,7 +512,7 @@ func TestEmptyBlockHash(t *testing.T) {
 			}
 
 			if err := a.Add(2, common.Update{
-				CreatedAccounts: []common.Address{addr1},
+				Balances: []common.BalanceUpdate{{Account: addr1, Balance: balance1}},
 			}, nil); err != nil {
 				t.Fatalf("failed to add block 2; %v", err)
 			}
@@ -549,7 +551,6 @@ func TestZeroBlock(t *testing.T) {
 			defer a.Close()
 
 			if err := a.Add(0, common.Update{
-				CreatedAccounts: []common.Address{addr1},
 				Balances: []common.BalanceUpdate{
 					{Account: addr1, Balance: balance1},
 				},
@@ -592,7 +593,7 @@ func TestTwinProtection(t *testing.T) {
 			}
 
 			if err := a.Add(0, common.Update{
-				CreatedAccounts: []common.Address{addr1},
+				Balances: []common.BalanceUpdate{{Account: addr1, Balance: balance1}},
 			}, nil); err == nil {
 				t.Errorf("second adding of block 0 should have failed but it succeed")
 			}
@@ -637,7 +638,7 @@ func TestBlockHeight(t *testing.T) {
 			}
 
 			// Adding block 5 should raise the block height accordingly.
-			if err := a.Add(5, common.Update{CreatedAccounts: []common.Address{addr1}}, nil); err != nil {
+			if err := a.Add(5, common.Update{Balances: []common.BalanceUpdate{{Account: addr1, Balance: balance1}}}, nil); err != nil {
 				t.Fatalf("failed to add block 5; %s", err)
 			}
 

--- a/go/backend/archive/benchmark_test.go
+++ b/go/backend/archive/benchmark_test.go
@@ -33,7 +33,6 @@ func BenchmarkAdding(b *testing.B) {
 		// initialize
 		var update common.Update
 		for i := byte(0); i < byte(bmAddressToCreate); i++ {
-			update.AppendCreateAccount(common.Address{i})
 			update.AppendBalanceUpdate(common.Address{i}, amount.New(uint64(i)))
 		}
 		if err := a.Add(1, update, nil); err != nil {

--- a/go/common/update.go
+++ b/go/common/update.go
@@ -23,7 +23,7 @@ import (
 //go:generate mockgen -source update.go -destination update_mocks.go -package common
 
 // Update summarizes the effective changes to the state DB at the end of a block.
-// It combines changes to the account state (created or deleted), balances, nonces
+// It combines changes to the account state (deleted), balances, nonces
 // codes, and slot updates.
 //
 // An example use of an update would look like this:
@@ -32,8 +32,8 @@ import (
 //	update := Update{}
 //	// Fill in changes.
 //	// Note: for each type of change, updates must be in order and unique.
-//	update.AppendCreateAccount(..)
-//	update.AppendCreateAccount(..)
+//	update.AppendBalanceUpdate(..)
+//	update.AppendBalanceUpdate(..)
 //	...
 //	// Optionally, check that the provided data is valid (sorted and unique).
 //	err := update.Check()
@@ -41,7 +41,6 @@ import (
 // Valid instances can then be forwarded to the State as a block update.
 type Update struct {
 	DeletedAccounts []Address
-	CreatedAccounts []Address
 	Balances        []BalanceUpdate
 	Nonces          []NonceUpdate
 	Codes           []CodeUpdate
@@ -51,7 +50,6 @@ type Update struct {
 // IsEmpty is true if there is no change covered by this update.
 func (u *Update) IsEmpty() bool {
 	return len(u.DeletedAccounts) == 0 &&
-		len(u.CreatedAccounts) == 0 &&
 		len(u.Balances) == 0 &&
 		len(u.Nonces) == 0 &&
 		len(u.Codes) == 0 &&
@@ -69,17 +67,6 @@ func (u *Update) AppendDeleteAccount(addr Address) {
 // AppendDeleteAccounts is the same as AppendDeleteAccount, but for a slice.
 func (u *Update) AppendDeleteAccounts(addr []Address) {
 	u.DeletedAccounts = append(u.DeletedAccounts, addr...)
-}
-
-// AppendCreateAccount registers a new account to be created in this block.
-// This takes affect after deleting the accounts listed in this update.
-func (u *Update) AppendCreateAccount(addr Address) {
-	u.AppendCreateAccounts([]Address{addr})
-}
-
-// AppendCreateAccounts is the same as AppendCreateAccount, but for a slice.
-func (u *Update) AppendCreateAccounts(addr []Address) {
-	u.CreatedAccounts = append(u.CreatedAccounts, addr...)
 }
 
 // AppendBalanceUpdate registers a balance update to be conducted.
@@ -106,7 +93,6 @@ func (u *Update) AppendSlotUpdate(addr Address, key Key, value Value) {
 func (u *Update) Normalize() error {
 
 	u.DeletedAccounts = sortUnique(u.DeletedAccounts, accountLess, accountEqual)
-	u.CreatedAccounts = sortUnique(u.CreatedAccounts, accountLess, accountEqual)
 	u.Balances = sortUnique(u.Balances, balanceLess, balanceEqual)
 	u.Codes = sortUnique(u.Codes, codeLess, codeEqual)
 	u.Nonces = sortUnique(u.Nonces, nonceLess, nonceEqual)
@@ -129,17 +115,12 @@ func (u *Update) Normalize() error {
 }
 
 // ApplyTo applies this update to the provided target in a standardized
-// order: delete accounts, create accounts, set balances, set nonces,
+// order: delete accounts, set balances, set nonces,
 // set codes, and set storage values. It is intended to be utilized by
 // state implementations to simplify the processing of updates.
 func (u *Update) ApplyTo(s UpdateTarget) error {
 	for _, addr := range u.DeletedAccounts {
 		if err := s.DeleteAccount(addr); err != nil {
-			return err
-		}
-	}
-	for _, addr := range u.CreatedAccounts {
-		if err := s.CreateAccount(addr); err != nil {
 			return err
 		}
 	}
@@ -178,12 +159,6 @@ func (u *Update) String() string {
 			fmt.Fprintf(&builder, "\t\t%v\n", account)
 		}
 	}
-	if len(u.CreatedAccounts) > 0 {
-		builder.WriteString("\tCreated Accounts:\n")
-		for _, account := range u.CreatedAccounts {
-			fmt.Fprintf(&builder, "\t\t%v\n", account)
-		}
-	}
 	if len(u.Balances) > 0 {
 		builder.WriteString("\tBalances:\n")
 		for _, change := range u.Balances {
@@ -218,9 +193,6 @@ func (u *Update) String() string {
 // and to be utilized by implementations to avoid the need of duplicating
 // the implementation of LiveDB's Apply function.
 type UpdateTarget interface {
-	// CreateAccount creates a new account with the given address.
-	CreateAccount(address Address) error
-
 	// DeleteAccount deletes the account with the given address.
 	DeleteAccount(address Address) error
 
@@ -240,7 +212,7 @@ type UpdateTarget interface {
 const updateEncodingVersion byte = 0
 
 func UpdateFromBytes(data []byte) (Update, error) {
-	if len(data) < 1+6*4 {
+	if len(data) < 1+5*4 {
 		return Update{}, fmt.Errorf("invalid encoding, too few bytes")
 	}
 	if data[0] != updateEncodingVersion {
@@ -249,13 +221,12 @@ func UpdateFromBytes(data []byte) (Update, error) {
 
 	data = data[1:]
 	deletedAccountSize := readUint32(data[0:])
-	createdAccountSize := readUint32(data[4:])
-	balancesSize := readUint32(data[8:])
-	codesSize := readUint32(data[12:])
-	noncesSize := readUint32(data[16:])
-	slotsSize := readUint32(data[20:])
+	balancesSize := readUint32(data[4:])
+	codesSize := readUint32(data[8:])
+	noncesSize := readUint32(data[12:])
+	slotsSize := readUint32(data[16:])
 
-	data = data[24:]
+	data = data[20:]
 
 	res := Update{}
 
@@ -267,18 +238,6 @@ func UpdateFromBytes(data []byte) (Update, error) {
 		res.DeletedAccounts = make([]Address, deletedAccountSize)
 		for i := 0; i < int(deletedAccountSize); i++ {
 			copy(res.DeletedAccounts[i][:], data[:])
-			data = data[len(Address{}):]
-		}
-	}
-
-	// Read list of created accounts
-	if createdAccountSize > 0 {
-		if len(data) < int(createdAccountSize)*len(Address{}) {
-			return res, fmt.Errorf("invalid encoding, truncated address list")
-		}
-		res.CreatedAccounts = make([]Address, createdAccountSize)
-		for i := 0; i < int(createdAccountSize); i++ {
-			copy(res.CreatedAccounts[i][:], data[:])
 			data = data[len(Address{}):]
 		}
 	}
@@ -352,9 +311,8 @@ func UpdateFromBytes(data []byte) (Update, error) {
 
 func (u *Update) ToBytes() []byte {
 	const addrLength = len(Address{})
-	size := 1 + 6*4 // version + sizes
+	size := 1 + 5*4 // version + sizes
 	size += len(u.DeletedAccounts) * addrLength
-	size += len(u.CreatedAccounts) * addrLength
 	size += len(u.Balances) * (addrLength + amount.BytesLength)
 	size += len(u.Nonces) * (addrLength + len(Nonce{}))
 	size += len(u.Slots) * (addrLength + len(Key{}) + len(Value{}))
@@ -366,16 +324,12 @@ func (u *Update) ToBytes() []byte {
 
 	res = append(res, updateEncodingVersion)
 	res = appendUint32(res, uint32(len(u.DeletedAccounts)))
-	res = appendUint32(res, uint32(len(u.CreatedAccounts)))
 	res = appendUint32(res, uint32(len(u.Balances)))
 	res = appendUint32(res, uint32(len(u.Codes)))
 	res = appendUint32(res, uint32(len(u.Nonces)))
 	res = appendUint32(res, uint32(len(u.Slots)))
 
 	for _, addr := range u.DeletedAccounts {
-		res = append(res, addr[:]...)
-	}
-	for _, addr := range u.CreatedAccounts {
 		res = append(res, addr[:]...)
 	}
 	for _, cur := range u.Balances {
@@ -419,9 +373,6 @@ func appendUint32(data []byte, value uint32) []byte {
 
 // Check verifies that all updates are unique and in order.
 func (u *Update) Check() error {
-	if !isSortedAndUnique(u.CreatedAccounts, accountLess) {
-		return fmt.Errorf("created accounts are not in order or unique")
-	}
 	if !isSortedAndUnique(u.DeletedAccounts, accountLess) {
 		return fmt.Errorf("deleted accounts are not in order or unique")
 	}
@@ -442,11 +393,23 @@ func (u *Update) Check() error {
 		return fmt.Errorf("storage updates are not in order or unique")
 	}
 
+	// Find all created accounts by looking at all balance, nonce, and code updates
+	createdAccounts := make([]Address, 0, len(u.Balances)+len(u.Nonces)+len(u.Codes))
+	for _, change := range u.Balances {
+		createdAccounts = append(createdAccounts, change.Account)
+	}
+	for _, change := range u.Nonces {
+		createdAccounts = insertOrdered(createdAccounts, change.Account)
+	}
+	for _, change := range u.Codes {
+		createdAccounts = insertOrdered(createdAccounts, change.Account)
+	}
+
 	// Make sure that there is no account created and deleted.
-	for i, j := 0, 0; i < len(u.CreatedAccounts) && j < len(u.DeletedAccounts); {
-		cmp := u.CreatedAccounts[i].Compare(&u.DeletedAccounts[j])
+	for i, j := 0, 0; i < len(createdAccounts) && j < len(u.DeletedAccounts); {
+		cmp := createdAccounts[i].Compare(&u.DeletedAccounts[j])
 		if cmp == 0 {
-			return fmt.Errorf("unable to create and delete same address in update: %v", u.CreatedAccounts[i])
+			return fmt.Errorf("unable to create and delete same address in update: %v", createdAccounts[i])
 		}
 		if cmp < 0 {
 			i++
@@ -456,6 +419,19 @@ func (u *Update) Check() error {
 	}
 
 	return nil
+}
+
+// insertOrdered inserts the given address into the provided list of addresses, which is assumed to be ordered and unique.
+// If addr is already in the list, the original list is returned. Otherwise, a new list with the address inserted in the correct order is returned.
+func insertOrdered(list []Address, addr Address) []Address {
+	i := sort.Search(len(list), func(i int) bool { return list[i].Compare(&addr) >= 0 })
+	if i < len(list) && list[i] == addr {
+		return list
+	}
+	list = append(list, Address{})
+	copy(list[i+1:], list[i:])
+	list[i] = addr
+	return list
 }
 
 func accountLess(a, b *Address) bool {

--- a/go/common/update.go
+++ b/go/common/update.go
@@ -393,29 +393,8 @@ func (u *Update) Check() error {
 		return fmt.Errorf("storage updates are not in order or unique")
 	}
 
-	// Find all created accounts by looking at all balance, nonce, and code updates
-	createdAccounts := make([]Address, 0, len(u.Balances)+len(u.Nonces)+len(u.Codes))
-	for _, change := range u.Balances {
-		createdAccounts = append(createdAccounts, change.Account)
-	}
-	for _, change := range u.Nonces {
-		createdAccounts = insertOrdered(createdAccounts, change.Account)
-	}
-	for _, change := range u.Codes {
-		createdAccounts = insertOrdered(createdAccounts, change.Account)
-	}
-
-	// Make sure that there is no account created and deleted.
-	for i, j := 0, 0; i < len(createdAccounts) && j < len(u.DeletedAccounts); {
-		cmp := createdAccounts[i].Compare(&u.DeletedAccounts[j])
-		if cmp == 0 {
-			return fmt.Errorf("unable to create and delete same address in update: %v", createdAccounts[i])
-		}
-		if cmp < 0 {
-			i++
-		} else {
-			j++
-		}
+	if len(u.DeletedAccounts) > 0 {
+		return fmt.Errorf("deleted accounts should be empty")
 	}
 
 	return nil

--- a/go/common/update_mocks.go
+++ b/go/common/update_mocks.go
@@ -40,20 +40,6 @@ func (m *MockUpdateTarget) EXPECT() *MockUpdateTargetMockRecorder {
 	return m.recorder
 }
 
-// CreateAccount mocks base method.
-func (m *MockUpdateTarget) CreateAccount(address Address) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAccount", address)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CreateAccount indicates an expected call of CreateAccount.
-func (mr *MockUpdateTargetMockRecorder) CreateAccount(address any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccount", reflect.TypeOf((*MockUpdateTarget)(nil).CreateAccount), address)
-}
-
 // DeleteAccount mocks base method.
 func (m *MockUpdateTarget) DeleteAccount(address Address) error {
 	m.ctrl.T.Helper()

--- a/go/common/update_test.go
+++ b/go/common/update_test.go
@@ -510,40 +510,35 @@ func TestUpdate_Print(t *testing.T) {
 }
 
 func Test_insertOrdered(t *testing.T) {
-	cases := []struct {
-		name     string
+	cases := map[string]struct {
 		list     []Address
 		addr     Address
 		expected []Address
 	}{
-		{
-			name:     "insert in the middle",
+		"insert in the middle": {
 			list:     []Address{{0x01}, {0x03}, {0x05}},
 			addr:     Address{0x02},
 			expected: []Address{{0x01}, {0x02}, {0x03}, {0x05}},
 		},
-		{
-			name:     "insert existing address",
+		"insert existing address": {
 			list:     []Address{{0x01}, {0x03}, {0x05}},
 			addr:     Address{0x03},
 			expected: []Address{{0x01}, {0x03}, {0x05}},
 		},
-		{
-			name:     "insert smaller than all",
+		"insert smaller than all": {
 			list:     []Address{{0x01}, {0x03}, {0x05}},
 			addr:     Address{0x00},
 			expected: []Address{{0x00}, {0x01}, {0x03}, {0x05}},
 		},
-		{
-			name:     "insert larger than all",
+		"insert larger than all": {
 			list:     []Address{{0x01}, {0x03}, {0x05}},
 			addr:     Address{0x06},
 			expected: []Address{{0x01}, {0x03}, {0x05}, {0x06}},
 		},
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
 			updatedList := insertOrdered(tc.list, tc.addr)
 			if !reflect.DeepEqual(updatedList, tc.expected) {
 				t.Errorf("expected %v, got %v", tc.expected, updatedList)

--- a/go/common/update_test.go
+++ b/go/common/update_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/carmen/go/common/amount"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -250,12 +251,6 @@ var updateValueCase = []struct {
 	appendThird  func(u *Update)
 }{
 	{
-		"DeleteAccount",
-		func(u *Update) { u.AppendDeleteAccount(Address{0x01}) },
-		func(u *Update) { u.AppendDeleteAccount(Address{0x02}) },
-		func(u *Update) { u.AppendDeleteAccount(Address{0x03}) },
-	},
-	{
 		"UpdateBalance",
 		func(u *Update) { u.AppendBalanceUpdate(Address{0x01}, amount.New()) },
 		func(u *Update) { u.AppendBalanceUpdate(Address{0x02}, amount.New()) },
@@ -361,6 +356,12 @@ func TestUpdateEmptyUpdateCanBeSerializedAndDeserialized(t *testing.T) {
 	if !reflect.DeepEqual(update, restored) {
 		t.Errorf("restored update is not the same as original\noriginal: %+v\nrestored: %+v", update, restored)
 	}
+}
+
+func TestCheck_FailsIfDeletedAccountsAreNotEmpty(t *testing.T) {
+	update := Update{}
+	update.AppendDeleteAccount(Address{0x01})
+	require.Error(t, update.Check())
 }
 
 func getExampleUpdate() Update {

--- a/go/common/update_test.go
+++ b/go/common/update_test.go
@@ -323,28 +323,6 @@ func TestUpdateCreatingAndDeletingSameAccountIsInvalid(t *testing.T) {
 	}
 }
 
-func TestUpdateSingleAccountCreatedAndDeletedIsDetectedAlsoWhenPartOfAList(t *testing.T) {
-	update := Update{}
-	for i := 0; i < 10; i++ {
-		addr := Address{byte(i)}
-		if i%2 == 0 {
-			update.AppendBalanceUpdate(addr, amount.New(1))
-		} else {
-			update.AppendDeleteAccount(addr)
-		}
-	}
-
-	if err := update.Check(); err != nil {
-		t.Errorf("non-overlapping create and delete list should be fine, but got: %v", err)
-	}
-
-	update.AppendBalanceUpdate(Address{9}, amount.New(1))
-
-	if update.Check() == nil {
-		t.Errorf("creating and deleting the same account should fail")
-	}
-}
-
 func TestUpdateEmptyUpdateCanBeSerializedAndDeserialized(t *testing.T) {
 	update := Update{}
 

--- a/go/common/update_test.go
+++ b/go/common/update_test.go
@@ -510,35 +510,44 @@ func TestUpdate_Print(t *testing.T) {
 }
 
 func Test_insertOrdered(t *testing.T) {
-	list := []Address{{0x01}, {0x03}, {0x05}}
-	addr := Address{0x02}
-	updatedList := insertOrdered(list, addr)
-	expectedList := []Address{{0x01}, {0x02}, {0x03}, {0x05}}
-	if !reflect.DeepEqual(updatedList, expectedList) {
-		t.Errorf("expected %v, got %v", expectedList, updatedList)
+	cases := []struct {
+		name     string
+		list     []Address
+		addr     Address
+		expected []Address
+	}{
+		{
+			name:     "insert in the middle",
+			list:     []Address{{0x01}, {0x03}, {0x05}},
+			addr:     Address{0x02},
+			expected: []Address{{0x01}, {0x02}, {0x03}, {0x05}},
+		},
+		{
+			name:     "insert existing address",
+			list:     []Address{{0x01}, {0x03}, {0x05}},
+			addr:     Address{0x03},
+			expected: []Address{{0x01}, {0x03}, {0x05}},
+		},
+		{
+			name:     "insert smaller than all",
+			list:     []Address{{0x01}, {0x03}, {0x05}},
+			addr:     Address{0x00},
+			expected: []Address{{0x00}, {0x01}, {0x03}, {0x05}},
+		},
+		{
+			name:     "insert larger than all",
+			list:     []Address{{0x01}, {0x03}, {0x05}},
+			addr:     Address{0x06},
+			expected: []Address{{0x01}, {0x03}, {0x05}, {0x06}},
+		},
 	}
 
-	// Test inserting an existing address does not change the list
-	addr = Address{0x03}
-	updatedList = insertOrdered(list, addr)
-	expectedList = []Address{{0x01}, {0x03}, {0x05}}
-	if !reflect.DeepEqual(updatedList, expectedList) {
-		t.Errorf("expected %v, got %v", expectedList, updatedList)
-	}
-
-	// Test inserting an address smaller than all existing addresses
-	addr = Address{0x00}
-	updatedList = insertOrdered(list, addr)
-	expectedList = []Address{{0x00}, {0x01}, {0x03}, {0x05}}
-	if !reflect.DeepEqual(updatedList, expectedList) {
-		t.Errorf("expected %v, got %v", expectedList, updatedList)
-	}
-
-	// Test inserting an address larger than all existing addresses
-	addr = Address{0x06}
-	updatedList = insertOrdered(list, addr)
-	expectedList = []Address{{0x01}, {0x03}, {0x05}, {0x06}}
-	if !reflect.DeepEqual(updatedList, expectedList) {
-		t.Errorf("expected %v, got %v", expectedList, updatedList)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			updatedList := insertOrdered(tc.list, tc.addr)
+			if !reflect.DeepEqual(updatedList, tc.expected) {
+				t.Errorf("expected %v, got %v", tc.expected, updatedList)
+			}
+		})
 	}
 }

--- a/go/common/update_test.go
+++ b/go/common/update_test.go
@@ -11,7 +11,6 @@
 package common
 
 import (
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"reflect"
@@ -33,31 +32,6 @@ func TestUpdateEmptyUpdateCheckReportsNoErrors(t *testing.T) {
 	update := Update{}
 	if err := update.Check(); err != nil {
 		t.Errorf("Empty update should not report an error, but got: %v", err)
-	}
-}
-
-func TestUpdateCreatedAccountsAreSortedAndMadeUniqueByNormalizer(t *testing.T) {
-	addr1 := Address{0x01}
-	addr2 := Address{0x02}
-	addr3 := Address{0x03}
-
-	update := Update{}
-	update.AppendCreateAccount(addr2)
-	update.AppendCreateAccount(addr1)
-	update.AppendCreateAccount(addr3)
-	update.AppendCreateAccount(addr1)
-
-	if err := update.Normalize(); err != nil {
-		t.Errorf("failed to normalize update: %v", err)
-	}
-
-	want := Update{}
-	want.AppendCreateAccount(addr1)
-	want.AppendCreateAccount(addr2)
-	want.AppendCreateAccount(addr3)
-
-	if !reflect.DeepEqual(want, update) {
-		t.Errorf("failed to normalize create-account list, wanted %v, got %v", want.CreatedAccounts, update.CreatedAccounts)
 	}
 }
 
@@ -276,12 +250,6 @@ var updateValueCase = []struct {
 	appendThird  func(u *Update)
 }{
 	{
-		"CreateAccount",
-		func(u *Update) { u.AppendCreateAccount(Address{0x01}) },
-		func(u *Update) { u.AppendCreateAccount(Address{0x02}) },
-		func(u *Update) { u.AppendCreateAccount(Address{0x03}) },
-	},
-	{
 		"DeleteAccount",
 		func(u *Update) { u.AppendDeleteAccount(Address{0x01}) },
 		func(u *Update) { u.AppendDeleteAccount(Address{0x02}) },
@@ -350,7 +318,7 @@ func TestUpdateCreatingAndDeletingSameAccountIsInvalid(t *testing.T) {
 	addr := Address{0x01}
 
 	update := Update{}
-	update.AppendCreateAccount(addr)
+	update.AppendBalanceUpdate(addr, amount.New(1))
 	if update.Check() != nil {
 		t.Errorf("just creating an account should be fine")
 	}
@@ -365,7 +333,7 @@ func TestUpdateSingleAccountCreatedAndDeletedIsDetectedAlsoWhenPartOfAList(t *te
 	for i := 0; i < 10; i++ {
 		addr := Address{byte(i)}
 		if i%2 == 0 {
-			update.AppendCreateAccount(addr)
+			update.AppendBalanceUpdate(addr, amount.New(1))
 		} else {
 			update.AppendDeleteAccount(addr)
 		}
@@ -375,7 +343,7 @@ func TestUpdateSingleAccountCreatedAndDeletedIsDetectedAlsoWhenPartOfAList(t *te
 		t.Errorf("non-overlapping create and delete list should be fine, but got: %v", err)
 	}
 
-	update.AppendCreateAccount(Address{9})
+	update.AppendBalanceUpdate(Address{9}, amount.New(1))
 
 	if update.Check() == nil {
 		t.Errorf("creating and deleting the same account should fail")
@@ -400,10 +368,6 @@ func getExampleUpdate() Update {
 
 	update.AppendDeleteAccount(Address{0xA1})
 	update.AppendDeleteAccount(Address{0xA2})
-
-	update.AppendCreateAccount(Address{0xB1})
-	update.AppendCreateAccount(Address{0xB2})
-	update.AppendCreateAccount(Address{0xB3})
 
 	update.AppendBalanceUpdate(Address{0xC1}, amount.New(1<<56, 0, 0, 0))
 	update.AppendBalanceUpdate(Address{0xC2}, amount.New(2<<56, 0, 0, 0))
@@ -463,30 +427,6 @@ func TestUpdateParsingTruncatedDataShouldFailWithError(t *testing.T) {
 	}
 }
 
-func TestUpdateKnownEncodings(t *testing.T) {
-	testCases := []struct {
-		update Update
-		hash   string
-	}{
-		{
-			Update{},
-			"61126de1b795b976f3ac878f48e88fa77a87d7308ba57c7642b9e1068403a496",
-		},
-		{
-			getExampleUpdate(),
-			"d16bcf097cba34ece949ae64db100861c15f0058a1366003ad8f90a0dadf351b",
-		},
-	}
-	for _, test := range testCases {
-		hasher := sha256.New()
-		hasher.Write(test.update.ToBytes())
-		hash := fmt.Sprintf("%x", hasher.Sum(nil))
-		if hash != test.hash {
-			t.Errorf("invalid encoding, expected hash %v, got %v", test.hash, hash)
-		}
-	}
-}
-
 func TestUpdate_ApplyTo(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
@@ -494,9 +434,6 @@ func TestUpdate_ApplyTo(t *testing.T) {
 	gomock.InOrder(
 		target.EXPECT().DeleteAccount(Address{0xA1}),
 		target.EXPECT().DeleteAccount(Address{0xA2}),
-		target.EXPECT().CreateAccount(Address{0xB1}),
-		target.EXPECT().CreateAccount(Address{0xB2}),
-		target.EXPECT().CreateAccount(Address{0xB3}),
 		target.EXPECT().SetBalance(Address{0xC1}, amount.New(1<<56, 0, 0, 0)),
 		target.EXPECT().SetBalance(Address{0xC2}, amount.New(2<<56, 0, 0, 0)),
 		target.EXPECT().SetNonce(Address{0xD1}, Nonce{0x03}),
@@ -516,7 +453,7 @@ func TestUpdate_ApplyTo(t *testing.T) {
 }
 
 func TestUpdate_ApplyTo_Failures(t *testing.T) {
-	const calls = 6
+	const calls = 5
 	for i := 0; i < calls; i++ {
 		i := i
 		t.Run(fmt.Sprintf("applyTo_failure_at_%d", i), func(t *testing.T) {
@@ -527,11 +464,10 @@ func TestUpdate_ApplyTo_Failures(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			target := NewMockUpdateTarget(ctrl)
 			target.EXPECT().DeleteAccount(gomock.Any()).AnyTimes().Return(returns[0])
-			target.EXPECT().CreateAccount(gomock.Any()).AnyTimes().Return(returns[1])
-			target.EXPECT().SetBalance(gomock.Any(), gomock.Any()).AnyTimes().Return(returns[2])
-			target.EXPECT().SetNonce(gomock.Any(), gomock.Any()).AnyTimes().Return(returns[3])
-			target.EXPECT().SetCode(gomock.Any(), gomock.Any()).AnyTimes().Return(returns[4])
-			target.EXPECT().SetStorage(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(returns[5])
+			target.EXPECT().SetBalance(gomock.Any(), gomock.Any()).AnyTimes().Return(returns[1])
+			target.EXPECT().SetNonce(gomock.Any(), gomock.Any()).AnyTimes().Return(returns[2])
+			target.EXPECT().SetCode(gomock.Any(), gomock.Any()).AnyTimes().Return(returns[3])
+			target.EXPECT().SetStorage(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(returns[4])
 
 			update := getExampleUpdate()
 			if err := update.ApplyTo(target); !errors.Is(err, returns[i]) {
@@ -549,7 +485,6 @@ func TestUpdate_Print(t *testing.T) {
 	}
 
 	update.AppendDeleteAccount(Address{1})
-	update.AppendCreateAccount(Address{2})
 	update.AppendBalanceUpdate(Address{3}, amount.New(1))
 	update.AppendNonceUpdate(Address{4}, ToNonce(2))
 	update.AppendCodeUpdate(Address{5}, []byte{1, 2, 3})
@@ -559,7 +494,6 @@ func TestUpdate_Print(t *testing.T) {
 
 	expectations := []string{
 		"Deleted Accounts:",
-		"Created Accounts:",
 		"Balances:",
 		"Nonces:",
 		"Slots:",
@@ -573,4 +507,38 @@ func TestUpdate_Print(t *testing.T) {
 		}
 	}
 
+}
+
+func Test_insertOrdered(t *testing.T) {
+	list := []Address{{0x01}, {0x03}, {0x05}}
+	addr := Address{0x02}
+	updatedList := insertOrdered(list, addr)
+	expectedList := []Address{{0x01}, {0x02}, {0x03}, {0x05}}
+	if !reflect.DeepEqual(updatedList, expectedList) {
+		t.Errorf("expected %v, got %v", expectedList, updatedList)
+	}
+
+	// Test inserting an existing address does not change the list
+	addr = Address{0x03}
+	updatedList = insertOrdered(list, addr)
+	expectedList = []Address{{0x01}, {0x03}, {0x05}}
+	if !reflect.DeepEqual(updatedList, expectedList) {
+		t.Errorf("expected %v, got %v", expectedList, updatedList)
+	}
+
+	// Test inserting an address smaller than all existing addresses
+	addr = Address{0x00}
+	updatedList = insertOrdered(list, addr)
+	expectedList = []Address{{0x00}, {0x01}, {0x03}, {0x05}}
+	if !reflect.DeepEqual(updatedList, expectedList) {
+		t.Errorf("expected %v, got %v", expectedList, updatedList)
+	}
+
+	// Test inserting an address larger than all existing addresses
+	addr = Address{0x06}
+	updatedList = insertOrdered(list, addr)
+	expectedList = []Address{{0x01}, {0x03}, {0x05}, {0x06}}
+	if !reflect.DeepEqual(updatedList, expectedList) {
+		t.Errorf("expected %v, got %v", expectedList, updatedList)
+	}
 }

--- a/go/database/flat/flat.go
+++ b/go/database/flat/flat.go
@@ -32,7 +32,6 @@ import (
 	"github.com/0xsoniclabs/carmen/go/common/witness"
 	"github.com/0xsoniclabs/carmen/go/state"
 	"github.com/0xsoniclabs/tracy"
-	"github.com/ethereum/go-ethereum/core/types"
 )
 
 // State is an in-memory flat representation of the blockchain state, wrapping
@@ -222,14 +221,6 @@ func (s *State) Apply(block uint64, data common.Update) (<-chan error, error) {
 
 	for _, address := range data.DeletedAccounts {
 		delete(s.accounts, address)
-	}
-
-	// init potentially empty accounts with empty code hash,
-	for _, address := range data.CreatedAccounts {
-		// empty account has empty code size, nonce, and balance
-		s.accounts[address] = account{
-			codeHash: common.Hash(types.EmptyCodeHash),
-		}
 	}
 
 	for _, update := range data.Nonces {

--- a/go/database/flat/flat_test.go
+++ b/go/database/flat/flat_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/0xsoniclabs/carmen/go/common/future"
 	"github.com/0xsoniclabs/carmen/go/common/result"
 	"github.com/0xsoniclabs/carmen/go/state"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
@@ -316,7 +315,6 @@ func TestState_Apply_SetsValuesInLocalMaps(t *testing.T) {
 	require := require.New(t)
 
 	update := common.Update{
-		CreatedAccounts: []common.Address{{0x01}, {0x02}},
 		Nonces: []common.NonceUpdate{
 			{Account: common.Address{0x03}, Nonce: common.Nonce{42}},
 			{Account: common.Address{0x04}, Nonce: common.Nonce{84}},
@@ -351,16 +349,6 @@ func TestState_Apply_SetsValuesInLocalMaps(t *testing.T) {
 	require.NotNil(command.update)
 	require.Equal(uint64(1), command.update.block)
 	require.Equal(update, command.update.data)
-
-	// The local maps are updated immediately.
-	for _, address := range update.CreatedAccounts {
-		acc, exists := state.accounts[address]
-		require.True(exists)
-		require.Equal(common.Hash(types.EmptyCodeHash), acc.codeHash)
-		require.Equal(0, acc.codeSize)
-		require.Equal(amount.New(0), acc.balance)
-		require.Equal(common.Nonce{}, acc.nonce)
-	}
 
 	for _, nonceUpdate := range update.Nonces {
 		acc, exists := state.accounts[nonceUpdate.Account]
@@ -407,7 +395,7 @@ func TestState_Apply_DeletesAccounts(t *testing.T) {
 	require.False(state.Exists(address))
 
 	_, err = state.Apply(1, common.Update{
-		CreatedAccounts: []common.Address{address},
+		Balances: []common.BalanceUpdate{{Account: address, Balance: amount.New(10)}},
 	})
 	require.NoError(err)
 

--- a/go/database/mpt/archive_trie_fuzzing_test.go
+++ b/go/database/mpt/archive_trie_fuzzing_test.go
@@ -487,7 +487,7 @@ func fuzzArchiveTrieRandomAccountStorageOps(f *testing.F) {
 		update := common.Update{}
 		// slot update does not include account creation, i.e., create the account if it does not exist.
 		if !c.AccountExists(value.address) {
-			update.AppendCreateAccount(value.address.GetAddress())
+			update.AppendNonceUpdate(value.address.GetAddress(), common.ToNonce(1))
 		}
 		update.AppendSlotUpdate(value.address.GetAddress(), value.key.GetKey(), value.value)
 
@@ -541,15 +541,6 @@ func fuzzArchiveTrieRandomAccountStorageOps(f *testing.F) {
 			t.Errorf("error to delete account storage: %v_%v -> %v,  block: %d", value.address, value.key, value.value, c.GetCurrentBlock())
 		}
 		c.DeleteAccountStorage(value.address, value.key)
-	}
-
-	var opCreateAccount = func(_ archiveStorageOpType, value archiveAccountStoragePayload, t fuzzing.TestingT, c *archiveTrieAccountStorageFuzzingContext) {
-		update := common.Update{}
-		update.AppendCreateAccount(value.address.GetAddress())
-		if err := c.archiveTrie.Add(uint64(c.GetNextBlock()), update, nil); err != nil {
-			t.Errorf("error to delete account: %v,  block: %d", value.address, c.GetCurrentBlock())
-		}
-		c.CreateAccount(value.address)
 	}
 
 	var opDeleteAccount = func(_ archiveStorageOpType, value archiveAccountStoragePayload, t fuzzing.TestingT, c *archiveTrieAccountStorageFuzzingContext) {
@@ -636,7 +627,6 @@ func fuzzArchiveTrieRandomAccountStorageOps(f *testing.F) {
 	fuzzing.RegisterDataOp(registry, setStorageArchive, serialiseAddressKeyValue, deserialiseAddressKeyValue, opSet)
 	fuzzing.RegisterDataOp(registry, deleteStorageArchive, serialiseAddressKey, deserialiseAddressKey, opDelete)
 	fuzzing.RegisterDataOp(registry, getStorageArchive, serialiseBlockAddressKey, deserialiseBlockAddressKey, opGet)
-	fuzzing.RegisterDataOp(registry, createAccountArchive, serialiseAddress, deserialiseAddress, opCreateAccount)
 	fuzzing.RegisterDataOp(registry, deleteAccountArchive, serialiseAddress, deserialiseAddress, opDeleteAccount)
 
 	init := func(registry fuzzing.OpsFactoryRegistry[archiveStorageOpType, archiveTrieAccountStorageFuzzingContext]) []fuzzing.OperationSequence[archiveTrieAccountStorageFuzzingContext] {
@@ -659,15 +649,6 @@ func fuzzArchiveTrieRandomAccountStorageOps(f *testing.F) {
 					}
 				}
 
-			}
-			seed = append(seed, sequence)
-		}
-
-		{
-			var sequence fuzzing.OperationSequence[archiveTrieAccountStorageFuzzingContext]
-			for _, addr := range []tinyAddress{0, 1, 2, 5, 10, 255} {
-				var empty common.Value
-				sequence = append(sequence, registry.CreateDataOp(createAccountArchive, archiveAccountStoragePayload{0, addr, 0, empty}))
 			}
 			seed = append(seed, sequence)
 		}
@@ -789,10 +770,8 @@ func (a *archiveAccountStoragePayload) SerialiseAddress() []byte {
 type archiveStorageOpType byte
 
 const (
-	// createAccountArchive causes deletion of the storage if the account existed in the tip of the chain.
-	createAccountArchive archiveStorageOpType = iota
 	// deleteAccountArchive causes deletion of an account with its storage from the tip of the chain.
-	deleteAccountArchive
+	deleteAccountArchive archiveStorageOpType = iota
 	// setStorageArchive updates the storage in the tip of the chain.
 	setStorageArchive
 	// deleteStorageArchive deletes the storage from the tip of the chain.
@@ -890,29 +869,6 @@ func (c *archiveTrieAccountStorageFuzzingContext) DeleteAccountStorage(address t
 	if storage, exists := current[address]; exists {
 		delete(storage, key)
 	}
-
-	// assign to the next block
-	c.shadow = append(c.shadow, current)
-}
-
-// CreateAccount creates a new empty account or empties the storage of an existing account.
-// The new, or modified, account is added as a new block in the shadow blockchain together with all other copied accounts.
-// If the account already exists, it is emptied by not-copying its storage from the tip of the shadow blockchain.
-// If the account does not exist, a new empty account is created for the given address.
-// The new copy of the block is then appended as a next block in the shadow db.
-func (c *archiveTrieAccountStorageFuzzingContext) CreateAccount(address tinyAddress) {
-	// copy the current block first while emptying the account if it exists
-	current := make(map[tinyAddress]map[tinyKey]common.Value)
-	if len(c.shadow) > 0 {
-		for addr, storage := range c.shadow[c.GetCurrentBlock()] {
-			if addr != address {
-				current[addr] = maps.Clone(storage)
-			}
-		}
-	}
-
-	// assign a new empty account
-	current[address] = make(map[tinyKey]common.Value)
 
 	// assign to the next block
 	c.shadow = append(c.shadow, current)

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -425,7 +425,6 @@ func TestArchiveTrie_CanHandleMultipleBlocks(t *testing.T) {
 			blc2 := amount.New(2)
 
 			archive.Add(1, common.Update{
-				CreatedAccounts: []common.Address{addr1},
 				Balances: []common.BalanceUpdate{
 					{Account: addr1, Balance: blc1},
 				},
@@ -463,7 +462,6 @@ func TestArchiveTrie_GetAccountInfo(t *testing.T) {
 
 			addr1 := common.Address{1}
 			if err := archive.Add(1, common.Update{
-				CreatedAccounts: []common.Address{addr1},
 				Balances: []common.BalanceUpdate{
 					{Account: addr1, Balance: amount.New(1)},
 				},
@@ -532,17 +530,15 @@ func TestArchiveTrie_VisitAccount(t *testing.T) {
 
 			// create a block with all accounts but empty slots
 			if err := archive.Add(1, common.Update{
-				CreatedAccounts: accounts,
-				Nonces:          nonces,
+				Nonces: nonces,
 			}, nil); err != nil {
 				t.Fatalf("failed to add block: %v", err)
 			}
 
 			// create a block with all accounts and slots
 			if err := archive.Add(2, common.Update{
-				CreatedAccounts: accounts,
-				Nonces:          nonces,
-				Slots:           slotUpdates,
+				Nonces: nonces,
+				Slots:  slotUpdates,
 			}, nil); err != nil {
 				t.Fatalf("failed to add block: %v", err)
 			}
@@ -608,7 +604,6 @@ func TestArchiveTrie_CanHandleEmptyBlocks(t *testing.T) {
 
 			// Block 1 adds an actual change.
 			err = archive.Add(1, common.Update{
-				CreatedAccounts: []common.Address{addr},
 				Balances: []common.BalanceUpdate{
 					{Account: addr, Balance: balance},
 				},
@@ -683,7 +678,6 @@ func TestArchiveTrie_CanProcessPrecomputedHashes(t *testing.T) {
 
 			// Block 1
 			update := common.Update{
-				CreatedAccounts: []common.Address{addr1, addr2},
 				Balances: []common.BalanceUpdate{
 					{Account: addr1, Balance: blc1},
 					{Account: addr2, Balance: blc2},
@@ -717,13 +711,11 @@ func TestArchiveTrie_CanProcessPrecomputedHashes(t *testing.T) {
 			for i := 0; i < 100; i++ {
 				addr := common.Address{byte(i + 10)}
 				err = errors.Join(
-					live.CreateAccount(addr),
 					live.SetBalance(addr, blc1),
 				)
 				if err != nil {
 					t.Fatalf("failed to update live db: %v", err)
 				}
-				update.CreatedAccounts = append(update.CreatedAccounts, addr)
 				update.Balances = append(update.Balances, common.BalanceUpdate{Account: addr, Balance: blc1})
 			}
 			hints, err = live.Apply(4, &update)
@@ -767,7 +759,6 @@ func TestArchiveTrie_VerificationOfFreshArchivePasses(t *testing.T) {
 			}
 
 			err = archive.Add(2, common.Update{
-				CreatedAccounts: []common.Address{{1}, {2}},
 				Nonces: []common.NonceUpdate{
 					{Account: common.Address{1}, Nonce: common.ToNonce(1)},
 					{Account: common.Address{2}, Nonce: common.ToNonce(2)},
@@ -783,7 +774,6 @@ func TestArchiveTrie_VerificationOfFreshArchivePasses(t *testing.T) {
 			}
 
 			err = archive.Add(4, common.Update{
-				CreatedAccounts: []common.Address{{3}},
 				Nonces: []common.NonceUpdate{
 					{Account: common.Address{3}, Nonce: common.ToNonce(3)},
 				},
@@ -823,13 +813,19 @@ func TestArchiveTrie_Add_DuplicatedBlock(t *testing.T) {
 			}()
 
 			if err = archive.Add(2, common.Update{
-				CreatedAccounts: []common.Address{{1}, {2}},
+				Balances: []common.BalanceUpdate{
+					{Account: common.Address{1}, Balance: amount.New(1)},
+					{Account: common.Address{2}, Balance: amount.New(2)},
+				},
 			}, nil); err != nil {
 				t.Fatalf("failed to update archive: %v", err)
 			}
 
 			if err = archive.Add(2, common.Update{
-				CreatedAccounts: []common.Address{{1}, {2}},
+				Balances: []common.BalanceUpdate{
+					{Account: common.Address{1}, Balance: amount.New(1)},
+					{Account: common.Address{2}, Balance: amount.New(2)},
+				},
 			}, nil); err == nil {
 				t.Errorf("adding duplicate block should fail")
 			}
@@ -1120,7 +1116,9 @@ func TestArchiveTrie_Add_LiveStateFailsHashing(t *testing.T) {
 
 	// fails for computing missing blocks
 	if err := archive.Add(20, common.Update{
-		CreatedAccounts: []common.Address{{1}, {2}},
+		Balances: []common.BalanceUpdate{
+			{Account: common.Address{1}, Balance: amount.New(1)},
+		},
 	}, nil); !errors.Is(err, injectedError) {
 		t.Errorf("applying update should fail")
 	}
@@ -1131,7 +1129,7 @@ func TestArchiveTrie_Add_LiveStateFailsCreateAccount(t *testing.T) {
 	var injectedError = errors.New("injectedError")
 	ctrl := gomock.NewController(t)
 	live := NewMockLiveState(ctrl)
-	live.EXPECT().CreateAccount(gomock.Any()).Return(injectedError)
+	live.EXPECT().SetBalance(gomock.Any(), gomock.Any()).Return(injectedError)
 	live.EXPECT().Flush()
 	live.EXPECT().closeWithError(gomock.Any())
 
@@ -1144,7 +1142,9 @@ func TestArchiveTrie_Add_LiveStateFailsCreateAccount(t *testing.T) {
 
 	// fails for computing this block
 	if err := archive.Add(0, common.Update{
-		CreatedAccounts: []common.Address{{1}, {2}},
+		Balances: []common.BalanceUpdate{
+			{Account: common.Address{1}, Balance: amount.New(1)},
+		},
 	}, nil); !errors.Is(err, injectedError) {
 		t.Errorf("applying update should fail")
 	}
@@ -1230,7 +1230,6 @@ func TestArchiveTrie_GetCodes(t *testing.T) {
 			code1 := []byte{1, 2, 3}
 			code2 := []byte{4, 5}
 			if err = archive.Add(0, common.Update{
-				CreatedAccounts: []common.Address{addr1, addr2},
 				Codes: []common.CodeUpdate{
 					{Account: addr1, Code: code1},
 					{Account: addr2, Code: code2},
@@ -1269,7 +1268,9 @@ func TestArchiveTrie_GetHash(t *testing.T) {
 				}
 
 				if err = archive.Add(0, common.Update{
-					CreatedAccounts: []common.Address{{1}},
+					Balances: []common.BalanceUpdate{
+						{Account: common.Address{1}, Balance: amount.New(1)},
+					},
 				}, nil); err != nil {
 					t.Fatalf("cannot apply update: %s", err)
 				}
@@ -1340,7 +1341,6 @@ func TestArchiveTrie_CreateWitnessProof(t *testing.T) {
 			}()
 
 			if err := arch.Add(1, common.Update{
-				CreatedAccounts: []common.Address{{1}},
 				Balances: []common.BalanceUpdate{
 					{Account: common.Address{1}, Balance: amount.New(12)},
 				},
@@ -1406,7 +1406,6 @@ func TestArchiveTrie_HasEmptyStorage(t *testing.T) {
 			const blocks = 10
 			for i := uint64(1); i <= blocks; i++ {
 				if err := arch.Add(i, common.Update{
-					CreatedAccounts: []common.Address{{1, 2}},
 					Balances: []common.BalanceUpdate{
 						{Account: common.Address{1}, Balance: amount.New(12)},
 						{Account: common.Address{2}, Balance: amount.New(12)},
@@ -1475,16 +1474,14 @@ func TestArchiveTrie_GetDiffProducesValidResults(t *testing.T) {
 			nonce2 := common.Nonce{2}
 
 			err = archive.Add(1, common.Update{
-				CreatedAccounts: []common.Address{addr1},
-				Nonces:          []common.NonceUpdate{{Account: addr1, Nonce: nonce1}},
+				Nonces: []common.NonceUpdate{{Account: addr1, Nonce: nonce1}},
 			}, nil)
 			if err != nil {
 				t.Fatalf("failed to create block in archive: %v", err)
 			}
 
 			err = archive.Add(3, common.Update{
-				CreatedAccounts: []common.Address{addr2},
-				Nonces:          []common.NonceUpdate{{Account: addr2, Nonce: nonce2}},
+				Nonces: []common.NonceUpdate{{Account: addr2, Nonce: nonce2}},
 			}, nil)
 			if err != nil {
 				t.Fatalf("failed to create block in archive: %v", err)
@@ -1578,16 +1575,14 @@ func TestArchiveTrie_GetDiffDetectsInvalidInput(t *testing.T) {
 			nonce2 := common.Nonce{2}
 
 			err = archive.Add(1, common.Update{
-				CreatedAccounts: []common.Address{addr1},
-				Nonces:          []common.NonceUpdate{{Account: addr1, Nonce: nonce1}},
+				Nonces: []common.NonceUpdate{{Account: addr1, Nonce: nonce1}},
 			}, nil)
 			if err != nil {
 				t.Fatalf("failed to create block in archive: %v", err)
 			}
 
 			err = archive.Add(3, common.Update{
-				CreatedAccounts: []common.Address{addr2},
-				Nonces:          []common.NonceUpdate{{Account: addr2, Nonce: nonce2}},
+				Nonces: []common.NonceUpdate{{Account: addr2, Nonce: nonce2}},
 			}, nil)
 			if err != nil {
 				t.Fatalf("failed to create block in archive: %v", err)
@@ -1633,16 +1628,14 @@ func TestArchiveTrie_GetDiffForBlockProducesValidResults(t *testing.T) {
 			nonce2 := common.Nonce{2}
 
 			err = archive.Add(0, common.Update{
-				CreatedAccounts: []common.Address{addr1},
-				Nonces:          []common.NonceUpdate{{Account: addr1, Nonce: nonce1}},
+				Nonces: []common.NonceUpdate{{Account: addr1, Nonce: nonce1}},
 			}, nil)
 			if err != nil {
 				t.Fatalf("failed to create block in archive: %v", err)
 			}
 
 			err = archive.Add(2, common.Update{
-				CreatedAccounts: []common.Address{addr2},
-				Nonces:          []common.NonceUpdate{{Account: addr2, Nonce: nonce2}},
+				Nonces: []common.NonceUpdate{{Account: addr2, Nonce: nonce2}},
 			}, nil)
 			if err != nil {
 				t.Fatalf("failed to create block in archive: %v", err)
@@ -1739,7 +1732,7 @@ func TestArchiveTrie_Dump(t *testing.T) {
 			}()
 
 			if err = archive.Add(0, common.Update{
-				CreatedAccounts: []common.Address{{1}},
+				Balances: []common.BalanceUpdate{{Account: common.Address{1}, Balance: amount.New(1)}},
 			}, nil); err != nil {
 				t.Fatalf("cannot apply update: %s", err)
 			}
@@ -1759,7 +1752,6 @@ func TestArchiveTrie_VerificationOfArchiveWithMissingFileFails(t *testing.T) {
 			}
 
 			err = archive.Add(2, common.Update{
-				CreatedAccounts: []common.Address{{1}, {2}},
 				Nonces: []common.NonceUpdate{
 					{Account: common.Address{1}, Nonce: common.ToNonce(1)},
 					{Account: common.Address{2}, Nonce: common.ToNonce(2)},
@@ -1799,7 +1791,6 @@ func TestArchiveTrie_VerificationOfArchiveWithCorruptedFileFails(t *testing.T) {
 			}
 
 			err = archive.Add(2, common.Update{
-				CreatedAccounts: []common.Address{{1}, {2}},
 				Nonces: []common.NonceUpdate{
 					{Account: common.Address{1}, Nonce: common.ToNonce(1)},
 					{Account: common.Address{2}, Nonce: common.ToNonce(2)},
@@ -2062,58 +2053,6 @@ func TestRootList_CanParticipateToCheckpointOperations(t *testing.T) {
 	}
 }
 
-func TestArchiveTrie_RecreateAccount_ClearStorage(t *testing.T) {
-	for _, config := range allMptConfigs {
-		t.Run(config.Name, func(t *testing.T) {
-			archive, err := OpenArchiveTrie(t.TempDir(), config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
-			if err != nil {
-				t.Fatalf("failed to open empty archive: %v", err)
-			}
-
-			addr := common.Address{0xA}
-			key := common.Key{0xB}
-			val := common.Value{0xC}
-
-			// create an account with a non-empty slot
-			update := common.Update{}
-			update.AppendCreateAccount(addr)
-			update.AppendSlotUpdate(addr, key, val)
-			if err := archive.Add(0, update, nil); err != nil {
-				t.Errorf("cannot add update: %s", err)
-			}
-
-			// re-create an account in the next block
-			update = common.Update{}
-			update.AppendCreateAccount(addr)
-			if err := archive.Add(1, update, nil); err != nil {
-				t.Errorf("cannot add update: %s", err)
-			}
-
-			// verify that the account is re-created with an empty slot
-			exists, err := archive.Exists(1, addr)
-			if err != nil {
-				t.Errorf("cannot check account existence: %s", err)
-			}
-			if !exists {
-				t.Errorf("account does not exist")
-			}
-			storage, err := archive.GetStorage(1, addr, key)
-			if err != nil {
-				t.Errorf("cannot get slot value: %s", err)
-			}
-
-			var empty common.Value
-			if storage != empty {
-				t.Errorf("value is not empty, but it is: %v", storage)
-			}
-
-			if err := archive.Close(); err != nil {
-				t.Fatalf("failed to close empty archive: %v", err)
-			}
-		})
-	}
-}
-
 func TestArchiveTrie_QueryLoadTest(t *testing.T) {
 	// Goal: stress-test an archive with a limited node cache.
 	archive, err := OpenArchiveTrie(t.TempDir(), S5ArchiveConfig, NodeCacheConfig{Capacity: 30_000}, ArchiveConfig{})
@@ -2128,7 +2067,7 @@ func TestArchiveTrie_QueryLoadTest(t *testing.T) {
 		for a := 0; a < N; a++ {
 			addr := common.Address{byte(a)}
 			if b == 0 {
-				update.AppendCreateAccount(addr)
+				update.AppendBalanceUpdate(addr, amount.New(10))
 			}
 			for k := 0; k < N; k++ {
 				update.AppendSlotUpdate(addr, common.Key{byte(k)}, common.Value{byte(b), byte(a), byte(k)})
@@ -2277,7 +2216,9 @@ func TestArchiveTrie_FailingOperation_InvalidatesOtherArchiveOperations(t *testi
 
 			// adding an update as well as all flush and close checks must fail
 			update := common.Update{
-				CreatedAccounts: []common.Address{{0xB}},
+				Balances: []common.BalanceUpdate{
+					{Account: common.Address{0xA}, Balance: amount.New(1)},
+				},
 			}
 
 			if err := archive.Add(0, update, nil); !errors.Is(err, injectedErr) {
@@ -2307,9 +2248,6 @@ func TestArchiveTrie_FailingLiveStateUpdate_InvalidatesArchive(t *testing.T) {
 		addExpectations func(db *MockLiveState, injectedErr error)
 	}{{"DeleteAccount", func(db *MockLiveState, injectedErr error) {
 		db.EXPECT().DeleteAccount(gomock.Any()).Return(injectedErr)
-	},
-	}, {"CreateAccount", func(db *MockLiveState, injectedErr error) {
-		db.EXPECT().CreateAccount(gomock.Any()).Return(injectedErr)
 	},
 	}, {"SetBalance", func(db *MockLiveState, injectedErr error) {
 		db.EXPECT().SetBalance(gomock.Any(), gomock.Any()).Return(injectedErr)
@@ -2368,7 +2306,6 @@ func TestArchiveTrie_FailingLiveStateUpdate_InvalidatesArchive(t *testing.T) {
 			// trigger error from the livedb
 			update := common.Update{
 				DeletedAccounts: []common.Address{{0xA}},
-				CreatedAccounts: []common.Address{{0xB}},
 				Balances:        []common.BalanceUpdate{{Account: common.Address{0xA}, Balance: amount.New(1)}},
 				Nonces:          []common.NonceUpdate{{Account: common.Address{0xA}, Nonce: common.Nonce{0x1}}},
 				Codes:           []common.CodeUpdate{{Account: common.Address{0xA}, Code: []byte{0x1}}},
@@ -2505,7 +2442,6 @@ func TestArchiveTrie_VisitTrie_CorrectDataIsVisited(t *testing.T) {
 				}()
 
 				err = archive.Add(1, common.Update{
-					CreatedAccounts: []common.Address{addr},
 					Nonces: []common.NonceUpdate{
 						{Account: addr, Nonce: common.ToNonce(1)},
 					},
@@ -2557,7 +2493,6 @@ func TestArchiveTrie_VisitTrie_InvalidBlock(t *testing.T) {
 			addr := common.Address{1}
 
 			err = archive.Add(0, common.Update{
-				CreatedAccounts: []common.Address{addr},
 				Nonces: []common.NonceUpdate{
 					{Account: addr, Nonce: common.ToNonce(1)},
 				},
@@ -2667,7 +2602,6 @@ func TestArchiveTrie_RestoreBlockHeight(t *testing.T) {
 	addBlocks := func(archive *ArchiveTrie, from int, to int) error {
 		for i := from; i < to; i++ {
 			err := archive.Add(uint64(i), common.Update{
-				CreatedAccounts: []common.Address{{byte(i)}},
 				Nonces: []common.NonceUpdate{
 					{Account: common.Address{byte(i)}, Nonce: common.Nonce{byte(i)}},
 				},
@@ -3024,7 +2958,6 @@ func TestArchiveTrie_RestoredTrieCanBeReused(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		counter++
 		err := archive.Add(uint64(i), common.Update{
-			CreatedAccounts: []common.Address{address},
 			Nonces: []common.NonceUpdate{
 				{Account: address, Nonce: common.Nonce{byte(counter)}},
 			},
@@ -3072,7 +3005,6 @@ func TestArchiveTrie_RestoredTrieCanBeReused(t *testing.T) {
 	for i := 51; i < 150; i++ {
 		counter++
 		err := archive.Add(uint64(i), common.Update{
-			CreatedAccounts: []common.Address{address},
 			Nonces: []common.NonceUpdate{
 				{Account: address, Nonce: common.Nonce{byte(counter)}},
 			},

--- a/go/database/mpt/io/archive_test.go
+++ b/go/database/mpt/io/archive_test.go
@@ -201,10 +201,9 @@ func fillTestBlocksIntoArchive(t *testing.T, archive *mpt.ArchiveTrie) (blockHei
 	code1 := []byte{1, 2, 3}
 
 	err := archive.Add(0, common.Update{
-		CreatedAccounts: []common.Address{addr1},
-		Balances:        []common.BalanceUpdate{{Account: addr1, Balance: balance1}},
-		Nonces:          []common.NonceUpdate{{Account: addr1, Nonce: nonce1}},
-		Codes:           []common.CodeUpdate{{Account: addr1, Code: code1}},
+		Balances: []common.BalanceUpdate{{Account: addr1, Balance: balance1}},
+		Nonces:   []common.NonceUpdate{{Account: addr1, Nonce: nonce1}},
+		Codes:    []common.CodeUpdate{{Account: addr1, Code: code1}},
 		Slots: []common.SlotUpdate{
 			{Account: addr1, Key: common.Key{1}, Value: common.Value{1}},
 			{Account: addr1, Key: common.Key{2}, Value: common.Value{2}},
@@ -215,9 +214,9 @@ func fillTestBlocksIntoArchive(t *testing.T, archive *mpt.ArchiveTrie) (blockHei
 	}
 
 	err = archive.Add(3, common.Update{
-		CreatedAccounts: []common.Address{addr2},
-		Balances:        []common.BalanceUpdate{{Account: addr2, Balance: balance2}},
-		Nonces:          []common.NonceUpdate{{Account: addr2, Nonce: nonce2}},
+		Balances: []common.BalanceUpdate{{Account: addr2, Balance: balance2}},
+		Nonces:   []common.NonceUpdate{{Account: addr2, Nonce: nonce2}},
+		Codes:    []common.CodeUpdate{{Account: addr2, Code: []byte{}}},
 		Slots: []common.SlotUpdate{
 			{Account: addr1, Key: common.Key{1}, Value: common.Value{0}},
 			{Account: addr1, Key: common.Key{2}, Value: common.Value{3}},

--- a/go/database/mpt/io/live_test.go
+++ b/go/database/mpt/io/live_test.go
@@ -304,7 +304,6 @@ func TestIO_ExportBlockFromArchive(t *testing.T) {
 		for j := 0; j < Accounts; j++ {
 			newAddr := common.AddressFromNumber(j)
 
-			update.CreatedAccounts = append(update.CreatedAccounts, newAddr)
 			update.Balances = append(update.Balances, common.BalanceUpdate{Account: newAddr, Balance: amount.New(u + 1)})
 			update.Nonces = append(update.Nonces, common.NonceUpdate{Account: newAddr, Nonce: common.ToNonce(u + 1)})
 			update.Codes = append(update.Codes, common.CodeUpdate{Account: newAddr, Code: code})
@@ -389,7 +388,6 @@ func TestIO_ExportBlockFromOnlineArchive(t *testing.T) {
 		for j := 0; j < Accounts; j++ {
 			newAddr := common.AddressFromNumber(j)
 
-			update.CreatedAccounts = append(update.CreatedAccounts, newAddr)
 			update.Balances = append(update.Balances, common.BalanceUpdate{Account: newAddr, Balance: amount.New(u + 1)})
 			update.Nonces = append(update.Nonces, common.NonceUpdate{Account: newAddr, Nonce: common.ToNonce(u + 1)})
 			update.Codes = append(update.Codes, common.CodeUpdate{Account: newAddr, Code: code})

--- a/go/database/mpt/io/parallel_visit_test.go
+++ b/go/database/mpt/io/parallel_visit_test.go
@@ -174,7 +174,6 @@ func TestVisit_CanHandleSlowConsumer(t *testing.T) {
 
 	addr := common.Address{}
 	err = errors.Join(
-		live.CreateAccount(addr),
 		live.SetNonce(addr, common.Nonce{1}),
 	)
 	if err != nil {
@@ -652,7 +651,6 @@ func createArchive(t *testing.T, dir string, config mpt.MptConfig) *mpt.ArchiveT
 		for j := 0; j < Accounts; j++ {
 			newAddr := common.AddressFromNumber(j)
 
-			update.CreatedAccounts = append(update.CreatedAccounts, newAddr)
 			update.Balances = append(update.Balances, common.BalanceUpdate{
 				Account: newAddr, Balance: amount.New(u + 1)})
 			update.Nonces = append(update.Nonces, common.NonceUpdate{

--- a/go/database/mpt/proof/verification_test.go
+++ b/go/database/mpt/proof/verification_test.go
@@ -46,10 +46,9 @@ func TestVerification_VerifyProofArchiveTrie(t *testing.T) {
 				}
 
 				update := common.Update{
-					CreatedAccounts: []common.Address{addr},
-					Nonces:          []common.NonceUpdate{{Account: addr, Nonce: common.Nonce{byte(i)}}},
-					Balances:        []common.BalanceUpdate{{Account: addr, Balance: amount.New(uint64(i))}},
-					Slots:           slotUpdates,
+					Nonces:   []common.NonceUpdate{{Account: addr, Nonce: common.Nonce{byte(i)}}},
+					Balances: []common.BalanceUpdate{{Account: addr, Balance: amount.New(uint64(i))}},
+					Slots:    slotUpdates,
 				}
 
 				if err := archive.Add(uint64(i), update, nil); err != nil {
@@ -99,8 +98,7 @@ func TestVerification_VerifyProofArchiveTrie_InvalidBlockNumber(t *testing.T) {
 	const Blocks = 3
 	for i := 0; i <= Blocks; i++ {
 		if err := archiveTrie.Add(uint64(i), common.Update{
-			CreatedAccounts: []common.Address{{byte(i)}},
-			Balances:        []common.BalanceUpdate{{Account: common.Address{byte(i)}, Balance: amount.New(12)}},
+			Balances: []common.BalanceUpdate{{Account: common.Address{byte(i)}, Balance: amount.New(12)}},
 		}, nil); err != nil {
 			t.Fatalf("failed to add block: %v", err)
 		}
@@ -224,8 +222,7 @@ func TestVerification_FailingArchiveTrie(t *testing.T) {
 	}()
 
 	if err := archiveTrie.Add(1, common.Update{
-		CreatedAccounts: []common.Address{{1}},
-		Balances:        []common.BalanceUpdate{{Account: common.Address{1}, Balance: amount.New(12)}},
+		Balances: []common.BalanceUpdate{{Account: common.Address{1}, Balance: amount.New(12)}},
 	}, nil); err != nil {
 		t.Fatalf("failed to add block: %v", err)
 	}

--- a/go/database/mpt/state.go
+++ b/go/database/mpt/state.go
@@ -198,21 +198,6 @@ func OpenGoFileState(directory string, config MptConfig, cacheConfig NodeCacheCo
 	return newMptState(directory, lock, trie)
 }
 
-func (s *MptState) CreateAccount(address common.Address) (err error) {
-	_, exists, err := s.trie.GetAccountInfo(address)
-	if err != nil {
-		return err
-	}
-	if exists {
-		// For existing accounts, only clear the storage, preserve the rest.
-		return s.trie.ClearStorage(address)
-	}
-	// Create account with hash of empty code.
-	return s.trie.SetAccountInfo(address, AccountInfo{
-		CodeHash: emptyCodeHash,
-	})
-}
-
 func (s *MptState) Exists(address common.Address) (bool, error) {
 	_, exists, err := s.trie.GetAccountInfo(address)
 	if err != nil {

--- a/go/database/mpt/state_mocks.go
+++ b/go/database/mpt/state_mocks.go
@@ -547,20 +547,6 @@ func (mr *MockLiveStateMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockLiveState)(nil).Close))
 }
 
-// CreateAccount mocks base method.
-func (m *MockLiveState) CreateAccount(address common.Address) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAccount", address)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CreateAccount indicates an expected call of CreateAccount.
-func (mr *MockLiveStateMockRecorder) CreateAccount(address any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccount", reflect.TypeOf((*MockLiveState)(nil).CreateAccount), address)
-}
-
 // DeleteAccount mocks base method.
 func (m *MockLiveState) DeleteAccount(address common.Address) error {
 	m.ctrl.T.Helper()

--- a/go/database/mpt/state_test.go
+++ b/go/database/mpt/state_test.go
@@ -352,7 +352,7 @@ func TestState_StateModifications_Failing(t *testing.T) {
 		t.Errorf("accessing data should fail")
 	}
 	update := common.Update{}
-	update.CreatedAccounts = []common.Address{{1}}
+	update.Balances = []common.BalanceUpdate{{Account: common.Address{1}, Balance: amount.New(1)}}
 	if _, err := state.Apply(0, &update); !errors.Is(err, injectedErr) {
 		t.Errorf("accessing data should fail")
 	}
@@ -720,7 +720,7 @@ func runFlushBenchmark(b *testing.B, config MptConfig, forceDirtyNodes bool) {
 				b.Fatalf("failed to update hashes: %v", err)
 			}
 		}
-		err = state.CreateAccount(addr)
+		err = state.SetNonce(addr, common.ToNonce(uint64(j)))
 		if err != nil {
 			b.Fatalf("failed to create account: %v", err)
 		}

--- a/go/database/mpt/visitor_test.go
+++ b/go/database/mpt/visitor_test.go
@@ -68,7 +68,6 @@ func TestNodeStatistics_CollectForestStatisticsWorks(t *testing.T) {
 	}
 
 	archive.Add(2, common.Update{
-		CreatedAccounts: []common.Address{{1}},
 		Nonces: []common.NonceUpdate{
 			{Account: common.Address{1}, Nonce: common.ToNonce(12)},
 		},

--- a/go/database/vt/geth/state.go
+++ b/go/database/vt/geth/state.go
@@ -234,18 +234,6 @@ func (s *verkleState) Apply(block uint64, update common.Update) (<-chan error, e
 		return nil, fmt.Errorf("not supported: verkle trie does not support deleting accounts")
 	}
 
-	// Process created accounts.
-	for _, newAccount := range update.CreatedAccounts {
-		data, err := getAccountData(newAccount)
-		if err != nil {
-			return nil, err
-		}
-		data.Balance = *uint256.NewInt(0)
-		data.Nonce = 0
-		data.CodeHash = common.Hash(types.EmptyCodeHash[:])
-		data.CodeLength = 0
-	}
-
 	// update balances
 	for _, update := range update.Balances {
 		account, err := getAccountData(update.Account)
@@ -409,13 +397,8 @@ type accountData struct {
 
 func (s *verkleState) getAccountData(address common.Address) (accountData, error) {
 	account, codeLength, err := s.getAccount(address)
-	if err != nil {
+	if err != nil || account == nil {
 		return accountData{}, err
-	}
-	if account == nil {
-		return accountData{
-			CodeHash: common.Hash(types.EmptyCodeHash),
-		}, nil
 	}
 	return accountData{
 		Nonce:      account.Nonce,

--- a/go/database/vt/reference/state.go
+++ b/go/database/vt/reference/state.go
@@ -25,7 +25,6 @@ import (
 	"github.com/0xsoniclabs/carmen/go/database/vt/commit"
 	"github.com/0xsoniclabs/carmen/go/database/vt/reference/trie"
 	"github.com/0xsoniclabs/carmen/go/state"
-	"github.com/ethereum/go-ethereum/core/types"
 )
 
 //go:generate mockgen -source state.go -destination state_mock.go -package reference
@@ -113,19 +112,6 @@ func (s *State) HasEmptyStorage(addr common.Address) (bool, error) {
 }
 
 func (s *State) Apply(block uint64, update common.Update) (<-chan error, error) {
-
-	// init potentially empty accounts with empty code hash,
-	for _, address := range update.CreatedAccounts {
-		accountKey := s.embedding.getBasicDataKey(address)
-		value := s.trie.Get(accountKey)
-		var empty [28]byte
-		// empty accnout has empty code size, nonce, and balance
-		if bytes.Equal(value[4:32], empty[:]) {
-			codeHashKey := s.embedding.getCodeHashKey(address)
-			s.trie.Set(accountKey, value) // must be initialized to empty account
-			s.trie.Set(codeHashKey, trie.Value(types.EmptyCodeHash))
-		}
-	}
 
 	for _, update := range update.Nonces {
 		key := s.embedding.getBasicDataKey(update.Account)

--- a/go/database/vt/reference/state_test.go
+++ b/go/database/vt/reference/state_test.go
@@ -475,9 +475,11 @@ func TestState_SingleAccountFittingInASingleNode_HasSameCommitmentAsReference(t 
 	addr1 := common.Address{1}
 
 	update := common.Update{
-		CreatedAccounts: []common.Address{addr1}, // we expect the account must be explicitly created
 		Balances: []common.BalanceUpdate{
 			{Account: addr1, Balance: amount.New(1)},
+		},
+		Codes: []common.CodeUpdate{
+			{Account: addr1, Code: []byte{1, 2, 3}},
 		},
 	}
 
@@ -493,39 +495,6 @@ func TestState_SingleAccountFittingInASingleNode_HasSameCommitmentAsReference(t 
 	_, err = reference.Apply(0, update)
 	require.NoError(err)
 
-	want, err := reference.GetCommitment().Await().Get()
-	require.NoError(err)
-
-	require.Equal(want, hash)
-}
-
-func TestState_Account_CodeHash_Initialised_With_Eth_Empty_Hash(t *testing.T) {
-	require := require.New(t)
-
-	addr1 := common.Address{1}
-
-	update := common.Update{
-		CreatedAccounts: []common.Address{addr1}, // we expect the account must be explicitly created
-		Balances: []common.BalanceUpdate{
-			{Account: addr1, Balance: amount.New(1)},
-		},
-	}
-
-	state := newState()
-	_, err := state.Apply(0, update)
-	require.NoError(err)
-
-	codeHash, err := state.GetCodeHash(addr1)
-	require.NoError(err)
-	require.Equal(common.Hash(types.EmptyCodeHash), codeHash)
-
-	hash, err := state.GetCommitment().Await().Get()
-	require.NoError(err)
-
-	reference, err := newRefState(t)
-	require.NoError(err)
-	_, err = reference.Apply(0, update)
-	require.NoError(err)
 	want, err := reference.GetCommitment().Await().Get()
 	require.NoError(err)
 

--- a/go/database/vt/state_test.go
+++ b/go/database/vt/state_test.go
@@ -27,35 +27,6 @@ import (
 	_ "github.com/0xsoniclabs/carmen/go/state/gostate/experimental"
 )
 
-func TestState_CreateAccount_Hash_Matches(t *testing.T) {
-	stateFactories, err := initTestedStates()
-	require.NoError(t, err, "failed to initialize tested states")
-
-	for _, factory := range stateFactories {
-		t.Run(fmt.Sprintf("state_%d_%s", factory.config.Schema, factory.config.Variant), func(t *testing.T) {
-			t.Parallel()
-			state, err := factory.newState(t)
-			require.NoError(t, err, "failed to initialize tested state")
-
-			defer func() {
-				require.NoError(t, state.Close(), "failed to close state")
-			}()
-
-			addr := common.Address{1}
-			update := common.Update{}
-			update.CreatedAccounts = append(update.CreatedAccounts, addr)
-
-			_, err = state.Apply(0, update)
-			require.NoError(t, err, "failed to apply update")
-
-			// check hash consistency
-			hash, err := state.GetHash()
-			require.NoError(t, err, "failed to get hash")
-			require.NotEmpty(t, hash, "hash should not be empty")
-		})
-	}
-}
-
 func TestState_Insert_Single_Values_One_Account_One_Storage(t *testing.T) {
 	stateFactories, err := initTestedStates()
 	require.NoError(t, err, "failed to initialize tested states")
@@ -75,8 +46,8 @@ func TestState_Insert_Single_Values_One_Account_One_Storage(t *testing.T) {
 			key := common.Key{1}
 			value := common.Value{1}
 
-			update.CreatedAccounts = append(update.CreatedAccounts, addr)
 			update.Nonces = append(update.Nonces, common.NonceUpdate{Account: addr, Nonce: common.ToNonce(1)})
+			update.Codes = append(update.Codes, common.CodeUpdate{Account: addr, Code: []byte{1, 2, 3}})
 			update.Balances = append(update.Balances, common.BalanceUpdate{Account: addr, Balance: amount.New(1)})
 			update.Slots = append(update.Slots, common.SlotUpdate{Account: addr, Key: key, Value: value})
 
@@ -125,9 +96,9 @@ func TestState_CreateAccounts_In_Blocks_Accounts_Updated(t *testing.T) {
 				update := common.Update{}
 				for j := 0; j < numInsertsPerBlock; j++ {
 					addr := common.Address{byte(j), byte(j >> 8)}
-					update.CreatedAccounts = append(update.CreatedAccounts, addr)
 					update.Nonces = append(update.Nonces, common.NonceUpdate{Account: addr, Nonce: common.ToNonce(uint64(i * j))})
 					update.Balances = append(update.Balances, common.BalanceUpdate{Account: addr, Balance: amount.New(uint64(i * j))})
+					update.Codes = append(update.Codes, common.CodeUpdate{Account: addr, Code: []byte{}})
 				}
 				_, err = state.Apply(uint64(i), update)
 				require.NoError(t, err, "failed to apply block %d", i)
@@ -286,9 +257,11 @@ func TestState_Storage_Leading_Zeros_HashesMatch(t *testing.T) {
 	value := common.Value{0, 0, 0, 1}
 
 	update := common.Update{
-		CreatedAccounts: []common.Address{addr1},
 		Balances: []common.BalanceUpdate{
 			{Account: addr1, Balance: amount.New(1)},
+		},
+		Codes: []common.CodeUpdate{
+			{Account: addr1, Code: []byte{}},
 		},
 		Slots: []common.SlotUpdate{
 			{Account: addr1, Key: common.Key{0, 0, 0, 1}, Value: value},

--- a/go/state/externalstate/external_state_test.go
+++ b/go/state/externalstate/external_state_test.go
@@ -41,23 +41,13 @@ func TestAccountsAreInitiallyUnknown(t *testing.T) {
 	})
 }
 
-func TestAccountsCanBeCreated(t *testing.T) {
-	runForEachExternalConfig(t, func(t *testing.T, state state.State, config state.Configuration) {
-		state.Apply(0, common.Update{CreatedAccounts: []common.Address{address1}})
-		account_state, _ := state.Exists(address1)
-		if account_state != true {
-			t.Errorf("Created account does not exist, got %v", account_state)
-		}
-	})
-}
-
 func TestAccountsCanBeDeleted(t *testing.T) {
 	runForEachExternalConfig(t, func(t *testing.T, state state.State, config state.Configuration) {
 		if config.Schema == 6 {
 			t.Skip("Schema 6 does not support account existence checks")
 		}
 
-		state.Apply(0, common.Update{CreatedAccounts: []common.Address{address1}})
+		state.Apply(0, common.Update{Balances: []common.BalanceUpdate{{Account: address1, Balance: balance1}}})
 		state.Apply(1, common.Update{DeletedAccounts: []common.Address{address1}})
 		account_state, _ := state.Exists(address1)
 		if account_state != false {

--- a/go/state/gostate/archive_state_test.go
+++ b/go/state/gostate/archive_state_test.go
@@ -227,11 +227,10 @@ func TestArchiveState_Export(t *testing.T) {
 	newAmount := amount.New(1)
 
 	update := common.Update{
-		CreatedAccounts: []common.Address{newAddr},
-		Balances:        []common.BalanceUpdate{{Account: newAddr, Balance: newAmount}},
-		Nonces:          []common.NonceUpdate{{Account: newAddr, Nonce: common.ToNonce(1)}},
-		Codes:           []common.CodeUpdate{{Account: newAddr, Code: []byte{0x1}}},
-		Slots:           []common.SlotUpdate{{Account: newAddr, Key: common.Key{byte(1)}, Value: common.Value{byte(1)}}},
+		Balances: []common.BalanceUpdate{{Account: newAddr, Balance: newAmount}},
+		Nonces:   []common.NonceUpdate{{Account: newAddr, Nonce: common.ToNonce(1)}},
+		Codes:    []common.CodeUpdate{{Account: newAddr, Code: []byte{0x1}}},
+		Slots:    []common.SlotUpdate{{Account: newAddr, Key: common.Key{byte(1)}, Value: common.Value{byte(1)}}},
 	}
 
 	err = trie.Add(2, update, nil)
@@ -270,11 +269,10 @@ func TestArchiveState_Export_CanBeCancelled(t *testing.T) {
 	newAmount := amount.New(1)
 
 	update := common.Update{
-		CreatedAccounts: []common.Address{newAddr},
-		Balances:        []common.BalanceUpdate{{Account: newAddr, Balance: newAmount}},
-		Nonces:          []common.NonceUpdate{{Account: newAddr, Nonce: common.ToNonce(1)}},
-		Codes:           []common.CodeUpdate{{Account: newAddr, Code: []byte{0x1}}},
-		Slots:           []common.SlotUpdate{{Account: newAddr, Key: common.Key{byte(1)}, Value: common.Value{byte(1)}}},
+		Balances: []common.BalanceUpdate{{Account: newAddr, Balance: newAmount}},
+		Nonces:   []common.NonceUpdate{{Account: newAddr, Nonce: common.ToNonce(1)}},
+		Codes:    []common.CodeUpdate{{Account: newAddr, Code: []byte{0x1}}},
+		Slots:    []common.SlotUpdate{{Account: newAddr, Key: common.Key{byte(1)}, Value: common.Value{byte(1)}}},
 	}
 
 	err = trie.Add(2, update, nil)

--- a/go/state/gostate/go_schema5_test.go
+++ b/go/state/gostate/go_schema5_test.go
@@ -36,8 +36,7 @@ func TestScheme5_Archive_And_Live_Must_Be_InSync(t *testing.T) {
 
 	addBlock := func(block uint64, db state.State) {
 		update := common.Update{
-			CreatedAccounts: []common.Address{{byte(block)}},
-			Balances:        []common.BalanceUpdate{{Account: common.Address{byte(block)}, Balance: amount.New(100)}},
+			Balances: []common.BalanceUpdate{{Account: common.Address{byte(block)}, Balance: amount.New(100)}},
 		}
 		if _, err := db.Apply(block, update); err != nil {
 			t.Fatalf("cannot add block: %v", err)
@@ -126,8 +125,7 @@ func TestCarmen_Empty_Archive_And_Live_Must_Be_InSync(t *testing.T) {
 	for i := 0; i < blocks; i++ {
 		block := uint64(i)
 		update := common.Update{
-			CreatedAccounts: []common.Address{{byte(block)}},
-			Balances:        []common.BalanceUpdate{{Account: common.Address{byte(block)}, Balance: amount.New(100)}},
+			Balances: []common.BalanceUpdate{{Account: common.Address{byte(block)}, Balance: amount.New(100)}},
 		}
 		if _, err := db.Apply(block, update); err != nil {
 			t.Fatalf("cannot add block: %v", err)

--- a/go/state/gostate/go_state_test.go
+++ b/go/state/gostate/go_state_test.go
@@ -131,11 +131,10 @@ func TestBasicOperations(t *testing.T) {
 
 			// fill-in values
 			_, err = state.Apply(12, common.Update{
-				CreatedAccounts: []common.Address{address1},
-				Nonces:          []common.NonceUpdate{{Account: address1, Nonce: common.Nonce{123}}},
-				Balances:        []common.BalanceUpdate{{Account: address2, Balance: amount.New(45)}},
-				Slots:           []common.SlotUpdate{{Account: address1, Key: key1, Value: common.Value{67}}},
-				Codes:           []common.CodeUpdate{{Account: address1, Code: []byte{0x12, 0x34}}},
+				Nonces:   []common.NonceUpdate{{Account: address1, Nonce: common.Nonce{123}}},
+				Balances: []common.BalanceUpdate{{Account: address2, Balance: amount.New(45)}},
+				Slots:    []common.SlotUpdate{{Account: address1, Key: key1, Value: common.Value{67}}},
+				Codes:    []common.CodeUpdate{{Account: address1, Code: []byte{0x12, 0x34}}},
 			})
 			if err != nil {
 				t.Errorf("Error: %s", err)
@@ -200,10 +199,9 @@ func TestDeletingAccounts(t *testing.T) {
 
 			// fill-in values
 			update := common.Update{
-				CreatedAccounts: []common.Address{address1},
-				Nonces:          []common.NonceUpdate{{Account: address1, Nonce: common.Nonce{123}}},
-				Balances:        []common.BalanceUpdate{{Account: address2, Balance: amount.New(45)}},
-				Codes:           []common.CodeUpdate{{Account: address1, Code: []byte{0x12, 0x34}}},
+				Nonces:   []common.NonceUpdate{{Account: address1, Nonce: common.Nonce{123}}},
+				Balances: []common.BalanceUpdate{{Account: address2, Balance: amount.New(45)}},
+				Codes:    []common.CodeUpdate{{Account: address1, Code: []byte{0x12, 0x34}}},
 			}
 			if _, err := state.Apply(1, update); err != nil {
 				t.Errorf("failed to update state: %v", err)
@@ -277,81 +275,6 @@ func TestMoreInserts(t *testing.T) {
 	}
 }
 
-func TestRecreatingAccountsPreservesEverythingButTheStorage(t *testing.T) {
-	for _, config := range initGoStates() {
-		t.Run(config.name(), func(t *testing.T) {
-			if config.config.Schema == 0 || config.config.Schema == 6 {
-				t.Skipf("scheme %d not supported", config.config.Schema)
-			}
-			if strings.Contains(config.name(), "flat") {
-				t.Skipf("flat variants not supported")
-			}
-
-			state, err := config.createState(t.TempDir())
-			if err != nil {
-				t.Fatalf("failed to initialize state %s; %s", config.name(), err)
-			}
-			defer state.Close()
-
-			code1 := []byte{1, 2, 3}
-
-			// create an account and set some of its properties
-			update := common.Update{
-				CreatedAccounts: []common.Address{address1},
-				Balances:        []common.BalanceUpdate{{Account: address1, Balance: balance1}},
-				Nonces:          []common.NonceUpdate{{Account: address1, Nonce: nonce1}},
-				Codes:           []common.CodeUpdate{{Account: address1, Code: code1}},
-				Slots:           []common.SlotUpdate{{Account: address1, Key: key1, Value: val1}},
-			}
-			if _, err := state.Apply(1, update); err != nil {
-				t.Errorf("failed to update state: %v", err)
-			}
-
-			if exists, err := state.Exists(address1); !exists || err != nil {
-				t.Errorf("account does not exist, err %v", err)
-			}
-
-			if got, err := state.GetBalance(address1); got != balance1 || err != nil {
-				t.Errorf("unexpected balance, wanted %v, got %v, err %v", balance1, got, err)
-			}
-
-			if got, err := state.GetNonce(address1); got != nonce1 || err != nil {
-				t.Errorf("unexpected nonce, wanted %v, got %v, err %v", nonce1, got, err)
-			}
-
-			if got, err := state.GetCode(address1); !bytes.Equal(got, code1) || err != nil {
-				t.Errorf("unexpected code, wanted %v, got %v, err %v", code1, got, err)
-			}
-
-			if got, err := state.GetStorage(address1, key1); got != val1 || err != nil {
-				t.Errorf("unexpected storage, wanted %v, got %v, err %v", val1, got, err)
-			}
-
-			// re-creating the account preserves everything but the state.
-			if _, err := state.Apply(2, common.Update{CreatedAccounts: []common.Address{address1}}); err != nil {
-				t.Errorf("failed to recreate account: %v", err)
-			}
-
-			if exists, err := state.Exists(address1); !exists || err != nil {
-				t.Errorf("account should still exist, err %v", err)
-			}
-			if got, err := state.GetBalance(address1); got != balance1 || err != nil {
-				t.Errorf("unexpected balance, wanted %v, got %v, err %v", balance1, got, err)
-			}
-			if got, err := state.GetNonce(address1); got != nonce1 || err != nil {
-				t.Errorf("unexpected nonce, wanted %v, got %v, err %v", nonce1, got, err)
-			}
-			if got, err := state.GetCode(address1); !bytes.Equal(got, code1) || err != nil {
-				t.Errorf("unexpected code, wanted %v, got %v, err %v", code1, got, err)
-			}
-			if got, err := state.GetStorage(address1, key1); got != val0 || err != nil {
-				t.Errorf("failed to clear the storage, wanted %v, got %v, err %v", val0, got, err)
-			}
-
-		})
-	}
-}
-
 func TestHashing(t *testing.T) {
 	states := initGoStates()
 	var hashes = make([][]common.Hash, len(states))
@@ -372,7 +295,7 @@ func TestHashing(t *testing.T) {
 				t.Fatalf("unable to get state hash; %v", err)
 			}
 
-			state.Apply(1, common.Update{CreatedAccounts: []common.Address{address1}})
+			state.Apply(1, common.Update{Balances: []common.BalanceUpdate{{Account: address1, Balance: balance1}}})
 			hash1, err := state.GetCommitment().Await().Get()
 			if err != nil {
 				t.Fatalf("unable to get state hash; %v", err)
@@ -387,7 +310,7 @@ func TestHashing(t *testing.T) {
 				t.Errorf("hash of changed state not changed")
 			}
 
-			state.Apply(3, common.Update{Balances: []common.BalanceUpdate{{Account: address1, Balance: balance1}}})
+			state.Apply(3, common.Update{Balances: []common.BalanceUpdate{{Account: address1, Balance: balance2}}})
 			hash3, err := state.GetCommitment().Await().Get()
 			if err != nil {
 				t.Fatalf("unable to get state hash; %v", err)
@@ -592,8 +515,7 @@ func TestState_Flush_Or_Close_Corrupted_State_Detected(t *testing.T) {
 	db := newGoState(liveDB, nil, []func(){})
 
 	update := common.Update{
-		CreatedAccounts: []common.Address{{0xA}},
-		Balances:        []common.BalanceUpdate{{Account: common.Address{0xA}, Balance: amount.New(10)}},
+		Balances: []common.BalanceUpdate{{Account: common.Address{0xA}, Balance: amount.New(10)}},
 	}
 
 	// the same result many times
@@ -655,8 +577,7 @@ func TestState_Apply_CannotCallRepeatedly_OnError(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		update := common.Update{
-			CreatedAccounts: []common.Address{{0xA}},
-			Balances:        []common.BalanceUpdate{{Account: common.Address{0xA}, Balance: amount.New(10)}},
+			Balances: []common.BalanceUpdate{{Account: common.Address{0xA}, Balance: amount.New(10)}},
 		}
 		if _, err := db.Apply(uint64(i), update); !errors.Is(err, injectedErr) {
 			t.Errorf("each operation should fail: %v", err)

--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -1288,7 +1288,6 @@ func (s *stateDB) EndBlock(block uint64) <-chan error {
 	for addr, value := range s.accounts {
 		if value.original != value.current {
 			if value.current == accountExists {
-				update.AppendCreateAccount(addr)
 				delete(nonExistingAccounts, addr)
 			}
 		}
@@ -1548,7 +1547,7 @@ type bulkLoad struct {
 }
 
 func (l *bulkLoad) CreateAccount(addr common.Address) {
-	l.update.AppendCreateAccount(addr)
+	// No-op
 }
 
 func (l *bulkLoad) SetBalance(addr common.Address, balance amount.Amount) {

--- a/go/state/state_db_and_state_test.go
+++ b/go/state/state_db_and_state_test.go
@@ -62,6 +62,9 @@ func TestCarmen_CanHandleMaximumBalance(t *testing.T) {
 			db.AddBalance(addr1, minBalance)
 			db.AddBalance(addr2, minBalance)
 			db.AddBalance(addr3, maxBalance)
+			db.SetCode(addr1, []byte{1, 2, 3})
+			db.SetCode(addr2, []byte{4, 5, 6})
+			db.SetCode(addr3, []byte{7, 8, 9})
 			db.EndTransaction()
 			db.EndBlock(0)
 
@@ -84,6 +87,7 @@ func TestCarmen_CanHandleMaximumBalance(t *testing.T) {
 
 			db.EndTransaction()
 			db.EndBlock(1)
+			require.NoError(t, db.Check(), "state DB check failed after block 1")
 
 			// Third block: check modified balances.
 			db.BeginBlock()
@@ -101,6 +105,7 @@ func TestCarmen_CanHandleMaximumBalance(t *testing.T) {
 
 			db.EndTransaction()
 			db.EndBlock(2)
+			require.NoError(t, db.Check(), "state DB check failed after block 1")
 
 			if err := db.Flush(); err != nil {
 				t.Fatalf("failed to flush the DB: %v", err)
@@ -216,6 +221,7 @@ func TestCarmenBulkLoadsCanBeInterleavedWithRegularUpdates(t *testing.T) {
 				address := common.Address{byte(i + 1)}
 				load.CreateAccount(address)
 				load.SetNonce(address, 1)
+				load.SetCode(address, []byte{})
 				if err := load.Close(); err != nil {
 					t.Errorf("bulk-insert failed: %v", err)
 				}
@@ -258,6 +264,11 @@ func testCarmenStateDbHashAfterModification(t *testing.T, mod func(s state.State
 	for i := 0; i < 3; i++ {
 		for _, config := range initStates() {
 			config := config
+			if strings.Contains(config.name(), "geth-leveldb") {
+				// This is the only implementation that sets the empty code hash by default.
+				// Therefore tests not modifying the code will fail.
+				t.Skipf("geth-leveldb requires setting the empty code hash in each update")
+			}
 			t.Run(fmt.Sprintf("%v/run=%d", config.name(), i), func(t *testing.T) {
 				t.Parallel()
 				store, err := config.createState(t.TempDir())
@@ -661,6 +672,7 @@ func TestStateDBSupportsConcurrentAccesses(t *testing.T) {
 						stateDb.BeginTransaction()
 						// Perform a read + update operation.
 						stateDb.AddBalance(address1, amount.New(1))
+						stateDb.SetCode(address1, []byte{})
 						stateDb.EndTransaction()
 						if isPrimary {
 							stateDb.(state.StateDB).EndBlock(uint64(block))
@@ -934,9 +946,6 @@ func TestStateDB_AccountsAreCreatedImplicitlyWhenSettingState(t *testing.T) {
 	}
 
 	for _, config := range initStates() {
-		if config.config.Schema < 4 {
-			continue
-		}
 		for name, fn := range ops {
 			t.Run(config.name()+"_"+name, func(t *testing.T) {
 				t.Parallel()
@@ -946,6 +955,8 @@ func TestStateDB_AccountsAreCreatedImplicitlyWhenSettingState(t *testing.T) {
 					fn(s)
 				})
 				without := executeOpOnCleanStateDB(t, config, func(s state.StateDB) {
+					// CreateAccount sets empty code, which is required.
+					s.SetCode(address1, []byte{})
 					fn(s)
 				})
 				require.Equal(without, with)

--- a/go/state/state_db_and_state_test.go
+++ b/go/state/state_db_and_state_test.go
@@ -105,7 +105,7 @@ func TestCarmen_CanHandleMaximumBalance(t *testing.T) {
 
 			db.EndTransaction()
 			db.EndBlock(2)
-			require.NoError(t, db.Check(), "state DB check failed after block 1")
+			require.NoError(t, db.Check(), "state DB check failed after block 2")
 
 			if err := db.Flush(); err != nil {
 				t.Fatalf("failed to flush the DB: %v", err)

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -186,10 +186,9 @@ func TestStateDB_RecreatingAnAccountSetsStorageToZero(t *testing.T) {
 	mock.EXPECT().Exists(address1).Return(false, nil)
 	mock.EXPECT().Check().AnyTimes()
 	mock.EXPECT().Apply(uint64(1), common.Update{
-		CreatedAccounts: []common.Address{address1},
-		Balances:        []common.BalanceUpdate{{Account: address1}},
-		Nonces:          []common.NonceUpdate{{Account: address1}},
-		Codes:           []common.CodeUpdate{{Account: address1, Code: []byte{}}},
+		Balances: []common.BalanceUpdate{{Account: address1}},
+		Nonces:   []common.NonceUpdate{{Account: address1}},
+		Codes:    []common.CodeUpdate{{Account: address1, Code: []byte{}}},
 	})
 
 	db.CreateAccount(address1)
@@ -245,10 +244,9 @@ func TestStateDB_RecreatingAccountResetsStorage(t *testing.T) {
 	mock.EXPECT().Exists(address1).Return(false, nil)
 	mock.EXPECT().Check().AnyTimes()
 	mock.EXPECT().Apply(uint64(1), common.Update{
-		CreatedAccounts: []common.Address{address1},
-		Balances:        []common.BalanceUpdate{{Account: address1}},
-		Nonces:          []common.NonceUpdate{{Account: address1, Nonce: common.Nonce{0, 0, 0, 0, 0, 0, 0, 1}}},
-		Codes:           []common.CodeUpdate{{Account: address1, Code: []byte{}}},
+		Balances: []common.BalanceUpdate{{Account: address1}},
+		Nonces:   []common.NonceUpdate{{Account: address1, Nonce: common.Nonce{0, 0, 0, 0, 0, 0, 0, 1}}},
+		Codes:    []common.CodeUpdate{{Account: address1, Code: []byte{}}},
 	})
 
 	// First transaction creates an account and sets some storage values.
@@ -306,11 +304,10 @@ func TestStateDB_RecreatingAccountResetsStorageButRetainsNewState(t *testing.T) 
 
 	// At the end the account is recreated with the new state.
 	mock.EXPECT().Apply(uint64(123), common.Update{
-		CreatedAccounts: []common.Address{address1},
-		Balances:        []common.BalanceUpdate{{Account: address1}},
-		Nonces:          []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(12)}},
-		Codes:           []common.CodeUpdate{{Account: address1, Code: []byte{}}},
-		Slots:           []common.SlotUpdate{{Account: address1, Key: key1, Value: val2}},
+		Balances: []common.BalanceUpdate{{Account: address1}},
+		Nonces:   []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(12)}},
+		Codes:    []common.CodeUpdate{{Account: address1, Code: []byte{}}},
+		Slots:    []common.SlotUpdate{{Account: address1, Key: key1, Value: val2}},
 	})
 
 	if got := db.GetState(address1, key1); got != val1 {
@@ -675,10 +672,9 @@ func TestStateDB_DestroyingAndRecreatingAnAccountInTheSameTransactionCallsDelete
 
 	// The account is to be re-created.
 	mock.EXPECT().Apply(uint64(1), common.Update{
-		CreatedAccounts: []common.Address{address1},
-		Balances:        []common.BalanceUpdate{{Account: address1}},
-		Nonces:          []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(1)}},
-		Codes:           []common.CodeUpdate{{Account: address1, Code: []byte{}}},
+		Balances: []common.BalanceUpdate{{Account: address1}},
+		Nonces:   []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(1)}},
+		Codes:    []common.CodeUpdate{{Account: address1, Code: []byte{}}},
 	})
 
 	// In a transaction we destroy the account and recreate it. This should cause
@@ -709,10 +705,9 @@ func TestStateDB_DoubleDestroyedAccountThatIsOnceRolledBackIsStillCleared(t *tes
 
 	// The account is to be re-created.
 	mock.EXPECT().Apply(uint64(1), common.Update{
-		CreatedAccounts: []common.Address{address1},
-		Balances:        []common.BalanceUpdate{{Account: address1}},
-		Nonces:          []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(1)}},
-		Codes:           []common.CodeUpdate{{Account: address1, Code: []byte{}}},
+		Balances: []common.BalanceUpdate{{Account: address1}},
+		Nonces:   []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(1)}},
+		Codes:    []common.CodeUpdate{{Account: address1, Code: []byte{}}},
 	})
 
 	// In a transaction we destroy the account, re-create it, destroy it and roll back
@@ -917,11 +912,10 @@ func TestStateDB_RepeatedSuicide(t *testing.T) {
 	// The original account is expected to be deleted, the last created one is expected to be really created.
 	newBalance := amount.New(456)
 	mock.EXPECT().Apply(uint64(1), common.Update{
-		CreatedAccounts: []common.Address{address1},
-		Balances:        []common.BalanceUpdate{{Account: address1, Balance: newBalance}},
-		Nonces:          []common.NonceUpdate{{Account: address1}},
-		Codes:           []common.CodeUpdate{{Account: address1, Code: []byte{}}},
-		Slots:           []common.SlotUpdate{{Account: address1, Key: key2, Value: val2}},
+		Balances: []common.BalanceUpdate{{Account: address1, Balance: newBalance}},
+		Nonces:   []common.NonceUpdate{{Account: address1}},
+		Codes:    []common.CodeUpdate{{Account: address1, Code: []byte{}}},
+		Slots:    []common.SlotUpdate{{Account: address1, Key: key2, Value: val2}},
 	})
 
 	// The changes are applied to the state at the end of the block.
@@ -1084,10 +1078,9 @@ func TestStateDB_CreatedAccountsAreStoredAtEndOfBlock(t *testing.T) {
 	mock.EXPECT().Check().AnyTimes()
 	mock.EXPECT().Exists(address1).Return(false, nil)
 	mock.EXPECT().Apply(uint64(1), common.Update{
-		CreatedAccounts: []common.Address{address1},
-		Balances:        []common.BalanceUpdate{{Account: address1}},
-		Nonces:          []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(1)}},
-		Codes:           []common.CodeUpdate{{Account: address1, Code: []byte{}}},
+		Balances: []common.BalanceUpdate{{Account: address1}},
+		Nonces:   []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(1)}},
+		Codes:    []common.CodeUpdate{{Account: address1, Code: []byte{}}},
 	})
 
 	db.CreateAccount(address1)
@@ -1105,10 +1098,9 @@ func TestStateDB_CreatedAccountsAreForgottenAtEndOfBlock(t *testing.T) {
 	mock.EXPECT().Check().AnyTimes()
 	mock.EXPECT().Exists(address1).Return(false, nil)
 	mock.EXPECT().Apply(uint64(1), common.Update{
-		CreatedAccounts: []common.Address{address1},
-		Balances:        []common.BalanceUpdate{{Account: address1}},
-		Nonces:          []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(1)}},
-		Codes:           []common.CodeUpdate{{Account: address1, Code: []byte{}}},
+		Balances: []common.BalanceUpdate{{Account: address1}},
+		Nonces:   []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(1)}},
+		Codes:    []common.CodeUpdate{{Account: address1, Code: []byte{}}},
 	})
 	mock.EXPECT().Apply(uint64(2), common.Update{})
 
@@ -1285,8 +1277,7 @@ func TestStateDB_SettingTheBalanceCreatesAccount(t *testing.T) {
 	mock.EXPECT().Check().AnyTimes()
 	mock.EXPECT().Exists(address1).Return(false, nil)
 	mock.EXPECT().Apply(uint64(1), common.Update{
-		CreatedAccounts: []common.Address{address1},
-		Balances:        []common.BalanceUpdate{{Account: address1, Balance: addedBalance}},
+		Balances: []common.BalanceUpdate{{Account: address1, Balance: addedBalance}},
 	})
 
 	db.AddBalance(address1, addedBalance)
@@ -1382,10 +1373,9 @@ func TestStateDB_SettingTheNonceMakesAccountNonEmpty(t *testing.T) {
 	mock.EXPECT().Check().AnyTimes()
 	mock.EXPECT().Exists(address1).Return(false, nil)
 	mock.EXPECT().Apply(uint64(1), common.Update{
-		CreatedAccounts: []common.Address{address1},
-		Balances:        []common.BalanceUpdate{{Account: address1}},
-		Nonces:          []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(1)}},
-		Codes:           []common.CodeUpdate{{Account: address1, Code: []byte{}}},
+		Balances: []common.BalanceUpdate{{Account: address1}},
+		Nonces:   []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(1)}},
+		Codes:    []common.CodeUpdate{{Account: address1, Code: []byte{}}},
 	})
 
 	db.CreateAccount(address1)
@@ -1433,9 +1423,8 @@ func TestStateDB_CreatesAccountOnNonceSetting(t *testing.T) {
 	mock.EXPECT().Check().AnyTimes()
 	mock.EXPECT().Exists(address1).Return(false, nil)
 	mock.EXPECT().Apply(uint64(1), common.Update{
-		CreatedAccounts: []common.Address{address1},
-		Balances:        []common.BalanceUpdate{{Account: address1}},
-		Nonces:          []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(1)}},
+		Balances: []common.BalanceUpdate{{Account: address1}},
+		Nonces:   []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(1)}},
 	})
 
 	db.SetNonce(address1, 1)
@@ -1688,10 +1677,9 @@ func TestStateDB_NonceOfADeletedAccountIsZero(t *testing.T) {
 	mock.EXPECT().Check().AnyTimes()
 	mock.EXPECT().Exists(address1).Return(false, nil)
 	mock.EXPECT().Apply(uint64(1), common.Update{
-		CreatedAccounts: []common.Address{address1},
-		Balances:        []common.BalanceUpdate{{Account: address1}},
-		Nonces:          []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(12)}},
-		Codes:           []common.CodeUpdate{{Account: address1, Code: []byte{}}},
+		Balances: []common.BalanceUpdate{{Account: address1}},
+		Nonces:   []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(12)}},
+		Codes:    []common.CodeUpdate{{Account: address1, Code: []byte{}}},
 	})
 
 	// Also the fetch of the Nonce value in the second transaction is expected.
@@ -2523,9 +2511,8 @@ func TestStateDB_SettingCodesCreatesAccountsImplicitly(t *testing.T) {
 	mock.EXPECT().Exists(address1).Return(false, nil)
 	want := []byte{0xAC, 0xDC}
 	mock.EXPECT().Apply(uint64(1), common.Update{
-		CreatedAccounts: []common.Address{address1},
-		Balances:        []common.BalanceUpdate{{Account: address1}},
-		Codes:           []common.CodeUpdate{{Account: address1, Code: want}},
+		Balances: []common.BalanceUpdate{{Account: address1}},
+		Codes:    []common.CodeUpdate{{Account: address1, Code: want}},
 	})
 
 	db.SetCode(address1, want)
@@ -3969,11 +3956,10 @@ func TestStateDB_BulkLoadReachesState(t *testing.T) {
 	code := []byte{1, 2, 3}
 
 	mock.EXPECT().Apply(uint64(0), common.Update{
-		CreatedAccounts: []common.Address{address1},
-		Balances:        []common.BalanceUpdate{{Account: address1, Balance: balance}},
-		Nonces:          []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(14)}},
-		Codes:           []common.CodeUpdate{{Account: address1, Code: code}},
-		Slots:           []common.SlotUpdate{{Account: address1, Key: key1, Value: val1}},
+		Balances: []common.BalanceUpdate{{Account: address1, Balance: balance}},
+		Nonces:   []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(14)}},
+		Codes:    []common.CodeUpdate{{Account: address1, Code: code}},
+		Slots:    []common.SlotUpdate{{Account: address1, Key: key1, Value: val1}},
 	})
 	mock.EXPECT().Flush().Return(nil)
 	mock.EXPECT().GetCommitment().Return(future.Immediate(result.Ok(common.Hash{})))

--- a/go/state/state_test.go
+++ b/go/state/state_test.go
@@ -141,6 +141,9 @@ func testHashAfterModification(t *testing.T, mod func(t *testing.T, schema state
 	}
 
 	testEachConfiguration(t, func(t *testing.T, config *namedStateConfig, s state.State) {
+		if strings.Contains(config.name(), "go-geth-leveldb_s6") {
+			t.Skipf("known hash incompatibility due to empty code hash handling")
+		}
 		mod(t, config.config.Schema, s)
 		got, err := s.GetHash()
 		if err != nil {
@@ -161,7 +164,7 @@ func TestEmptyHash(t *testing.T) {
 func TestAddressHashes(t *testing.T) {
 	testHashAfterModification(t, func(t *testing.T, schema state.Schema, s state.State) {
 		s.Apply(0, common.Update{
-			CreatedAccounts: []common.Address{address1},
+			Balances: []common.BalanceUpdate{{Account: common.Address{0x01}, Balance: amount.New(100)}},
 		})
 	})
 }
@@ -169,7 +172,11 @@ func TestAddressHashes(t *testing.T) {
 func TestMultipleAddressHashes(t *testing.T) {
 	testHashAfterModification(t, func(t *testing.T, schema state.Schema, s state.State) {
 		s.Apply(0, common.Update{
-			CreatedAccounts: []common.Address{address1, address2, address3},
+			Balances: []common.BalanceUpdate{
+				{Account: address1, Balance: balance1},
+				{Account: address2, Balance: balance2},
+				{Account: address3, Balance: balance3},
+			},
 		})
 	})
 }
@@ -180,7 +187,7 @@ func TestDeletedAddressHashes(t *testing.T) {
 			t.Skipf("schema %d not supported", schema)
 		}
 		s.Apply(0, common.Update{
-			CreatedAccounts: []common.Address{address1, address2, address3},
+			Balances:        []common.BalanceUpdate{{Account: address1, Balance: balance1}},
 			DeletedAccounts: []common.Address{address1, address2},
 		})
 	})
@@ -209,7 +216,6 @@ func TestMultipleStorageHashes(t *testing.T) {
 func TestBalanceUpdateHashes(t *testing.T) {
 	testHashAfterModification(t, func(t *testing.T, schema state.Schema, s state.State) {
 		s.Apply(0, common.Update{
-			CreatedAccounts: []common.Address{address1},
 			Balances: []common.BalanceUpdate{
 				{Account: address1, Balance: balance1},
 			},
@@ -220,7 +226,6 @@ func TestBalanceUpdateHashes(t *testing.T) {
 func TestMultipleBalanceUpdateHashes(t *testing.T) {
 	testHashAfterModification(t, func(t *testing.T, schema state.Schema, s state.State) {
 		s.Apply(0, common.Update{
-			CreatedAccounts: []common.Address{address1, address2, address3},
 			Balances: []common.BalanceUpdate{
 				{Account: address1, Balance: balance1},
 				{Account: address2, Balance: balance2},
@@ -233,7 +238,6 @@ func TestMultipleBalanceUpdateHashes(t *testing.T) {
 func TestNonceUpdateHashes(t *testing.T) {
 	testHashAfterModification(t, func(t *testing.T, schema state.Schema, s state.State) {
 		s.Apply(0, common.Update{
-			CreatedAccounts: []common.Address{address1},
 			Nonces: []common.NonceUpdate{
 				{Account: address1, Nonce: nonce1},
 			},
@@ -244,7 +248,6 @@ func TestNonceUpdateHashes(t *testing.T) {
 func TestMultipleNonceUpdateHashes(t *testing.T) {
 	testHashAfterModification(t, func(t *testing.T, schema state.Schema, s state.State) {
 		s.Apply(0, common.Update{
-			CreatedAccounts: []common.Address{address1, address2, address3},
 			Nonces: []common.NonceUpdate{
 				{Account: address1, Nonce: nonce1},
 				{Account: address2, Nonce: nonce2},
@@ -281,7 +284,6 @@ func TestLargeStateHashes(t *testing.T) {
 		update := common.Update{}
 		for i := 0; i < 100; i++ {
 			address := common.Address{byte(i)}
-			update.CreatedAccounts = append(update.CreatedAccounts, address)
 			for j := 0; j < 100; j++ {
 				key := common.Key{byte(j)}
 				update.Slots = append(update.Slots, common.SlotUpdate{Account: address, Key: key, Value: common.Value{byte(i), 0, 0, byte(j)}})
@@ -322,7 +324,8 @@ func TestCodeCanBeUpdated(t *testing.T) {
 	testEachConfiguration(t, func(t *testing.T, config *namedStateConfig, s state.State) {
 		// account must exist (not aut-created in Verkle Trie)
 		if _, err := s.Apply(0, common.Update{
-			CreatedAccounts: []common.Address{address1},
+			Balances: []common.BalanceUpdate{{Account: address1, Balance: balance1}},
+			Codes:    []common.CodeUpdate{{Account: address1, Code: []byte{}}},
 		}); err != nil {
 			t.Errorf("failed to apply: %v", err)
 		}
@@ -382,7 +385,8 @@ func TestCodeHashesMatchCodes(t *testing.T) {
 	testEachConfiguration(t, func(t *testing.T, config *namedStateConfig, s state.State) {
 		// account must exist (not aut-created in Verkle Trie)
 		if _, err := s.Apply(0, common.Update{
-			CreatedAccounts: []common.Address{address1},
+			Balances: []common.BalanceUpdate{{Account: address1, Balance: balance1}},
+			Codes:    []common.CodeUpdate{{Account: address1, Code: []byte{}}},
 		}); err != nil {
 			t.Errorf("failed to apply: %v", err)
 		}
@@ -396,20 +400,10 @@ func TestCodeHashesMatchCodes(t *testing.T) {
 			t.Errorf("Invalid hash, wanted %v, got %v", hashOfEmptyCode, hash)
 		}
 
-		// Creating an account should not change this.
-		s.Apply(1, common.Update{CreatedAccounts: []common.Address{address1}})
-		hash, err = s.GetCodeHash(address1)
-		if err != nil {
-			t.Fatalf("error fetching code hash: %v", err)
-		}
-		if hash != hashOfEmptyCode {
-			t.Errorf("Invalid hash, wanted %v, got %v", hashOfEmptyCode, hash)
-		}
-
 		// Update code to non-empty code updates hash accordingly.
 		code := []byte{1, 2, 3, 4}
 		hashOfTestCode := common.GetKeccak256Hash(code)
-		s.Apply(2, common.Update{Codes: []common.CodeUpdate{{Account: address1, Code: code}}})
+		s.Apply(1, common.Update{Codes: []common.CodeUpdate{{Account: address1, Code: code}}})
 		hash, err = s.GetCodeHash(address1)
 		if err != nil {
 			t.Fatalf("error fetching code hash: %v", err)
@@ -419,7 +413,7 @@ func TestCodeHashesMatchCodes(t *testing.T) {
 		}
 
 		// Reset code to empty code updates hash accordingly.
-		s.Apply(3, common.Update{Codes: []common.CodeUpdate{{Account: address1, Code: []byte{}}}})
+		s.Apply(2, common.Update{Codes: []common.CodeUpdate{{Account: address1, Code: []byte{}}}})
 		hash, err = s.GetCodeHash(address1)
 		if err != nil {
 			t.Fatalf("error fetching code hash: %v", err)
@@ -435,7 +429,7 @@ func TestDeleteNotExistingAccount(t *testing.T) {
 		if config.config.Schema == 6 {
 			t.Skipf("scheme %d not supported", config.config.Schema)
 		}
-		if _, err := s.Apply(0, common.Update{CreatedAccounts: []common.Address{address1}}); err != nil {
+		if _, err := s.Apply(0, common.Update{Codes: []common.CodeUpdate{{Account: address1, Code: []byte{1, 2, 3}}}}); err != nil {
 			t.Fatalf("Error: %s", err)
 		}
 		if _, err := s.Apply(1, common.Update{DeletedAccounts: []common.Address{address2}}); err != nil { // deleting never-existed account
@@ -451,54 +445,6 @@ func TestDeleteNotExistingAccount(t *testing.T) {
 	})
 }
 
-func TestCreatingAccountClearsStorage(t *testing.T) {
-	testEachConfiguration(t, func(t *testing.T, config *namedStateConfig, s state.State) {
-		if config.config.Schema == 0 || config.config.Schema == 6 {
-			t.Skipf("scheme %d not supported", config.config.Schema)
-		}
-		if strings.Contains(config.name(), "flat") {
-			t.Skipf("schema with flat variant does not support account recreation")
-		}
-
-		zero := common.Value{}
-		if _, err := s.Apply(0, common.Update{CreatedAccounts: []common.Address{address1}}); err != nil {
-			t.Errorf("failed to create account: %v", err)
-		}
-
-		val, err := s.GetStorage(address1, key1)
-		if err != nil {
-			t.Errorf("failed to fetch storage value: %v", err)
-		}
-		if val != zero {
-			t.Errorf("storage slot are initially not zero")
-		}
-
-		if _, err = s.Apply(1, common.Update{Slots: []common.SlotUpdate{{Account: address1, Key: key1, Value: val1}}}); err != nil {
-			t.Errorf("failed to update storage slot: %v", err)
-		}
-
-		val, err = s.GetStorage(address1, key1)
-		if err != nil {
-			t.Errorf("failed to fetch storage value: %v", err)
-		}
-		if val != val1 {
-			t.Errorf("storage slot update did not take effect")
-		}
-
-		if _, err := s.Apply(2, common.Update{CreatedAccounts: []common.Address{address1}}); err != nil {
-			t.Fatalf("Error: %s", err)
-		}
-
-		val, err = s.GetStorage(address1, key1)
-		if err != nil {
-			t.Errorf("failed to fetch storage value: %v", err)
-		}
-		if val != zero {
-			t.Errorf("account creation did not clear storage slots")
-		}
-	})
-}
-
 func TestDeletingAccountsClearsStorage(t *testing.T) {
 	testEachConfiguration(t, func(t *testing.T, config *namedStateConfig, s state.State) {
 		if config.config.Schema == 0 || config.config.Schema == 6 {
@@ -509,7 +455,7 @@ func TestDeletingAccountsClearsStorage(t *testing.T) {
 		}
 
 		zero := common.Value{}
-		if _, err := s.Apply(0, common.Update{CreatedAccounts: []common.Address{address1}}); err != nil {
+		if _, err := s.Apply(0, common.Update{Codes: []common.CodeUpdate{{Account: address1, Code: []byte{1, 2, 3}}}}); err != nil {
 			t.Errorf("failed to create account: %v", err)
 		}
 
@@ -545,7 +491,6 @@ func TestArchive(t *testing.T) {
 		if config.config.Archive == state.NoArchive {
 			continue
 		}
-		config := config
 		t.Run(config.name(), func(t *testing.T) {
 			t.Parallel()
 			dir := t.TempDir()
@@ -563,7 +508,6 @@ func TestArchive(t *testing.T) {
 			balance34 := amount.New(0x34)
 
 			if _, err := s.Apply(0, common.Update{
-				CreatedAccounts: []common.Address{address1},
 				Balances: []common.BalanceUpdate{
 					{Account: address1, Balance: balance12},
 				},
@@ -686,13 +630,13 @@ func TestLastArchiveBlock(t *testing.T) {
 			}
 
 			if _, err := s.Apply(0, common.Update{
-				CreatedAccounts: []common.Address{address1},
+				Balances: []common.BalanceUpdate{{Account: address1, Balance: balance1}},
 			}); err != nil {
 				t.Fatalf("failed to add block 0; %s", err)
 			}
 
 			if _, err := s.Apply(1, common.Update{
-				CreatedAccounts: []common.Address{address2},
+				Balances: []common.BalanceUpdate{{Account: address2, Balance: balance2}},
 			}); err != nil {
 				t.Fatalf("failed to add block 1; %s", err)
 			}
@@ -764,7 +708,6 @@ func TestPersistentState(t *testing.T) {
 
 			// init state data
 			update := common.Update{}
-			update.AppendCreateAccount(address1)
 			update.AppendBalanceUpdate(address1, balance1)
 			update.AppendNonceUpdate(address1, nonce1)
 			update.AppendSlotUpdate(address1, key1, val1)
@@ -833,46 +776,6 @@ func TestStateRead(t *testing.T) {
 	}
 	if code, err := as.GetCode(address1); err != nil || !bytes.Equal(code, []byte{1, 2, 3}) {
 		t.Errorf("Unexpected value or err, val: %v != %v, err:  %v", code, []byte{1, 2, 3}, err)
-	}
-}
-
-func TestHasEmptyStorage_S3_Always_Returns_True(t *testing.T) {
-	updates := []common.Update{
-		{
-			CreatedAccounts: []common.Address{address1},
-		},
-		{
-			Slots: []common.SlotUpdate{{Account: address1, Key: key1, Value: val0}},
-		},
-		{
-			Slots: []common.SlotUpdate{{Account: address1, Key: key1, Value: val1}},
-		},
-		{
-			DeletedAccounts: []common.Address{address1},
-		},
-	}
-
-	for _, config := range initStates() {
-		if config.config.Schema != 3 {
-			continue
-		}
-		dir := t.TempDir()
-		st, err := config.createState(dir)
-		if err != nil {
-			t.Fatalf("unable to create state: %v", err)
-		}
-		for i, update := range updates {
-			if _, err = st.Apply(uint64(i), update); err != nil {
-				t.Fatalf("failed to apply state: %v", err)
-			}
-			isEmpty, err := st.HasEmptyStorage(address1)
-			if err != nil {
-				t.Fatalf("failed to check state: %v", err)
-			}
-			if !isEmpty {
-				t.Errorf("HasEmptyStorage should always return true")
-			}
-		}
 	}
 }
 

--- a/go/state/tool/benchmark.go
+++ b/go/state/tool/benchmark.go
@@ -259,10 +259,8 @@ func runBenchmarkState(
 			counter++
 		}
 		update := common.Update{}
-		update.CreatedAccounts = make([]common.Address, 0, numInsertsPerBlock)
 		for j := 0; j < numInsertsPerBlock; j++ {
 			addr := common.Address{byte(counter), byte(counter >> 8), byte(counter >> 16), byte(counter >> 24), byte(counter >> 32)}
-			update.CreatedAccounts = append(update.CreatedAccounts, addr)
 			update.Nonces = append(update.Nonces, common.NonceUpdate{Account: addr, Nonce: common.ToNonce(1)})
 			counter++
 		}

--- a/rust/src/database/verkle/keyed_update.rs
+++ b/rust/src/database/verkle/keyed_update.rs
@@ -19,10 +19,7 @@ use sha3::{Digest, Keccak256};
 use verkle_trie::Key;
 
 use crate::{
-    database::verkle::{
-        embedding::{VerkleTrieEmbedding, code},
-        state::EMPTY_CODE_HASH,
-    },
+    database::verkle::embedding::{VerkleTrieEmbedding, code},
     types::{BalanceUpdate, CodeUpdate, Hash, NonceUpdate, SlotUpdate, Update, Value},
 };
 
@@ -149,8 +146,7 @@ impl KeyedUpdateBatch<'static> {
         update: Update<'_>,
         embedding: &VerkleTrieEmbedding,
     ) -> Result<Self, EmptyUpdate> {
-        if update.created_accounts.is_empty()
-            && update.balances.is_empty()
+        if update.balances.is_empty()
             && update.nonces.is_empty()
             && update.codes.is_empty()
             && update.slots.is_empty()
@@ -158,28 +154,12 @@ impl KeyedUpdateBatch<'static> {
             return Err(EmptyUpdate);
         }
         let mut updates = Vec::with_capacity(
-            // in practice created_accounts also have other updates, so we don't count them here
             update.balances.len()
                 + update.nonces.len()
                 + update.codes.len() * 2 // lower bound: code length and code hash
                 + update.slots.len(),
         );
-        for addr in update.created_accounts {
-            // This is just to set the used bit.
-            // Because the mask is all zeros, we don't overwrite any data, so we also don't have to
-            // account for nonce, balance or code length updates here.
-            updates.push(KeyedUpdate::PartialSlot {
-                key: embedding.get_basic_data_key(addr),
-                value: [0u8; 32],
-                mask: mask_for_range(0..0),
-            });
-            // If we also get a code update for this account, we have to make sure that this does
-            // not override the actual code hash. This is checked when processing the code update.
-            updates.push(KeyedUpdate::FullSlot {
-                key: embedding.get_code_hash_key(addr),
-                value: EMPTY_CODE_HASH,
-            });
-        }
+
         for BalanceUpdate { addr, balance } in update.balances {
             updates.push(KeyedUpdate::PartialSlot {
                 key: embedding.get_basic_data_key(addr),
@@ -214,14 +194,7 @@ impl KeyedUpdateBatch<'static> {
                 key,
                 value: code_hash,
             };
-            // This is needed in case the account was created in this same batch, in which case we
-            // already have a FullSlot update for the code hash with value EMPTY_CODE_HASH that we
-            // have to override.
-            if let Some(u) = updates.iter_mut().find(|u| u.key() == &key) {
-                *u = update;
-            } else {
-                updates.push(update);
-            }
+            updates.push(update);
 
             for (i, chunk) in code::split_code(code).into_iter().enumerate() {
                 updates.push(KeyedUpdate::FullSlot {
@@ -236,6 +209,7 @@ impl KeyedUpdateBatch<'static> {
                 value: *value,
             });
         }
+
         if updates.len() > 100_000 {
             updates.par_sort_unstable();
         } else {
@@ -542,7 +516,6 @@ mod tests {
         let embedding = VerkleTrieEmbedding::new();
 
         let update = Update {
-            created_accounts: &[[1; 20], [2; 20]],
             deleted_accounts: &[[3; 20], [4; 20]], // These will be ignored
             balances: &[
                 BalanceUpdate {
@@ -566,7 +539,7 @@ mod tests {
             ],
             codes: vec![
                 CodeUpdate {
-                    addr: [1; 20], // should overwrite the created account code hash
+                    addr: [1; 20],
                     code: &[14; 20],
                 },
                 CodeUpdate {
@@ -594,11 +567,9 @@ mod tests {
         // Verify total number of updates
         assert_eq!(
             keyed_updates.len(),
-            update.created_accounts.len() * 2
-                + update.balances.len()
+            update.balances.len()
                 + update.nonces.len()
                 + update.codes.len() * 2
-                - 1 // the overwrite of the created account code hash
                 + update
                     .codes
                     .iter()
@@ -606,22 +577,6 @@ mod tests {
                     .sum::<usize>()
                 + update.slots.len()
         );
-
-        // Verify created accounts
-        for addr in update.created_accounts {
-            let mut found = false;
-            for keyed_update in &*keyed_updates {
-                if let KeyedUpdate::PartialSlot { key, value, mask } = keyed_update
-                    && *key == embedding.get_basic_data_key(addr)
-                    && *value == [0u8; 32]
-                    && *mask == mask_for_range(0..0)
-                {
-                    assert!(!found);
-                    found = true;
-                }
-            }
-            assert!(found, "No matching PartialSlot for created account");
-        }
 
         // Verify balances
         for balance_update in update.balances {
@@ -661,7 +616,6 @@ mod tests {
         // Verify codes
         for code_update in update.codes {
             let mut found_code_len = false;
-            let mut found_code_hash = false;
             let mut found_chunks = vec![false; code::split_code(code_update.code).len()];
 
             for keyed_update in &*keyed_updates {
@@ -677,23 +631,12 @@ mod tests {
                         found_code_len = true;
                     }
                 } else if let KeyedUpdate::FullSlot { key, value } = keyed_update {
-                    if key == &embedding.get_code_hash_key(&code_update.addr) {
-                        let mut hasher = Keccak256::new();
-                        hasher.update(code_update.code);
-                        let expected_hash = Hash::from(hasher.finalize());
-                        if *value == expected_hash {
-                            assert!(!found_code_hash);
-                            found_code_hash = true;
-                        }
-                    } else {
-                        for (i, chunk) in code::split_code(code_update.code).into_iter().enumerate()
+                    for (i, chunk) in code::split_code(code_update.code).into_iter().enumerate() {
+                        if *key == embedding.get_code_chunk_key(&code_update.addr, i as u32)
+                            && *value == chunk
                         {
-                            if *key == embedding.get_code_chunk_key(&code_update.addr, i as u32)
-                                && *value == chunk
-                            {
-                                assert!(!found_chunks[i]);
-                                found_chunks[i] = true;
-                            }
+                            assert!(!found_chunks[i]);
+                            found_chunks[i] = true;
                         }
                     }
                 }
@@ -703,7 +646,6 @@ mod tests {
                 found_code_len,
                 "No matching PartialSlot found for code length"
             );
-            assert!(found_code_hash, "No matching FullSlot found for code hash");
             assert!(
                 found_chunks.iter().all(|&found| found),
                 "Not all code chunks were found"

--- a/rust/src/database/verkle/state.rs
+++ b/rust/src/database/verkle/state.rs
@@ -28,11 +28,6 @@ use crate::{
     types::{Address, Hash, Key, Nonce, U256, Update, Value},
 };
 
-pub const EMPTY_CODE_HASH: Hash = [
-    197, 210, 70, 1, 134, 247, 35, 60, 146, 126, 125, 178, 220, 199, 3, 192, 229, 0, 182, 83, 202,
-    130, 39, 59, 123, 250, 216, 4, 93, 133, 164, 112,
-];
-
 /// The mode of the Verkle trie state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StateMode {
@@ -266,13 +261,6 @@ mod tests {
     fn all_state_impls(#[case] state: Box<dyn CarmenState>) {}
 
     #[test]
-    fn empty_code_hash_is_keccak256_of_empty_code() {
-        let hasher = Keccak256::new();
-        let expected = hasher.finalize();
-        assert_eq!(EMPTY_CODE_HASH, expected.as_slice());
-    }
-
-    #[test]
     fn new_live_creates_empty_state() {
         let state = VerkleTrieCarmenState::<SimpleInMemoryVerkleTrie>::new_live();
         assert_eq!(state.get_hash().unwrap(), Hash::default());
@@ -371,31 +359,6 @@ mod tests {
 
         set_nonce(&*state, addr, 7u64.to_be_bytes(), 0);
         assert!(state.account_exists(&addr).unwrap());
-    }
-
-    #[rstest_reuse::apply(all_state_impls)]
-    fn creating_account_sets_empty_code_hash(#[case] state: Box<dyn CarmenState>) {
-        let addr = Address::from_index_values(0, &[(0, 1)]);
-        create_account(&*state, addr, 0);
-        let code_hash = state.get_code_hash(&addr).unwrap();
-        assert_eq!(code_hash, EMPTY_CODE_HASH);
-    }
-
-    #[rstest_reuse::apply(all_state_impls)]
-    fn creating_account_does_not_overwrite_basic_account_data(#[case] state: Box<dyn CarmenState>) {
-        let addr = Address::from_index_values(0, &[(0, 1)]);
-        let initial_balance = crypto_bigint::U256::from_u32(42).to_be_bytes();
-        let initial_nonce = 7u64.to_be_bytes();
-
-        set_balance(&*state, addr, initial_balance, 0);
-        set_nonce(&*state, addr, initial_nonce, 1);
-
-        create_account(&*state, addr, 2);
-
-        let balance = state.get_balance(&addr).unwrap();
-        assert_eq!(balance, initial_balance);
-        let nonce = state.get_nonce(&addr).unwrap();
-        assert_eq!(nonce, initial_nonce);
     }
 
     #[rstest_reuse::apply(all_state_impls)]
@@ -902,18 +865,6 @@ mod tests {
         };
         state
             .apply_block_update(block_height, Update::default())
-            .unwrap();
-    }
-
-    fn create_account(state: &dyn CarmenState, addr: Address, block_number: u64) {
-        state
-            .apply_block_update(
-                block_number,
-                Update {
-                    created_accounts: &[addr],
-                    ..Default::default()
-                },
-            )
             .unwrap();
     }
 

--- a/rust/src/ffi/exported.rs
+++ b/rust/src/ffi/exported.rs
@@ -2164,7 +2164,7 @@ mod tests {
         create_state_then_call_fn_then_release_state(
             |_| {},
             move |state| {
-                let mut update_data = [0; 24];
+                let mut update_data = [0; 20];
                 let result = unsafe {
                     Carmen_Rust_Apply(
                         state,

--- a/rust/src/types/update.rs
+++ b/rust/src/types/update.rs
@@ -54,7 +54,6 @@ pub struct SlotUpdate {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Update<'d> {
     pub deleted_accounts: &'d [Address],
-    pub created_accounts: &'d [Address],
     pub balances: &'d [BalanceUpdate],
     pub codes: Vec<CodeUpdate<'d>>,
     pub nonces: &'d [NonceUpdate],
@@ -68,9 +67,9 @@ const VERSION_0: u8 = 0;
 impl<'d> Update<'d> {
     /// Parses an update from its encoded form.
     pub fn from_encoded(mut bytes: &'d [u8]) -> BTResult<Self, String> {
-        if bytes.len() < 1 + 6 * 4 {
+        if bytes.len() < 1 + 5 * 4 {
             return Err(format!(
-                "encoded update has length {}, but minimum length is 1 + 6 * 4 = 25",
+                "encoded update has length {}, but minimum length is 1 + 5 * 4 = 21",
                 bytes.len()
             )
             .into());
@@ -84,7 +83,6 @@ impl<'d> Update<'d> {
         }
 
         let deleted_accounts_len = u32::from_be_bytes(read_array(bytes)?) as usize;
-        let created_accounts_len = u32::from_be_bytes(read_array(bytes)?) as usize;
         let balances_len = u32::from_be_bytes(read_array(bytes)?) as usize;
         let codes_len = u32::from_be_bytes(read_array(bytes)?) as usize;
         let nonces_len = u32::from_be_bytes(read_array(bytes)?) as usize;
@@ -93,10 +91,6 @@ impl<'d> Update<'d> {
         let deleted_accounts = transmute_ref!(read_slice_of_arrays::<{ size_of::<Address>() }>(
             bytes,
             deleted_accounts_len
-        )?);
-        let created_accounts = transmute_ref!(read_slice_of_arrays::<{ size_of::<Address>() }>(
-            bytes,
-            created_accounts_len
         )?);
         let balances = transmute_ref!(read_slice_of_arrays::<{ size_of::<BalanceUpdate>() }>(
             bytes,
@@ -118,7 +112,6 @@ impl<'d> Update<'d> {
 
         Ok(Self {
             deleted_accounts,
-            created_accounts,
             balances,
             codes,
             nonces,
@@ -222,7 +215,6 @@ mod tests {
     fn update_from_encoded_can_decode_empty_update() {
         let update = Update {
             deleted_accounts: &[],
-            created_accounts: &[],
             balances: &[],
             codes: Vec::new(),
             nonces: &[],
@@ -232,7 +224,6 @@ mod tests {
         let mut encoded_update = Vec::new();
         encoded_update.push(VERSION_0);
         encoded_update.extend_from_slice(&(update.deleted_accounts.len() as u32).to_be_bytes());
-        encoded_update.extend_from_slice(&(update.created_accounts.len() as u32).to_be_bytes());
         encoded_update.extend_from_slice(&(update.balances.len() as u32).to_be_bytes());
         encoded_update.extend_from_slice(&(update.codes.len() as u32).to_be_bytes());
         encoded_update.extend_from_slice(&(update.nonces.len() as u32).to_be_bytes());
@@ -246,7 +237,6 @@ mod tests {
     fn update_from_encoded_can_decode_non_empty_update() {
         let update = Update {
             deleted_accounts: &[[1; 20], [2; 20]],
-            created_accounts: &[[3; 20], [4; 20]],
             balances: &[
                 BalanceUpdate {
                     addr: [5; 20],
@@ -294,14 +284,12 @@ mod tests {
         let mut encoded_update = Vec::new();
         encoded_update.push(VERSION_0);
         encoded_update.extend_from_slice(&(update.deleted_accounts.len() as u32).to_be_bytes());
-        encoded_update.extend_from_slice(&(update.created_accounts.len() as u32).to_be_bytes());
         encoded_update.extend_from_slice(&(update.balances.len() as u32).to_be_bytes());
         encoded_update.extend_from_slice(&(update.codes.len() as u32).to_be_bytes());
         encoded_update.extend_from_slice(&(update.nonces.len() as u32).to_be_bytes());
         encoded_update.extend_from_slice(&(update.slots.len() as u32).to_be_bytes());
 
         encoded_update.extend_from_slice(update.deleted_accounts.concat().as_slice());
-        encoded_update.extend_from_slice(update.created_accounts.concat().as_slice());
         encoded_update.extend_from_slice(
             update
                 .balances
@@ -350,7 +338,6 @@ mod tests {
     fn update_from_encoded_returns_error_for_invalid_version() {
         let update = Update {
             deleted_accounts: &[],
-            created_accounts: &[],
             balances: &[],
             codes: Vec::new(),
             nonces: &[],
@@ -360,7 +347,6 @@ mod tests {
         let mut encoded_update = Vec::new();
         encoded_update.push(1); // Invalid version
         encoded_update.extend_from_slice(&(update.deleted_accounts.len() as u32).to_be_bytes());
-        encoded_update.extend_from_slice(&(update.created_accounts.len() as u32).to_be_bytes());
         encoded_update.extend_from_slice(&(update.balances.len() as u32).to_be_bytes());
         encoded_update.extend_from_slice(&(update.codes.len() as u32).to_be_bytes());
         encoded_update.extend_from_slice(&(update.nonces.len() as u32).to_be_bytes());
@@ -379,7 +365,6 @@ mod tests {
     fn update_from_encoded_returns_error_when_buffer_too_short() {
         let update = Update {
             deleted_accounts: &[[1; 20], [2; 20]],
-            created_accounts: &[[3; 20], [4; 20]],
             balances: &[
                 BalanceUpdate {
                     addr: [5; 20],
@@ -433,10 +418,6 @@ mod tests {
                     .extend_from_slice(&(update.deleted_accounts.len() as u32).to_be_bytes());
             },
             |encoded_update: &mut Vec<u8>, update| {
-                encoded_update
-                    .extend_from_slice(&(update.created_accounts.len() as u32).to_be_bytes());
-            },
-            |encoded_update: &mut Vec<u8>, update| {
                 encoded_update.extend_from_slice(&(update.balances.len() as u32).to_be_bytes());
             },
             |encoded_update: &mut Vec<u8>, update| {
@@ -450,9 +431,6 @@ mod tests {
             },
             |encoded_update: &mut Vec<u8>, update| {
                 encoded_update.extend_from_slice(update.deleted_accounts.concat().as_slice());
-            },
-            |encoded_update: &mut Vec<u8>, update| {
-                encoded_update.extend_from_slice(update.created_accounts.concat().as_slice());
             },
             |encoded_update: &mut Vec<u8>, update| {
                 encoded_update.extend_from_slice(


### PR DESCRIPTION
This PR removes the `CreateAccount` function from the `UpdateTarget` interface, and therefore from each `State` implementation.
On his own, `CreateAccount` could never be called, and was always followed by a state-changing operation (balance, nonce, code).

This also removes the empty code hash set by the state implementations when creating an account: this was complicating the implementation, adding an unexpected side effect to the update functions. 
A note: the `geth-leveldb` VK implementation uses the leveldb geth implementation, which sets all the fields in the account update, including the code hash, in each update. Therefore, it is not possible not to set the empty code hash in this implementation. For such reason, tests changing only one value and then checking the resulting hash are skipped for this implementation.

Note that the CreateAccount function is still available in the `VMStateDB` interface, where it's called from the EVM.