### PR TITLE
Mark account as existing if any field is set in Rust

### DIFF
--- a/rust/src/database/verkle/state.rs
+++ b/rust/src/database/verkle/state.rs
@@ -132,7 +132,9 @@ impl<T: VerkleTrie> IsArchive for VerkleTrieCarmenState<T> {
 
 impl<T: VerkleTrie> CarmenState for VerkleTrieCarmenState<T> {
     fn account_exists(&self, addr: &Address) -> BTResult<bool, Error> {
-        Ok(self.get_code_hash(addr)? != Hash::default())
+        Ok(self.get_code_hash(addr)? != Hash::default()
+            || self.get_balance(addr)? != U256::default()
+            || self.get_nonce(addr)? != Nonce::default())
     }
 
     fn get_balance(&self, addr: &Address) -> BTResult<U256, Error> {
@@ -339,6 +341,35 @@ mod tests {
         assert_eq!(state.get_code_hash(&addr).unwrap(), Hash::default());
 
         set_code(&*state, addr, &[0x01, 0x02, 0x03], 0);
+        assert!(state.account_exists(&addr).unwrap());
+    }
+
+    #[rstest_reuse::apply(all_state_impls)]
+    fn account_exists_checks_whether_account_has_non_zero_balance(
+        #[case] state: Box<dyn CarmenState>,
+    ) {
+        let addr = Address::default();
+        assert!(!state.account_exists(&addr).unwrap());
+        assert_eq!(state.get_balance(&addr).unwrap(), U256::default());
+
+        set_balance(
+            &*state,
+            addr,
+            crypto_bigint::U256::from_u32(42).to_be_bytes(),
+            0,
+        );
+        assert!(state.account_exists(&addr).unwrap());
+    }
+
+    #[rstest_reuse::apply(all_state_impls)]
+    fn account_exists_checks_whether_account_has_non_zero_nonce(
+        #[case] state: Box<dyn CarmenState>,
+    ) {
+        let addr = Address::default();
+        assert!(!state.account_exists(&addr).unwrap());
+        assert_eq!(state.get_nonce(&addr).unwrap(), Nonce::default());
+
+        set_nonce(&*state, addr, 7u64.to_be_bytes(), 0);
         assert!(state.account_exists(&addr).unwrap());
     }
 


### PR DESCRIPTION
In S5, an account is marked as existing if any of its fields are present. This PR aligns the Rust implementation to the same behavior. This is especially useful in tests, where accounts are not always filled up and will be useful in a subsequent PR where the empty code hash set by the `State` will be removed.

The Rust implementation does not have a way to query all the account information in a single query, therefore multiple ones are issued. However, in a real-world scenario, each field is set and therefore this shouldn't impact on performance. 