### PR TITLE
Fix errcheck lint errors

### DIFF
--- a/go/backend/archive/archive_test.go
+++ b/go/backend/archive/archive_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/0xsoniclabs/carmen/go/backend/archive"
 	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/stretchr/testify/require"
 )
 
 type archiveFactory struct {
@@ -69,7 +70,7 @@ func TestAddGet(t *testing.T) {
 	for _, factory := range getArchiveFactories(t) {
 		t.Run(factory.label, func(t *testing.T) {
 			a := factory.getArchive(t.TempDir())
-			defer a.Close()
+			defer func() { require.NoError(t, a.Close()) }()
 
 			if err := a.Add(1, common.Update{
 				Balances: []common.BalanceUpdate{
@@ -158,7 +159,7 @@ func TestAccountDeleteCreate(t *testing.T) {
 	for _, factory := range getArchiveFactories(t) {
 		t.Run(factory.label, func(t *testing.T) {
 			a := factory.getArchive(t.TempDir())
-			defer a.Close()
+			defer func() { require.NoError(t, a.Close()) }()
 
 			if err := a.Add(1, common.Update{
 				Balances: []common.BalanceUpdate{
@@ -345,7 +346,7 @@ func TestAccountStatusOnly(t *testing.T) {
 	for _, factory := range getArchiveFactories(t) {
 		t.Run(factory.label, func(t *testing.T) {
 			a := factory.getArchive(t.TempDir())
-			defer a.Close()
+			defer func() { require.NoError(t, a.Close()) }()
 
 			if err := a.Add(1, common.Update{
 				Balances: []common.BalanceUpdate{{Account: addr1, Balance: balance1}},
@@ -370,7 +371,7 @@ func TestBalanceOnly(t *testing.T) {
 	for _, factory := range getArchiveFactories(t) {
 		t.Run(factory.label, func(t *testing.T) {
 			a := factory.getArchive(t.TempDir())
-			defer a.Close()
+			defer func() { require.NoError(t, a.Close()) }()
 
 			if err := a.Add(1, common.Update{
 				Balances: []common.BalanceUpdate{
@@ -407,7 +408,7 @@ func TestStorageOnly(t *testing.T) {
 	for _, factory := range getArchiveFactories(t) {
 		t.Run(factory.label, func(t *testing.T) {
 			a := factory.getArchive(t.TempDir())
-			defer a.Close()
+			defer func() { require.NoError(t, a.Close()) }()
 
 			if err := a.Add(1, common.Update{
 				Balances: []common.BalanceUpdate{
@@ -446,7 +447,7 @@ func TestPreventingBlockOverrides(t *testing.T) {
 	for _, factory := range getArchiveFactories(t) {
 		t.Run(factory.label, func(t *testing.T) {
 			a := factory.getArchive(t.TempDir())
-			defer a.Close()
+			defer func() { require.NoError(t, a.Close()) }()
 
 			if err := a.Add(1, common.Update{}, nil); err != nil {
 				t.Fatalf("failed to add block 1; %s", err)
@@ -472,7 +473,7 @@ func TestPreventingBlockOutOfOrder(t *testing.T) {
 	for _, factory := range getArchiveFactories(t) {
 		t.Run(factory.label, func(t *testing.T) {
 			a := factory.getArchive(t.TempDir())
-			defer a.Close()
+			defer func() { require.NoError(t, a.Close()) }()
 
 			if err := a.Add(2, common.Update{
 				Balances: []common.BalanceUpdate{
@@ -501,7 +502,7 @@ func TestEmptyBlockHash(t *testing.T) {
 	for _, factory := range getArchiveFactories(t) {
 		t.Run(factory.label, func(t *testing.T) {
 			a := factory.getArchive(t.TempDir())
-			defer a.Close()
+			defer func() { require.NoError(t, a.Close()) }()
 
 			if err := a.Add(0, common.Update{}, nil); err != nil {
 				t.Fatalf("failed to add empty block 0; %v", err)
@@ -548,7 +549,7 @@ func TestZeroBlock(t *testing.T) {
 	for _, factory := range getArchiveFactories(t) {
 		t.Run(factory.label, func(t *testing.T) {
 			a := factory.getArchive(t.TempDir())
-			defer a.Close()
+			defer func() { require.NoError(t, a.Close()) }()
 
 			if err := a.Add(0, common.Update{
 				Balances: []common.BalanceUpdate{
@@ -586,7 +587,7 @@ func TestTwinProtection(t *testing.T) {
 	for _, factory := range getArchiveFactories(t) {
 		t.Run(factory.label, func(t *testing.T) {
 			a := factory.getArchive(t.TempDir())
-			defer a.Close()
+			defer func() { require.NoError(t, a.Close()) }()
 
 			if err := a.Add(0, common.Update{}, nil); err != nil {
 				t.Fatalf("failed to add empty block 0; %s", err)
@@ -621,7 +622,7 @@ func TestBlockHeight(t *testing.T) {
 	for _, factory := range getArchiveFactories(t) {
 		t.Run(factory.label, func(t *testing.T) {
 			a := factory.getArchive(t.TempDir())
-			defer a.Close()
+			defer func() { require.NoError(t, a.Close()) }()
 
 			// Initially, the block height should be indicated as empty.
 			if _, empty, err := a.GetBlockHeight(); !empty || err != nil {

--- a/go/backend/archive/benchmark_test.go
+++ b/go/backend/archive/benchmark_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/common/amount"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -28,7 +29,7 @@ const (
 func BenchmarkAdding(b *testing.B) {
 	for _, factory := range getArchiveFactories(b) {
 		a := factory.getArchive(b.TempDir())
-		defer a.Close()
+		defer func() { require.NoError(b, a.Close()) }()
 
 		// initialize
 		var update common.Update

--- a/go/backend/stock/file/file.go
+++ b/go/backend/stock/file/file.go
@@ -184,7 +184,6 @@ func verifyStockFilesInternal[I stock.Index, V any](encoder stock.ValueEncoder[V
 	if err != nil {
 		return meta, err
 	}
-	defer func() { err = errors.Join(err, freelist.Close()) }()
 	if err := verifyStackInternal[I](meta, freelist); err != nil {
 		return meta, err
 	}

--- a/go/backend/stock/file/file.go
+++ b/go/backend/stock/file/file.go
@@ -147,7 +147,7 @@ func verifyStockInternal[I stock.Index, V any](encoder stock.ValueEncoder[V], di
 	return verifyStockFilesInternal[I](encoder, metafile, valuefile, freelistfile)
 }
 
-func verifyStockFilesInternal[I stock.Index, V any](encoder stock.ValueEncoder[V], metafile, valuefile, freelistfile string) (metadata, error) {
+func verifyStockFilesInternal[I stock.Index, V any](encoder stock.ValueEncoder[V], metafile, valuefile, freelistfile string) (m metadata, err error) {
 	// Attempt to parse the meta-data.
 	meta, err := utils.ReadJsonFile[metadata](metafile)
 	if err != nil {
@@ -184,7 +184,7 @@ func verifyStockFilesInternal[I stock.Index, V any](encoder stock.ValueEncoder[V
 	if err != nil {
 		return meta, err
 	}
-	defer freelist.Close()
+	defer func() { err = errors.Join(err, freelist.Close()) }()
 	if err := verifyStackInternal[I](meta, freelist); err != nil {
 		return meta, err
 	}
@@ -211,7 +211,7 @@ func verifyStackInternal[I stock.Index](meta metadata, freelistfile utils.OsFile
 		if err != nil {
 			return err
 		}
-		defer stack.Close()
+		defer func() { err = errors.Join(err, stack.Close()) }()
 		list, err := stack.GetAll()
 		if err != nil {
 			return err

--- a/go/backend/stock/file/file.go
+++ b/go/backend/stock/file/file.go
@@ -147,7 +147,7 @@ func verifyStockInternal[I stock.Index, V any](encoder stock.ValueEncoder[V], di
 	return verifyStockFilesInternal[I](encoder, metafile, valuefile, freelistfile)
 }
 
-func verifyStockFilesInternal[I stock.Index, V any](encoder stock.ValueEncoder[V], metafile, valuefile, freelistfile string) (m metadata, err error) {
+func verifyStockFilesInternal[I stock.Index, V any](encoder stock.ValueEncoder[V], metafile, valuefile, freelistfile string) (metadata, error) {
 	// Attempt to parse the meta-data.
 	meta, err := utils.ReadJsonFile[metadata](metafile)
 	if err != nil {
@@ -191,7 +191,7 @@ func verifyStockFilesInternal[I stock.Index, V any](encoder stock.ValueEncoder[V
 	return meta, nil
 }
 
-func verifyStackInternal[I stock.Index](meta metadata, freelistfile utils.OsFile) error {
+func verifyStackInternal[I stock.Index](meta metadata, freelistfile utils.OsFile) (retErr error) {
 	// Check size of the free-list file.
 	{
 		indexSize := int(unsafe.Sizeof(I(0)))
@@ -210,7 +210,7 @@ func verifyStackInternal[I stock.Index](meta metadata, freelistfile utils.OsFile
 		if err != nil {
 			return err
 		}
-		defer func() { err = errors.Join(err, stack.Close()) }()
+		defer func() { retErr = errors.Join(retErr, stack.Close()) }()
 		list, err := stack.GetAll()
 		if err != nil {
 			return err

--- a/go/backend/stock/file/file_test.go
+++ b/go/backend/stock/file/file_test.go
@@ -1086,7 +1086,7 @@ func TestStock_Restore_FailsOnIoIssues(t *testing.T) {
 	}
 }
 
-func copyDirectory(src, dst string) (err error) {
+func copyDirectory(src, dst string) (retErr error) {
 	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -1103,12 +1103,12 @@ func copyDirectory(src, dst string) (err error) {
 		if err != nil {
 			return err
 		}
-		defer func() { err = errors.Join(err, srcFile.Close()) }()
+		defer func() { retErr = errors.Join(retErr, srcFile.Close()) }()
 		dstFile, err := os.Create(dstPath)
 		if err != nil {
 			return err
 		}
-		defer func() { err = errors.Join(err, dstFile.Close()) }()
+		defer func() { retErr = errors.Join(retErr, dstFile.Close()) }()
 		_, err = io.Copy(dstFile, srcFile)
 		return err
 	})

--- a/go/backend/stock/file/file_test.go
+++ b/go/backend/stock/file/file_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/0xsoniclabs/carmen/go/backend/stock"
 	"github.com/0xsoniclabs/carmen/go/backend/utils"
 	"github.com/0xsoniclabs/carmen/go/backend/utils/checkpoint"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -573,7 +574,7 @@ func TestFile_SetValue_FailingEncoder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create stock: %v", err)
 	}
-	defer s.Close()
+	defer func() { require.NoError(t, s.Close()) }()
 	id, err := s.New()
 	if err != nil {
 		t.Fatalf("cannot generate ID: %s", err)
@@ -599,7 +600,7 @@ func TestFile_GetValue_FailingEncoder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create stock: %v", err)
 	}
-	defer s.Close()
+	defer func() { require.NoError(t, s.Close()) }()
 
 	id, err := s.New()
 	if err != nil {
@@ -705,7 +706,7 @@ func TestStock_Commit_FailsOnIoIssues(t *testing.T) {
 				t.Fatalf("prepare should succeed, got %v", err)
 			}
 
-			modify(t, dir)
+			require.NoError(t, modify(t, dir))
 
 			if s.Commit(checkpoint.Checkpoint(1)) == nil {
 				t.Errorf("commit should fail")
@@ -745,7 +746,7 @@ func TestStock_Abort_FailsOnIoIssues(t *testing.T) {
 				t.Fatalf("prepare should succeed, got %v", err)
 			}
 
-			modify(t, dir)
+			require.NoError(t, modify(t, dir))
 
 			if s.Abort(checkpoint.Checkpoint(1)) == nil {
 				t.Errorf("abort should fail")
@@ -1076,7 +1077,7 @@ func TestStock_Restore_FailsOnIoIssues(t *testing.T) {
 				t.Fatalf("failed to checkpoint and close stock: %v", err)
 			}
 
-			modify(t, dir)
+			require.NoError(t, modify(t, dir))
 
 			if err := GetRestorer(dir).Restore(checkpoint); err == nil {
 				t.Errorf("restoration should fail")
@@ -1085,7 +1086,7 @@ func TestStock_Restore_FailsOnIoIssues(t *testing.T) {
 	}
 }
 
-func copyDirectory(src, dst string) error {
+func copyDirectory(src, dst string) (err error) {
 	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -1102,12 +1103,12 @@ func copyDirectory(src, dst string) error {
 		if err != nil {
 			return err
 		}
-		defer srcFile.Close()
+		defer func() { err = errors.Join(err, srcFile.Close()) }()
 		dstFile, err := os.Create(dstPath)
 		if err != nil {
 			return err
 		}
-		defer dstFile.Close()
+		defer func() { err = errors.Join(err, dstFile.Close()) }()
 		_, err = io.Copy(dstFile, srcFile)
 		return err
 	})
@@ -1180,7 +1181,7 @@ func BenchmarkFileStock_Get(b *testing.B) {
 	if err != nil {
 		b.Fatalf("failed to open stock")
 	}
-	defer stock.Close()
+	defer func() { require.NoError(b, stock.Close()) }()
 
 	id, err := stock.New()
 	if err != nil {
@@ -1203,7 +1204,7 @@ func BenchmarkFileStock_Set(b *testing.B) {
 	if err != nil {
 		b.Fatalf("failed to open stock")
 	}
-	defer stock.Close()
+	defer func() { require.NoError(b, stock.Close()) }()
 
 	id, err := stock.New()
 	if err != nil {
@@ -1231,7 +1232,7 @@ func BenchmarkFileStock_Commit(b *testing.B) {
 			b.Fatalf("failed to set value in stock")
 		}
 	}
-	defer stock.Close()
+	defer func() { require.NoError(b, stock.Close()) }()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/go/backend/stock/file/stack_test.go
+++ b/go/backend/stock/file/stack_test.go
@@ -13,9 +13,11 @@ package file
 import (
 	"errors"
 	"fmt"
-	"github.com/0xsoniclabs/carmen/go/backend/utils"
-	"go.uber.org/mock/gomock"
 	"testing"
+
+	"github.com/0xsoniclabs/carmen/go/backend/utils"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 func TestStack_OpenClose(t *testing.T) {
@@ -33,7 +35,7 @@ func TestStack_PushAndPop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open empty stack: %v", err)
 	}
-	defer stack.Close()
+	defer func() { require.NoError(t, stack.Close()) }()
 
 	if err := stack.Push(12); err != nil {
 		t.Fatalf("failed to push element: %v", err)
@@ -57,7 +59,7 @@ func TestStack_LargePushAndPop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open empty stack: %v", err)
 	}
-	defer stack.Close()
+	defer func() { require.NoError(t, stack.Close()) }()
 
 	for i := 0; i < 10*stackBufferSize; i++ {
 		if got, want := stack.Size(), i; got != want {
@@ -105,7 +107,7 @@ func TestStack_CloseAndReopen(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to re-open stack: %v", err)
 		}
-		defer stack.Close()
+		defer func() { require.NoError(t, stack.Close()) }()
 
 		if got, want := stack.Size(), 2; got != want {
 			t.Fatalf("invalid stack size after reopening, wanted %d, got %d", want, got)
@@ -150,7 +152,7 @@ func TestStack_CloseAndReopenLarge(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to re-open stack: %v", err)
 		}
-		defer stack.Close()
+		defer func() { require.NoError(t, stack.Close()) }()
 
 		if got, want := stack.Size(), N; got != want {
 			t.Fatalf("invalid stack size after reopening, wanted %d, got %d", want, got)

--- a/go/backend/stock/memory/memory.go
+++ b/go/backend/stock/memory/memory.go
@@ -12,6 +12,7 @@ package memory
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -45,7 +46,7 @@ const (
 	fileNamePreparedCheckpoint  = "prepare.json"
 )
 
-func OpenStock[I stock.Index, V any](encoder stock.ValueEncoder[V], directory string) (stock.Stock[I, V], error) {
+func OpenStock[I stock.Index, V any](encoder stock.ValueEncoder[V], directory string) (s stock.Stock[I, V], retErr error) {
 	res := &inMemoryStock[I, V]{
 		values:    make([]V, 0, 10),
 		freeList:  make([]I, 0, 10),
@@ -104,7 +105,7 @@ func OpenStock[I stock.Index, V any](encoder stock.ValueEncoder[V], directory st
 		if err != nil {
 			return nil, err
 		}
-		defer file.Close()
+		defer func() { retErr = errors.Join(retErr, file.Close()) }()
 		for i := 0; i < meta.ValueListLength; i++ {
 			_, err := io.ReadFull(file, buffer)
 			if err != nil {
@@ -132,7 +133,7 @@ func OpenStock[I stock.Index, V any](encoder stock.ValueEncoder[V], directory st
 		if err != nil {
 			return nil, err
 		}
-		defer file.Close()
+		defer func() { retErr = errors.Join(retErr, file.Close()) }()
 		for i := 0; i < meta.FreeListLength; i++ {
 			_, err := io.ReadFull(file, buffer)
 			if err != nil {
@@ -218,7 +219,7 @@ func (s *inMemoryStock[I, V]) Flush() error {
 	return s.writeTo(s.directory)
 }
 
-func (s *inMemoryStock[I, V]) writeTo(dir string) error {
+func (s *inMemoryStock[I, V]) writeTo(dir string) (retErr error) {
 	// Create the directory if needed.
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return err
@@ -248,11 +249,14 @@ func (s *inMemoryStock[I, V]) writeTo(dir string) error {
 	if f, err := os.Create(filepath.Join(dir, fileNameValues)); err != nil {
 		return err
 	} else {
-		defer f.Close()
+		defer func() { retErr = errors.Join(retErr, f.Close()) }()
 
 		buffer := make([]byte, s.encoder.GetEncodedSize())
 		for _, v := range s.values {
-			s.encoder.Store(buffer, &v)
+			err = s.encoder.Store(buffer, &v)
+			if err != nil {
+				return err
+			}
 			_, err := f.Write(buffer)
 			if err != nil {
 				return err
@@ -268,7 +272,7 @@ func (s *inMemoryStock[I, V]) writeTo(dir string) error {
 	if f, err := os.Create(filepath.Join(dir, fileNameFreeList)); err != nil {
 		return err
 	} else {
-		defer f.Close()
+		defer func() { retErr = errors.Join(retErr, f.Close()) }()
 
 		buffer := make([]byte, indexSize)
 		for _, i := range s.freeList {

--- a/go/backend/stock/memory/memory.go
+++ b/go/backend/stock/memory/memory.go
@@ -246,10 +246,10 @@ func (s *inMemoryStock[I, V]) writeTo(dir string) (retErr error) {
 	}
 
 	// Write list of values.
-	if f, err := os.Create(filepath.Join(dir, fileNameValues)); err != nil {
+	if valueList, err := os.Create(filepath.Join(dir, fileNameValues)); err != nil {
 		return err
 	} else {
-		defer func() { retErr = errors.Join(retErr, f.Close()) }()
+		defer func() { retErr = errors.Join(retErr, valueList.Close()) }()
 
 		buffer := make([]byte, s.encoder.GetEncodedSize())
 		for _, v := range s.values {
@@ -257,33 +257,25 @@ func (s *inMemoryStock[I, V]) writeTo(dir string) (retErr error) {
 			if err != nil {
 				return err
 			}
-			_, err := f.Write(buffer)
+			_, err := valueList.Write(buffer)
 			if err != nil {
 				return err
 			}
 		}
-
-		if err := f.Close(); err != nil {
-			return err
-		}
 	}
 
 	// Write free list.
-	if f, err := os.Create(filepath.Join(dir, fileNameFreeList)); err != nil {
+	if freeList, err := os.Create(filepath.Join(dir, fileNameFreeList)); err != nil {
 		return err
 	} else {
-		defer func() { retErr = errors.Join(retErr, f.Close()) }()
+		defer func() { retErr = errors.Join(retErr, freeList.Close()) }()
 
 		buffer := make([]byte, indexSize)
 		for _, i := range s.freeList {
 			stock.EncodeIndex(i, buffer)
-			if _, err := f.Write(buffer); err != nil {
+			if _, err := freeList.Write(buffer); err != nil {
 				return err
 			}
-		}
-
-		if err := f.Close(); err != nil {
-			return err
 		}
 	}
 

--- a/go/backend/stock/memory/memory_test.go
+++ b/go/backend/stock/memory/memory_test.go
@@ -11,10 +11,12 @@
 package memory
 
 import (
+	"errors"
 	"testing"
 	"unsafe"
 
 	"github.com/0xsoniclabs/carmen/go/backend/stock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInMemoryStock(t *testing.T) {
@@ -50,3 +52,28 @@ func FuzzMemoryStock_RandomOps(f *testing.F) {
 
 	stock.FuzzStockRandomOps(f, open, false)
 }
+
+func TestFlush_PropagatesEncoderStoreError(t *testing.T) {
+	injectedErr := errors.New("store failed")
+	encoder := &failingStoreEncoder{err: injectedErr}
+
+	dir := t.TempDir()
+	s, err := OpenStock[int](encoder, dir)
+	require.NoError(t, err)
+
+	// Add a value so that Flush has something to encode.
+	_, err = s.New()
+	require.NoError(t, err)
+
+	err = s.Flush()
+	require.ErrorIs(t, err, injectedErr)
+}
+
+// failingStoreEncoder is a ValueEncoder that returns an error from Store.
+type failingStoreEncoder struct {
+	err error
+}
+
+func (e *failingStoreEncoder) GetEncodedSize() int           { return stock.IntEncoder{}.GetEncodedSize() }
+func (e *failingStoreEncoder) Load(src []byte, v *int) error { return stock.IntEncoder{}.Load(src, v) }
+func (e *failingStoreEncoder) Store([]byte, *int) error      { return e.err }

--- a/go/backend/stock/stock_test_utils.go
+++ b/go/backend/stock/stock_test_utils.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/carmen/go/backend/utils/checkpoint"
+	"github.com/stretchr/testify/require"
 )
 
 type IntEncoder struct{}
@@ -79,7 +80,7 @@ func testNewCreatesFreshIndexValues(t *testing.T, factory NamedStockFactory) {
 	if err != nil {
 		t.Fatalf("failed to create empty stock: %v", err)
 	}
-	defer stock.Close()
+	defer func() { require.NoError(t, stock.Close()) }()
 	index1, err := stock.New()
 	if err != nil {
 		t.Fatalf("failed to create new element: %v", err)
@@ -99,7 +100,7 @@ func testLookUpsRetrieveTheSameValue(t *testing.T, factory NamedStockFactory) {
 	if err != nil {
 		t.Fatalf("failed to create empty stock: %v", err)
 	}
-	defer stock.Close()
+	defer func() { require.NoError(t, stock.Close()) }()
 	index1, err := stock.New()
 	if err != nil {
 		t.Fatalf("failed to create new element: %v", err)
@@ -138,7 +139,7 @@ func testDeletedElementsAreReused(t *testing.T, factory NamedStockFactory) {
 	if err != nil {
 		t.Fatalf("failed to create empty stock: %v", err)
 	}
-	defer stock.Close()
+	defer func() { require.NoError(t, stock.Close()) }()
 
 	seen := map[int]bool{}
 	for i := 0; i < 1_000_000; i++ {
@@ -162,7 +163,7 @@ func testReusedElementsAreCleared(t *testing.T, factory NamedStockFactory) {
 	if err != nil {
 		t.Fatalf("failed to create empty stock: %v", err)
 	}
-	defer stock.Close()
+	defer func() { require.NoError(t, stock.Close()) }()
 
 	seen := map[int]bool{}
 	for i := 0; i < 1_000_000; i++ {
@@ -190,7 +191,7 @@ func testLargeNumberOfElements(t *testing.T, factory NamedStockFactory) {
 	if err != nil {
 		t.Fatalf("failed to create empty stock: %v", err)
 	}
-	defer stock.Close()
+	defer func() { require.NoError(t, stock.Close()) }()
 	indexes := map[int]int{}
 	for i := 0; i < N; i++ {
 		index, err := stock.New()
@@ -219,7 +220,7 @@ func testProvidesMemoryFootprint(t *testing.T, factory NamedStockFactory) {
 	if err != nil {
 		t.Fatalf("failed to create empty stock: %v", err)
 	}
-	defer stock.Close()
+	defer func() { require.NoError(t, stock.Close()) }()
 	if _, err := stock.New(); err != nil {
 		t.Fatalf("failed to insert single element into empty stock: %v", err)
 	}
@@ -238,7 +239,7 @@ func testCreatesMissingDirectories(t *testing.T, factory NamedStockFactory) {
 	if err != nil {
 		t.Fatalf("failed to create empty stock: %v", err)
 	}
-	defer stock.Close()
+	defer func() { require.NoError(t, stock.Close()) }()
 	if _, err := os.Stat(directory); err != nil {
 		t.Errorf("failed to create output directory: %v", err)
 	}
@@ -249,7 +250,7 @@ func testCanBeFlushed(t *testing.T, factory NamedStockFactory) {
 	if err != nil {
 		t.Fatalf("failed to create empty stock: %v", err)
 	}
-	defer stock.Close()
+	defer func() { require.NoError(t, stock.Close()) }()
 	if err := stock.Flush(); err != nil {
 		t.Fatalf("failed to flush empty stock: %v", err)
 	}
@@ -266,7 +267,6 @@ func testCanBeClosed(t *testing.T, factory NamedStockFactory) {
 	if err != nil {
 		t.Fatalf("failed to create empty stock: %v", err)
 	}
-	defer stock.Close()
 	if _, err := stock.New(); err != nil {
 		t.Fatalf("failed to insert single element into empty stock: %v", err)
 	}
@@ -281,7 +281,7 @@ func testCanBeClosedAndReopened(t *testing.T, factory NamedStockFactory) {
 	if err != nil {
 		t.Fatalf("failed to create empty stock: %v", err)
 	}
-	defer stock.Close()
+	defer func() { require.NoError(t, stock.Close()) }()
 
 	// The first element shall be a deleted element.
 	key1, err := stock.New()
@@ -348,7 +348,7 @@ func testGetIdsProducesAllIdsInTheStock(t *testing.T, factory NamedStockFactory)
 	if err != nil {
 		t.Fatalf("failed to create empty stock: %v", err)
 	}
-	defer stock.Close()
+	defer func() { require.NoError(t, stock.Close()) }()
 
 	const N = 100
 	ids := map[int]struct{}{}
@@ -398,7 +398,7 @@ func testDeleteIndexOutOfRange(t *testing.T, factory NamedStockFactory) {
 	if err != nil {
 		t.Fatalf("failed to create empty stock: %v", err)
 	}
-	defer stock.Close()
+	defer func() { require.NoError(t, stock.Close()) }()
 
 	if err := stock.Delete(-1); err != nil {
 		t.Errorf("deleting negative index should be no-op")

--- a/go/backend/stock/stock_test_utils.go
+++ b/go/backend/stock/stock_test_utils.go
@@ -47,7 +47,7 @@ type NamedStockFactory struct {
 func RunStockTests(t *testing.T, factory NamedStockFactory) {
 	wrap := func(test func(*testing.T, NamedStockFactory)) func(*testing.T) {
 		return func(t *testing.T) {
-			t.Parallel()
+			// t.Parallel()
 			test(t, factory)
 		}
 	}

--- a/go/backend/stock/stock_test_utils.go
+++ b/go/backend/stock/stock_test_utils.go
@@ -47,7 +47,7 @@ type NamedStockFactory struct {
 func RunStockTests(t *testing.T, factory NamedStockFactory) {
 	wrap := func(test func(*testing.T, NamedStockFactory)) func(*testing.T) {
 		return func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 			test(t, factory)
 		}
 	}

--- a/go/backend/stock/synced/synced_test.go
+++ b/go/backend/stock/synced/synced_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/0xsoniclabs/carmen/go/backend/stock"
 	"github.com/0xsoniclabs/carmen/go/backend/stock/file"
 	"github.com/0xsoniclabs/carmen/go/backend/stock/memory"
+	"github.com/stretchr/testify/require"
 )
 
 var configs = []stock.NamedStockFactory{
@@ -59,7 +60,7 @@ func testCanBeAccessedConcurrently(t *testing.T, factory stock.NamedStockFactory
 	if err != nil {
 		t.Fatalf("failed to create empty stock: %v", err)
 	}
-	defer stock.Close()
+	defer func() { require.NoError(t, stock.Close()) }()
 
 	var wg sync.WaitGroup
 	var errors [N]error

--- a/go/backend/utils/buffered_file.go
+++ b/go/backend/utils/buffered_file.go
@@ -49,15 +49,14 @@ func OpenBufferedFile(path string) (*BufferedFile, error) {
 	return openBufferedFile(f)
 }
 
-func openBufferedFile(f OsFile) (*BufferedFile, error) {
+func openBufferedFile(f OsFile) (b *BufferedFile, retErr error) {
 	stats, err := f.Stat()
 	if err != nil {
-		f.Close()
-		return nil, err
+		return nil, errors.Join(err, f.Close())
 	}
+	defer func() { retErr = errors.Join(retErr, f.Close()) }()
 	size := stats.Size()
 	if size%bufferSize != 0 {
-		f.Close()
 		return nil, fmt.Errorf("invalid file size, got %d, expected multiple of %d", size, bufferSize)
 	}
 	res := &BufferedFile{
@@ -66,8 +65,7 @@ func openBufferedFile(f OsFile) (*BufferedFile, error) {
 	}
 
 	if err := res.readFile(0, res.buffer[:]); err != nil {
-		f.Close()
-		return nil, err
+		return nil, errors.Join(err, f.Close())
 	}
 
 	return res, nil

--- a/go/backend/utils/buffered_file.go
+++ b/go/backend/utils/buffered_file.go
@@ -54,10 +54,9 @@ func openBufferedFile(f OsFile) (b *BufferedFile, retErr error) {
 	if err != nil {
 		return nil, errors.Join(err, f.Close())
 	}
-	defer func() { retErr = errors.Join(retErr, f.Close()) }()
 	size := stats.Size()
 	if size%bufferSize != 0 {
-		return nil, fmt.Errorf("invalid file size, got %d, expected multiple of %d", size, bufferSize)
+		return nil, errors.Join(fmt.Errorf("invalid file size, got %d, expected multiple of %d", size, bufferSize), f.Close())
 	}
 	res := &BufferedFile{
 		file:     f,

--- a/go/backend/utils/buffered_file_fuzz_test.go
+++ b/go/backend/utils/buffered_file_fuzz_test.go
@@ -13,9 +13,11 @@ package utils
 import (
 	"bytes"
 	"encoding/binary"
-	"github.com/0xsoniclabs/carmen/go/fuzzing"
 	"strings"
 	"testing"
+
+	"github.com/0xsoniclabs/carmen/go/fuzzing"
+	"github.com/stretchr/testify/require"
 )
 
 func FuzzBufferedFile_RandomOps(f *testing.F) {
@@ -56,7 +58,7 @@ func FuzzBufferedFile_ReadWrite(f *testing.F) {
 		if err != nil {
 			t.Fatalf("failed to open buffered file: %v", err)
 		}
-		defer file.Close()
+		defer func() { require.NoError(t, file.Close()) }()
 
 		ops := parseUpdates(rawData)
 		for _, op := range ops {

--- a/go/backend/utils/buffered_file_test.go
+++ b/go/backend/utils/buffered_file_test.go
@@ -13,10 +13,12 @@ package utils
 import (
 	"bytes"
 	"fmt"
-	"go.uber.org/mock/gomock"
-	"golang.org/x/exp/slices"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"golang.org/x/exp/slices"
 )
 
 func TestBufferedFile_Open_NonExisting(t *testing.T) {
@@ -450,6 +452,7 @@ func TestBufferedFile_ReadAndWriteCanHandleUnalignedData(t *testing.T) {
 }
 
 func TestBufferedFile_WriteAndReadAddBufferBoundary(t *testing.T) {
+	require := require.New(t)
 	path := t.TempDir() + "/test.dat"
 	file, err := OpenBufferedFile(path)
 	if err != nil {
@@ -457,10 +460,12 @@ func TestBufferedFile_WriteAndReadAddBufferBoundary(t *testing.T) {
 	}
 
 	src := []byte{1, 2, 3, 4, 5}
-	file.WriteAt(src, 5*bufferSize-2)
+	_, err = file.WriteAt(src, 5*bufferSize-2)
+	require.NoError(err)
 
 	dst := []byte{0, 0, 0, 0, 0}
-	file.ReadAt(dst, 5*bufferSize-2)
+	_, err = file.ReadAt(dst, 5*bufferSize-2)
+	require.NoError(err)
 
 	if !bytes.Equal(src, dst) {
 		t.Errorf("failed to read data written across buffer boundary, wanted %v, got %v", src, dst)

--- a/go/backend/utils/checkpoint/checkpoint_test.go
+++ b/go/backend/utils/checkpoint/checkpoint_test.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -184,7 +185,7 @@ func TestCheckpointCoordinator_CreationFailsIfTheProvidedDirectoryLacksWritePerm
 	if err != nil {
 		t.Fatalf("failed to get directory info: %v", err)
 	}
-	defer os.Chmod(dir, info.Mode())
+	defer func() { require.NoError(t, os.Chmod(dir, info.Mode())) }()
 
 	if err := os.Chmod(dir, 0500); err != nil {
 		t.Fatalf("failed to change permissions: %v", err)

--- a/go/backend/utils/json_file_io_test.go
+++ b/go/backend/utils/json_file_io_test.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestReadJsonFile_CanReadJsonData(t *testing.T) {
@@ -48,7 +50,7 @@ func TestReadJsonFile_DetectsIoError(t *testing.T) {
 	if err := os.Chmod(file, 0); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chmod(file, 0600)
+	defer func() { require.NoError(t, os.Chmod(file, 0600)) }()
 
 	_, err := ReadJsonFile[chan bool](file)
 	if err == nil {
@@ -99,7 +101,7 @@ func TestWriteJsonFile_DetectsIoError(t *testing.T) {
 	if err := os.Chmod(file, 0); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chmod(file, 0600)
+	defer func() { require.NoError(t, os.Chmod(file, 0600)) }()
 
 	err := WriteJsonFile(file, "test")
 	if err == nil {

--- a/go/carmen/block_test.go
+++ b/go/carmen/block_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/carmen/go/state"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -332,7 +333,7 @@ func TestBlockContext_PanickingCommitsReleaseQueryLock(t *testing.T) {
 		}
 	}()
 
-	context.Commit()
+	require.NoError(t, context.Commit())
 }
 
 func initBlockContexts() map[string]func(t *testing.T) blockContext {

--- a/go/carmen/database_test.go
+++ b/go/carmen/database_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/0xsoniclabs/carmen/go/database/mpt"
 	"github.com/0xsoniclabs/carmen/go/database/mpt/io"
 	"github.com/0xsoniclabs/carmen/go/state/gostate"
+	"github.com/stretchr/testify/require"
 
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/state"
@@ -2188,13 +2189,15 @@ func TestDatabase_ActiveHeadQueryBlockDataBaseClose(t *testing.T) {
 
 	queryStarted := make(chan bool)
 	done := &atomic.Bool{}
-	go db.QueryHeadState(func(QueryContext) {
-		defer wg.Done()
-		queryStarted <- true
-		// keep this alive to block the closing of the database
-		time.Sleep(time.Second)
-		done.Store(true)
-	})
+	go func() {
+		require.NoError(t, db.QueryHeadState(func(QueryContext) {
+			defer wg.Done()
+			queryStarted <- true
+			// keep this alive to block the closing of the database
+			time.Sleep(time.Second)
+			done.Store(true)
+		}))
+	}()
 
 	go func() {
 		defer wg.Done()

--- a/go/common/keccak.go
+++ b/go/common/keccak.go
@@ -36,14 +36,22 @@ func Keccak256ForKey(key Key) Hash {
 
 var keccakHasherPool = sync.Pool{New: func() any { return sha3.NewLegacyKeccak256() }}
 
-func keccak256_Go(data []byte) Hash {
+func keccak256_Go(data []byte) (Hash, error) {
 	hasher := keccakHasherPool.Get().(keccakHasher)
 	hasher.Reset()
-	hasher.Write(data)
+	_, err := hasher.Write(data)
+	if err != nil {
+		keccakHasherPool.Put(hasher)
+		return Hash{}, err
+	}
 	var res Hash
-	hasher.Read(res[:])
+	_, err = hasher.Read(res[:])
+	if err != nil {
+		keccakHasherPool.Put(hasher)
+		return Hash{}, err
+	}
 	keccakHasherPool.Put(hasher)
-	return res
+	return res, nil
 }
 
 type keccakHasher interface {
@@ -52,7 +60,12 @@ type keccakHasher interface {
 	Read(out []byte) (int, error)
 }
 
-var emptyKeccak256Hash = keccak256_Go([]byte{})
+var emptyKeccak256Hash Hash
+
+func init() {
+	// keccak256 of empty input cannot fail: the sha3 hasher always accepts Write/Read on valid buffers.
+	emptyKeccak256Hash, _ = keccak256_Go([]byte{})
+}
 
 func keccak256_C(data []byte) Hash {
 	if len(data) == 0 {

--- a/go/common/keccak_test.go
+++ b/go/common/keccak_test.go
@@ -14,6 +14,8 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestKeccakC_ProducesSameHashAsGo(t *testing.T) {
@@ -150,7 +152,8 @@ func benchmark(b *testing.B, hasher func([]byte)) {
 
 func BenchmarkKeccakGo(b *testing.B) {
 	benchmark(b, func(data []byte) {
-		_, _ = keccak256_Go(data)
+		_, err := keccak256_Go(data)
+		require.NoError(b, err)
 	})
 }
 
@@ -163,7 +166,8 @@ func BenchmarkKeccakC(b *testing.B) {
 func BenchmarkKeccakGoAddressGeneric(b *testing.B) {
 	addr := Address{}
 	for i := 0; i < b.N; i++ {
-		_, _ = keccak256_Go(addr[:])
+		_, err := keccak256_Go(addr[:])
+		require.NoError(b, err)
 	}
 }
 
@@ -184,7 +188,8 @@ func BenchmarkKeccakCAddressSpecialized(b *testing.B) {
 func BenchmarkKeccakGoKeyGeneric(b *testing.B) {
 	key := Key{}
 	for i := 0; i < b.N; i++ {
-		_, _ = keccak256_Go(key[:])
+		_, err := keccak256_Go(key[:])
+		require.NoError(b, err)
 	}
 }
 

--- a/go/common/keccak_test.go
+++ b/go/common/keccak_test.go
@@ -26,7 +26,10 @@ func TestKeccakC_ProducesSameHashAsGo(t *testing.T) {
 		make([]byte, 1024),
 	}
 	for _, test := range tests {
-		want := keccak256_Go(test)
+		want, err := keccak256_Go(test)
+		if err != nil {
+			t.Fatal(err)
+		}
 		got := keccak256_C(test)
 		if want != got {
 			t.Errorf("unexpected hash for %v, wanted %v, got %v", test, want, got)
@@ -58,7 +61,10 @@ func TestKeccakC_AddressSpecializationProducesSameHashAsGenericVersion(t *testin
 	t.Run("keccak256_C_Address", func(t *testing.T) {
 		t.Parallel()
 		for _, test := range tests {
-			want := keccak256_Go(test[:])
+			want, err := keccak256_Go(test[:])
+			if err != nil {
+				t.Fatal(err)
+			}
 			got := keccak256_C_Address(test)
 			if want != got {
 				t.Errorf("unexpected hash for %v, wanted %v, got %v", test, want, got)
@@ -69,7 +75,10 @@ func TestKeccakC_AddressSpecializationProducesSameHashAsGenericVersion(t *testin
 	t.Run("Keccak256ForAddress", func(t *testing.T) {
 		t.Parallel()
 		for _, test := range tests {
-			want := keccak256_Go(test[:])
+			want, err := keccak256_Go(test[:])
+			if err != nil {
+				t.Fatal(err)
+			}
 			got := Keccak256ForAddress(test)
 			if want != got {
 				t.Errorf("unexpected hash for %v, wanted %v, got %v", test, want, got)
@@ -102,7 +111,10 @@ func TestKeccakC_KeySpecializationProducesSameHashAsGenericVersion(t *testing.T)
 	t.Run("keccak256_C_Key", func(t *testing.T) {
 		t.Parallel()
 		for _, test := range tests {
-			want := keccak256_Go(test[:])
+			want, err := keccak256_Go(test[:])
+			if err != nil {
+				t.Fatal(err)
+			}
 			got := keccak256_C_Key(test)
 			if want != got {
 				t.Errorf("unexpected hash for %v, wanted %v, got %v", test, want, got)
@@ -113,7 +125,10 @@ func TestKeccakC_KeySpecializationProducesSameHashAsGenericVersion(t *testing.T)
 	t.Run("Keccak256ForKey", func(t *testing.T) {
 		t.Parallel()
 		for _, test := range tests {
-			want := keccak256_Go(test[:])
+			want, err := keccak256_Go(test[:])
+			if err != nil {
+				t.Fatal(err)
+			}
 			got := Keccak256ForKey(test)
 			if want != got {
 				t.Errorf("unexpected hash for %v, wanted %v, got %v", test, want, got)

--- a/go/common/keccak_test.go
+++ b/go/common/keccak_test.go
@@ -150,7 +150,7 @@ func benchmark(b *testing.B, hasher func([]byte)) {
 
 func BenchmarkKeccakGo(b *testing.B) {
 	benchmark(b, func(data []byte) {
-		keccak256_Go(data)
+		_, _ = keccak256_Go(data)
 	})
 }
 
@@ -163,7 +163,7 @@ func BenchmarkKeccakC(b *testing.B) {
 func BenchmarkKeccakGoAddressGeneric(b *testing.B) {
 	addr := Address{}
 	for i := 0; i < b.N; i++ {
-		keccak256_Go(addr[:])
+		_, _ = keccak256_Go(addr[:])
 	}
 }
 
@@ -184,7 +184,7 @@ func BenchmarkKeccakCAddressSpecialized(b *testing.B) {
 func BenchmarkKeccakGoKeyGeneric(b *testing.B) {
 	key := Key{}
 	for i := 0; i < b.N; i++ {
-		keccak256_Go(key[:])
+		_, _ = keccak256_Go(key[:])
 	}
 }
 

--- a/go/common/utils.go
+++ b/go/common/utils.go
@@ -1,3 +1,13 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
 package common
 
 import (

--- a/go/common/utils.go
+++ b/go/common/utils.go
@@ -1,0 +1,22 @@
+package common
+
+import (
+	"io/fs"
+	"path/filepath"
+)
+
+// GetDirectorySize computes the size of all files in the given directory in bytes.
+// Returns 0 if the directory does not exist.
+func GetDirectorySize(directory string) (int64, error) {
+	var sum int64 = 0
+	err := filepath.Walk(directory, func(path string, info fs.FileInfo, retErr error) error {
+		if retErr != nil {
+			return nil
+		}
+		if !info.IsDir() {
+			sum += info.Size()
+		}
+		return nil
+	})
+	return sum, err
+}

--- a/go/common/utils_test.go
+++ b/go/common/utils_test.go
@@ -1,3 +1,13 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
 package common
 
 import (

--- a/go/common/utils_test.go
+++ b/go/common/utils_test.go
@@ -1,0 +1,39 @@
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDirectorySize_ComputesSizeCorrectly(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "testfile")
+	data := []byte("hello world")
+	err := os.WriteFile(file, data, 0644)
+	require.NoError(t, err)
+
+	size, err := GetDirectorySize(dir)
+	require.NoError(t, err)
+	require.Equal(t, int64(len(data)), size, "directory size should match file size")
+}
+
+func TestGetDirectorySize_NonExistentDirectoryReturnsZeroSize(t *testing.T) {
+	size, _ := GetDirectorySize("/path/does/not/exist")
+	// GetDirectorySize should return 0 for non-existent directory
+	require.Equal(t, int64(0), size, "size should be zero for non-existent directory")
+}
+
+func TestGetDirectorySize_SkipsUnreadableFile(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "file2")
+	data := []byte("xyz")
+	require.NoError(t, os.WriteFile(file, data, 0000)) // No permissions
+
+	size, err := GetDirectorySize(dir)
+	require.NoError(t, err)
+	// Should skip unreadable file and not panic
+	require.GreaterOrEqual(t, size, int64(0))
+}

--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -508,14 +508,14 @@ func GetCheckpointBlock(dir string) (uint64, error) {
 	return uint64(numRoots - 1), err
 }
 
-func RestoreBlockHeight(directory string, config MptConfig, block uint64) (err error) {
+func RestoreBlockHeight(directory string, config MptConfig, block uint64) (retErr error) {
 
 	// Make sure access to the directory is exclusive.
 	lock, err := LockDirectory(directory)
 	if err != nil {
 		return fmt.Errorf("failed to get exclusive access to directory: %v", err)
 	}
-	defer lock.Release()
+	defer func() { retErr = errors.Join(retErr, lock.Release()) }()
 
 	// Check available block height -- stop recovery if there are not enough blocks.
 	checkpointHeight, err := GetCheckpointBlock(directory)
@@ -532,8 +532,8 @@ func RestoreBlockHeight(directory string, config MptConfig, block uint64) (err e
 	}
 	defer func() {
 		// Only remove dirty flag is the recovery was successful.
-		if err == nil {
-			err = markClean(directory)
+		if retErr == nil {
+			retErr = markClean(directory)
 		}
 	}()
 
@@ -636,7 +636,7 @@ func (l *rootList) append(r Root) {
 	l.roots = append(l.roots, r)
 }
 
-func loadRoots(archiveDirectory string) (*rootList, error) {
+func loadRoots(archiveDirectory string) (_ *rootList, retErr error) {
 	filename := filepath.Join(archiveDirectory, fileNameArchiveRoots)
 	directory := filepath.Join(archiveDirectory, fileNameArchiveRootsCheckpointDirectory)
 
@@ -662,7 +662,7 @@ func loadRoots(archiveDirectory string) (*rootList, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { retErr = errors.Join(retErr, f.Close()) }()
 	stat, err := f.Stat()
 	if err != nil {
 		return nil, err

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/common/amount"
 	"github.com/0xsoniclabs/carmen/go/database/mpt/shared"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/exp/maps"
 )
@@ -383,7 +384,9 @@ func TestArchiveTrie_CanTrackBlocksHeight(t *testing.T) {
 				t.Errorf("archive should be initially empty, got %t, %d", empty, block)
 			}
 
-			archive.Add(1, common.Update{}, nil)
+			if err := archive.Add(1, common.Update{}, nil); err != nil {
+				t.Fatalf("failed to add block: %v", err)
+			}
 
 			block, empty, err = archive.GetBlockHeight()
 			if err != nil {
@@ -393,7 +396,9 @@ func TestArchiveTrie_CanTrackBlocksHeight(t *testing.T) {
 				t.Errorf("archive should be have height 1, got %t, %d", empty, block)
 			}
 
-			archive.Add(3, common.Update{}, nil)
+			if err := archive.Add(3, common.Update{}, nil); err != nil {
+				t.Fatalf("failed to add block: %v", err)
+			}
 
 			block, empty, err = archive.GetBlockHeight()
 			if err != nil {
@@ -424,17 +429,21 @@ func TestArchiveTrie_CanHandleMultipleBlocks(t *testing.T) {
 			blc1 := amount.New(1)
 			blc2 := amount.New(2)
 
-			archive.Add(1, common.Update{
+			if err := archive.Add(1, common.Update{
 				Balances: []common.BalanceUpdate{
 					{Account: addr1, Balance: blc1},
 				},
-			}, nil)
+			}, nil); err != nil {
+				t.Fatalf("failed to add block: %v", err)
+			}
 
-			archive.Add(3, common.Update{
+			if err := archive.Add(3, common.Update{
 				Balances: []common.BalanceUpdate{
 					{Account: addr1, Balance: blc2},
 				},
-			}, nil)
+			}, nil); err != nil {
+				t.Fatalf("failed to add block: %v", err)
+			}
 
 			want := []amount.Amount{blc0, blc1, blc1, blc2}
 			for i, want := range want {
@@ -1836,8 +1845,8 @@ func TestArchiveTrie_CanLoadRootsFromJunkySource(t *testing.T) {
 
 	var b bytes.Buffer
 	writer := bufio.NewWriter(&b)
-	storeRootsTo(writer, roots)
-	writer.Flush()
+	require.NoError(t, storeRootsTo(writer, roots))
+	require.NoError(t, writer.Flush())
 
 	for _, size := range []int{1, 2, 4, 1024} {
 		reader := utils.NewChunkReader(b.Bytes(), size)
@@ -2518,7 +2527,7 @@ func TestArchiveTrie_createCheckpoint_forwardsErrors(t *testing.T) {
 	tests := map[string]func(archive *ArchiveTrie) error{
 		"failing flush": func(archive *ArchiveTrie) error {
 			// Registering a pre-observed error causes the flush operation to fail.
-			archive.addError(fmt.Errorf("injected error"))
+			_ = archive.addError(fmt.Errorf("injected error"))
 			return nil
 		},
 		"out-of-sync components": func(archive *ArchiveTrie) error {
@@ -3072,7 +3081,7 @@ func TestRootList_LoadRoots_ForwardsIoIssues(t *testing.T) {
 				return err
 			}
 			t.Cleanup(func() {
-				os.Remove(dir)
+				require.NoError(t, os.Remove(dir))
 			})
 			return os.WriteFile(dir, []byte{}, 0700)
 		},
@@ -3505,7 +3514,7 @@ func TestRootList_Restore_FailsIfPendingCheckpointFileCanNotBeRenamed(t *testing
 	if err := os.Chmod(roots.directory, 0500); err != nil {
 		t.Fatalf("failed to make directory read-only: %v", err)
 	}
-	defer os.Chmod(roots.directory, 0700)
+	defer func() { require.NoError(t, os.Chmod(roots.directory, 0700)) }()
 
 	if err := getRootListRestorer(dir).Restore(cp); err == nil {
 		t.Errorf("expected recovery error due to read-only directory")
@@ -3684,7 +3693,7 @@ func BenchmarkArchiveFlush_Roots(b *testing.B) {
 			b.Errorf("failed to close archive: %v", err)
 		}
 	}()
-	archive.Add(1_000_000, common.Update{}, nil)
+	require.NoError(b, archive.Add(1_000_000, common.Update{}, nil))
 	for i := 0; i < b.N; i++ {
 		if err := archive.Flush(); err != nil {
 			b.Fatalf("failed to flush archive: %v", err)

--- a/go/database/mpt/codes.go
+++ b/go/database/mpt/codes.go
@@ -244,7 +244,7 @@ func readCodes(path string) (map[common.Hash][]byte, error) {
 
 // readCodesAndSize parses the content of the given file and returns the
 // contained collection of codes and the size of the file.
-func readCodesAndSize(path string) (map[common.Hash][]byte, uint64, error) {
+func readCodesAndSize(path string) (_ map[common.Hash][]byte, _ uint64, retErr error) {
 	// If there is no file, initialize and return an empty code collection.
 	info, err := os.Stat(path)
 	if os.IsNotExist(err) {
@@ -258,7 +258,7 @@ func readCodesAndSize(path string) (map[common.Hash][]byte, uint64, error) {
 	if err != nil {
 		return nil, 0, err
 	}
-	defer file.Close()
+	defer func() { retErr = errors.Join(retErr, file.Close()) }()
 	reader := bufio.NewReader(file)
 	data, err := parseCodes(reader)
 	return data, uint64(info.Size()), err

--- a/go/database/mpt/codes_test.go
+++ b/go/database/mpt/codes_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/0xsoniclabs/carmen/go/backend/utils"
 	"github.com/0xsoniclabs/carmen/go/backend/utils/checkpoint"
 	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -56,7 +57,7 @@ func TestCodes_OpenCodes_IOErrorsAreHandled(t *testing.T) {
 				t.Fatalf("failed to change directory permissions: %v", err)
 			}
 			t.Cleanup(func() {
-				os.Chmod(dir, stat.Mode())
+				require.NoError(t, os.Chmod(dir, stat.Mode()))
 			})
 			return dir
 		},
@@ -74,7 +75,7 @@ func TestCodes_OpenCodes_IOErrorsAreHandled(t *testing.T) {
 				t.Fatalf("failed to change directory permissions: %v", err)
 			}
 			t.Cleanup(func() {
-				os.Chmod(dir, stat.Mode())
+				require.NoError(t, os.Chmod(dir, stat.Mode()))
 			})
 			return dir
 		},
@@ -88,7 +89,7 @@ func TestCodes_OpenCodes_IOErrorsAreHandled(t *testing.T) {
 				t.Fatalf("failed to change file permissions: %v", err)
 			}
 			t.Cleanup(func() {
-				os.Chmod(file, 0600)
+				require.NoError(t, os.Chmod(file, 0600))
 			})
 			return dir
 		},
@@ -106,7 +107,7 @@ func TestCodes_OpenCodes_IOErrorsAreHandled(t *testing.T) {
 				t.Fatalf("failed to change file permissions: %v", err)
 			}
 			t.Cleanup(func() {
-				os.Chmod(file, 0600)
+				require.NoError(t, os.Chmod(file, 0600))
 			})
 			return dir
 		},
@@ -356,8 +357,8 @@ func TestCodes_Prepare_FailsIfFlushFails(t *testing.T) {
 
 	codes.add([]byte("code1"))
 
-	os.Chmod(codes.file, 0400) // make the file read-only
-	defer os.Chmod(codes.file, 0600)
+	require.NoError(t, os.Chmod(codes.file, 0400)) // make the file read-only
+	defer func() { require.NoError(t, os.Chmod(codes.file, 0600)) }()
 
 	cp1 := checkpoint.Checkpoint(1)
 	if err := codes.Prepare(cp1); err == nil {
@@ -379,7 +380,7 @@ func TestCodes_Commit_HandlesIoIssues(t *testing.T) {
 				return err
 			}
 			t.Cleanup(func() {
-				os.Chmod(subDir, 0700)
+				require.NoError(t, os.Chmod(subDir, 0700))
 			})
 			return nil
 		},
@@ -858,7 +859,7 @@ func TestCodes_readCodesAndSize_PermissionErrorsAreDetected(t *testing.T) {
 	if err := os.Chmod(dir, 0000); err != nil {
 		t.Fatalf("failed to change directory permissions: %v", err)
 	}
-	defer os.Chmod(dir, 0700)
+	defer func() { require.NoError(t, os.Chmod(dir, 0700)) }()
 
 	_, _, err := readCodesAndSize(path)
 	if err == nil {

--- a/go/database/mpt/directory_lock_test.go
+++ b/go/database/mpt/directory_lock_test.go
@@ -15,6 +15,8 @@ import (
 	"os"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestDirectoryLock_AcquireAndRelease(t *testing.T) {
@@ -52,7 +54,7 @@ func TestDirectoryLock_LockIsExclusive(t *testing.T) {
 		t.Errorf("unexpected non-nil lock result in error case: %v", lockB)
 	}
 
-	lockA.Release()
+	require.NoError(t, lockA.Release())
 }
 
 func TestDirectoryLock_CannotLockFile(t *testing.T) {
@@ -114,7 +116,7 @@ func TestDirectoryLock_ForceUnlockDirectory_ReportsErrorIfUnlockingFailed(t *tes
 	if err := os.Chmod(dir, 0500); err != nil {
 		t.Fatalf("failed to remove write permission: %v", err)
 	}
-	defer os.Chmod(dir, 0700)
+	defer func() { require.NoError(t, os.Chmod(dir, 0700)) }()
 
 	if err := ForceUnlockDirectory(dir); err == nil {
 		t.Fatalf("expected error when unlocking failed")

--- a/go/database/mpt/forest.go
+++ b/go/database/mpt/forest.go
@@ -663,7 +663,9 @@ func (s *Forest) Dump(rootRef *NodeReference) {
 		return
 	}
 	defer root.Release()
-	root.Get().Dump(os.Stdout, s, rootRef, "")
+	if err := root.Get().Dump(os.Stdout, s, rootRef, ""); err != nil {
+		fmt.Printf("Failed to dump trie: %v", err)
+	}
 }
 
 // Check verifies internal invariants of the Trie instance. If the trie is

--- a/go/database/mpt/hasher_test.go
+++ b/go/database/mpt/hasher_test.go
@@ -380,8 +380,14 @@ func TestEthereumLikeHasher_BranchNode_RecomputesEmbeddedFlagsForHashInNodeMode(
 	// In those cases, embedded flags in branch nodes have not been updated
 	// if the hashes of the child nodes have been valid.
 
-	key1 := hexToKey("c76547ce3912f8c25a9943819c2992169865dfd500bed5213c8a92ceff5db5e3")
-	key2 := hexToKey("2968f9295ca3ab4960ae553a18f47567e56f2777ad762ee1d639421728926a37")
+	key1, err := hexToKey("c76547ce3912f8c25a9943819c2992169865dfd500bed5213c8a92ceff5db5e3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	key2, err := hexToKey("2968f9295ca3ab4960ae553a18f47567e56f2777ad762ee1d639421728926a37")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	val1 := common.Value{}
 	val1[len(val1)-1] = 1
@@ -405,7 +411,7 @@ func TestEthereumLikeHasher_BranchNode_RecomputesEmbeddedFlagsForHashInNodeMode(
 	}
 
 	hasher := makeEthereumLikeHasher()
-	_, _, err := hasher.updateHashes(&ref, ctxt)
+	_, _, err = hasher.updateHashes(&ref, ctxt)
 	if err != nil {
 		t.Fatalf("failed to compute hash for node: %v", err)
 	}

--- a/go/database/mpt/io/archive_test.go
+++ b/go/database/mpt/io/archive_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/common/amount"
 	"github.com/0xsoniclabs/carmen/go/database/mpt"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIO_Archive_ExportAndImport(t *testing.T) {
@@ -67,7 +68,7 @@ func TestIO_Archive_ExportAndImport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open recovered Archive: %v", err)
 	}
-	defer target.Close()
+	defer func() { require.NoError(t, target.Close()) }()
 
 	height, _, err := target.GetBlockHeight()
 	if err != nil {
@@ -133,7 +134,7 @@ func TestIO_ArchiveAndLive_ExportAndImport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot open live trie: %v", err)
 	}
-	defer live.Close()
+	defer func() { require.NoError(t, live.Close()) }()
 	headHash, _, err := live.UpdateHashes()
 	if err != nil {
 		t.Fatalf("cannot get live trie hash: %v", err)
@@ -151,7 +152,7 @@ func TestIO_ArchiveAndLive_ExportAndImport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open recovered Archive: %v", err)
 	}
-	defer archive.Close()
+	defer func() { require.NoError(t, archive.Close()) }()
 
 	height, _, err := archive.GetBlockHeight()
 	if err != nil {

--- a/go/database/mpt/io/live.go
+++ b/go/database/mpt/io/live.go
@@ -140,7 +140,7 @@ func (e *exportableLiveTrie) GetCodeForHash(hash common.Hash) []byte {
 // its content to the given output writer. The result contains all the
 // information required by the Import function below to reconstruct the full
 // state of the LiveDB.
-func Export(ctx context.Context, logger *Log, directory string, out io.Writer) error {
+func Export(ctx context.Context, logger *Log, directory string, out io.Writer) (retErr error) {
 	info, err := CheckMptDirectoryAndGetInfo(directory)
 	if err != nil {
 		return fmt.Errorf("error in input directory: %v", err)
@@ -155,7 +155,7 @@ func Export(ctx context.Context, logger *Log, directory string, out io.Writer) e
 	if err != nil {
 		return fmt.Errorf("failed to open LiveDB: %v", err)
 	}
-	defer db.Close()
+	defer func() { retErr = errors.Join(retErr, db.Close()) }()
 
 	_, err = ExportLive(ctx, logger, &exportableLiveTrie{db: db, directory: directory}, out)
 	return err
@@ -163,7 +163,7 @@ func Export(ctx context.Context, logger *Log, directory string, out io.Writer) e
 
 // ExportBlockFromArchive exports LiveDB genesis for a single given block from an Archive.
 // Note: block must be <= of Archive block height.
-func ExportBlockFromArchive(ctx context.Context, logger *Log, directory string, out io.Writer, block uint64) error {
+func ExportBlockFromArchive(ctx context.Context, logger *Log, directory string, out io.Writer, block uint64) (retErr error) {
 	info, err := CheckMptDirectoryAndGetInfo(directory)
 	if err != nil {
 		return fmt.Errorf("error in input directory: %v", err)
@@ -178,7 +178,7 @@ func ExportBlockFromArchive(ctx context.Context, logger *Log, directory string, 
 		return err
 	}
 
-	defer archive.Close()
+	defer func() { retErr = errors.Join(retErr, archive.Close()) }()
 	_, err = ExportLive(ctx, logger, exportableArchiveTrie{trie: archive, block: block}, out)
 	return err
 }
@@ -517,12 +517,12 @@ func (e *exportVisitor) Visit(node mpt.Node, _ mpt.NodeInfo) error {
 	return nil
 }
 
-func checkEmptyDirectory(directory string) error {
+func checkEmptyDirectory(directory string) (retErr error) {
 	file, err := os.Open(directory)
 	if err != nil {
 		return fmt.Errorf("failed to open directory %s: %w", directory, err)
 	}
-	defer file.Close()
+	defer func() { retErr = errors.Join(retErr, file.Close()) }()
 	state, err := file.Stat()
 	if err != nil {
 		return fmt.Errorf("failed to open file information for %s: %w", directory, err)

--- a/go/database/mpt/io/live_test.go
+++ b/go/database/mpt/io/live_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/common/amount"
 	"github.com/0xsoniclabs/carmen/go/database/mpt"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIO_ExportAndImportAsLiveDb(t *testing.T) {
@@ -40,7 +41,7 @@ func TestIO_ExportAndImportAsLiveDb(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open recovered DB: %v", err)
 	}
-	defer db.Close()
+	defer func() { require.NoError(t, db.Close()) }()
 
 	if exists, err := db.Exists(common.Address{1}); err != nil || !exists {
 		t.Fatalf("restored DB does not contain account 1")
@@ -72,7 +73,7 @@ func TestIO_ExportAndImportAsArchive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open recovered DB: %v", err)
 	}
-	defer db.Close()
+	defer func() { require.NoError(t, db.Close()) }()
 
 	height, empty, err := db.GetBlockHeight()
 	if err != nil || empty || height != genesisBlock {
@@ -121,8 +122,8 @@ func TestIO_ExportedDataDoesNotContainExtraCodes(t *testing.T) {
 			t.Fatalf("failed to fetch code: %v", err)
 		}
 		modified := append(code, []byte("extra_code")...)
-		s.SetCode(addr1, modified)
-		s.SetCode(addr1, code)
+		require.NoError(t, s.SetCode(addr1, modified))
+		require.NoError(t, s.SetCode(addr1, code))
 		codesAfter := s.GetCodes()
 		if before, after := len(codesBefore), len(codesAfter); before+1 != after {
 			t.Fatalf("modification did not had expected code-altering effect: %d -> %d", before, after)

--- a/go/database/mpt/io/total_supply.go
+++ b/go/database/mpt/io/total_supply.go
@@ -12,14 +12,16 @@ package io
 
 import (
 	"context"
+	"errors"
 	"fmt"
+
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/common/interrupt"
 	"github.com/0xsoniclabs/carmen/go/database/mpt"
 	"github.com/holiman/uint256"
 )
 
-func CalculateLiveTotalSupply(ctx context.Context, logger *Log, directory string) error {
+func CalculateLiveTotalSupply(ctx context.Context, logger *Log, directory string) (retErr error) {
 	info, err := CheckMptDirectoryAndGetInfo(directory)
 	if err != nil {
 		return fmt.Errorf("error in input directory: %v", err)
@@ -33,7 +35,7 @@ func CalculateLiveTotalSupply(ctx context.Context, logger *Log, directory string
 	if err != nil {
 		return fmt.Errorf("failed to open LiveDB: %v", err)
 	}
-	defer mptState.Close()
+	defer func() { retErr = errors.Join(retErr, mptState.Close()) }()
 
 	hash, err := mptState.GetHash()
 	if err != nil {
@@ -63,7 +65,7 @@ func CalculateLiveTotalSupply(ctx context.Context, logger *Log, directory string
 	return nil
 }
 
-func CalculateArchiveTotalSupply(ctx context.Context, logger *Log, directory string, block uint64) error {
+func CalculateArchiveTotalSupply(ctx context.Context, logger *Log, directory string, block uint64) (retErr error) {
 	info, err := CheckMptDirectoryAndGetInfo(directory)
 	if err != nil {
 		return fmt.Errorf("error in input directory: %v", err)
@@ -77,7 +79,7 @@ func CalculateArchiveTotalSupply(ctx context.Context, logger *Log, directory str
 	if err != nil {
 		return err
 	}
-	defer archive.Close()
+	defer func() { retErr = errors.Join(retErr, archive.Close()) }()
 
 	hash, err := archive.GetHash(block)
 	if err != nil {

--- a/go/database/mpt/live_trie_test.go
+++ b/go/database/mpt/live_trie_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/0xsoniclabs/carmen/go/backend/stock"
 	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLiveTrie_EmptyTrieIsConsistent(t *testing.T) {
@@ -580,8 +581,8 @@ func TestLiveTrie_SameContentProducesSameHash(t *testing.T) {
 
 			info1 := AccountInfo{Nonce: common.ToNonce(1)}
 			info2 := AccountInfo{Nonce: common.ToNonce(2)}
-			trie1.SetAccountInfo(common.Address{1}, info1)
-			trie2.SetAccountInfo(common.Address{2}, info2)
+			require.NoError(t, trie1.SetAccountInfo(common.Address{1}, info1))
+			require.NoError(t, trie2.SetAccountInfo(common.Address{2}, info2))
 
 			hash1, _, err = trie1.UpdateHashes()
 			if err != nil {
@@ -596,8 +597,8 @@ func TestLiveTrie_SameContentProducesSameHash(t *testing.T) {
 			}
 
 			// Update tries to contain same data.
-			trie1.SetAccountInfo(common.Address{2}, info2)
-			trie2.SetAccountInfo(common.Address{1}, info1)
+			require.NoError(t, trie1.SetAccountInfo(common.Address{2}, info2))
+			require.NoError(t, trie2.SetAccountInfo(common.Address{1}, info1))
 
 			hash1, _, err = trie1.UpdateHashes()
 			if err != nil {
@@ -629,8 +630,8 @@ func TestLiveTrie_ChangeInTrieSubstructureUpdatesHash(t *testing.T) {
 
 			info1 := AccountInfo{Nonce: common.ToNonce(1)}
 			info2 := AccountInfo{Nonce: common.ToNonce(2)}
-			trie.SetAccountInfo(common.Address{1}, info1)
-			trie.SetAccountInfo(common.Address{2}, info2)
+			require.NoError(t, trie.SetAccountInfo(common.Address{1}, info1))
+			require.NoError(t, trie.SetAccountInfo(common.Address{2}, info2))
 
 			hash1, _, err := trie.UpdateHashes()
 			if err != nil {
@@ -639,7 +640,7 @@ func TestLiveTrie_ChangeInTrieSubstructureUpdatesHash(t *testing.T) {
 
 			// The next update does not change anything in the root node, but the hash should
 			// still be updated.
-			trie.SetAccountInfo(common.Address{1}, info2)
+			require.NoError(t, trie.SetAccountInfo(common.Address{1}, info2))
 
 			hash2, _, err := trie.UpdateHashes()
 			if err != nil {
@@ -942,21 +943,21 @@ func TestLiveTrie_VerificationOfFreshArchivePasses(t *testing.T) {
 			}
 
 			// Add some data.
-			trie.SetAccountInfo(common.Address{1}, AccountInfo{Nonce: common.ToNonce(1), CodeHash: emptyCodeHash})
-			trie.SetAccountInfo(common.Address{2}, AccountInfo{Nonce: common.ToNonce(2), CodeHash: emptyCodeHash})
-			trie.SetAccountInfo(common.Address{3}, AccountInfo{Nonce: common.ToNonce(3), CodeHash: emptyCodeHash})
+			require.NoError(t, trie.SetAccountInfo(common.Address{1}, AccountInfo{Nonce: common.ToNonce(1), CodeHash: emptyCodeHash}))
+			require.NoError(t, trie.SetAccountInfo(common.Address{2}, AccountInfo{Nonce: common.ToNonce(2), CodeHash: emptyCodeHash}))
+			require.NoError(t, trie.SetAccountInfo(common.Address{3}, AccountInfo{Nonce: common.ToNonce(3), CodeHash: emptyCodeHash}))
 
-			trie.SetValue(common.Address{1}, common.Key{1}, common.Value{1})
+			require.NoError(t, trie.SetValue(common.Address{1}, common.Key{1}, common.Value{1}))
 
-			trie.SetValue(common.Address{2}, common.Key{1}, common.Value{1})
-			trie.SetValue(common.Address{2}, common.Key{2}, common.Value{1})
+			require.NoError(t, trie.SetValue(common.Address{2}, common.Key{1}, common.Value{1}))
+			require.NoError(t, trie.SetValue(common.Address{2}, common.Key{2}, common.Value{1}))
 
-			trie.SetValue(common.Address{3}, common.Key{1}, common.Value{1})
-			trie.SetValue(common.Address{3}, common.Key{2}, common.Value{1})
-			trie.SetValue(common.Address{3}, common.Key{3}, common.Value{1})
+			require.NoError(t, trie.SetValue(common.Address{3}, common.Key{1}, common.Value{1}))
+			require.NoError(t, trie.SetValue(common.Address{3}, common.Key{2}, common.Value{1}))
+			require.NoError(t, trie.SetValue(common.Address{3}, common.Key{3}, common.Value{1}))
 
 			// Delete some data.
-			trie.SetAccountInfo(common.Address{2}, AccountInfo{})
+			require.NoError(t, trie.SetAccountInfo(common.Address{2}, AccountInfo{}))
 
 			if err := trie.Close(); err != nil {
 				t.Fatalf("failed to close trie: %v", err)
@@ -979,21 +980,21 @@ func TestLiveTrie_VerificationOfLiveTrieWithMissingFileFails(t *testing.T) {
 			}
 
 			// Add some data.
-			trie.SetAccountInfo(common.Address{1}, AccountInfo{Nonce: common.ToNonce(1)})
-			trie.SetAccountInfo(common.Address{2}, AccountInfo{Nonce: common.ToNonce(2)})
-			trie.SetAccountInfo(common.Address{3}, AccountInfo{Nonce: common.ToNonce(3)})
+			require.NoError(t, trie.SetAccountInfo(common.Address{1}, AccountInfo{Nonce: common.ToNonce(1)}))
+			require.NoError(t, trie.SetAccountInfo(common.Address{2}, AccountInfo{Nonce: common.ToNonce(2)}))
+			require.NoError(t, trie.SetAccountInfo(common.Address{3}, AccountInfo{Nonce: common.ToNonce(3)}))
 
-			trie.SetValue(common.Address{1}, common.Key{1}, common.Value{1})
+			require.NoError(t, trie.SetValue(common.Address{1}, common.Key{1}, common.Value{1}))
 
-			trie.SetValue(common.Address{2}, common.Key{1}, common.Value{1})
-			trie.SetValue(common.Address{2}, common.Key{2}, common.Value{1})
+			require.NoError(t, trie.SetValue(common.Address{2}, common.Key{1}, common.Value{1}))
+			require.NoError(t, trie.SetValue(common.Address{2}, common.Key{2}, common.Value{1}))
 
-			trie.SetValue(common.Address{3}, common.Key{1}, common.Value{1})
-			trie.SetValue(common.Address{3}, common.Key{2}, common.Value{1})
-			trie.SetValue(common.Address{3}, common.Key{3}, common.Value{1})
+			require.NoError(t, trie.SetValue(common.Address{3}, common.Key{1}, common.Value{1}))
+			require.NoError(t, trie.SetValue(common.Address{3}, common.Key{2}, common.Value{1}))
+			require.NoError(t, trie.SetValue(common.Address{3}, common.Key{3}, common.Value{1}))
 
 			// Delete some data.
-			trie.SetAccountInfo(common.Address{2}, AccountInfo{})
+			require.NoError(t, trie.SetAccountInfo(common.Address{2}, AccountInfo{}))
 
 			if err := trie.Close(); err != nil {
 				t.Fatalf("failed to close trie: %v", err)
@@ -1020,21 +1021,21 @@ func TestLiveTrie_VerificationOfLiveTrieWithCorruptedFileFails(t *testing.T) {
 			}
 
 			// Add some data.
-			trie.SetAccountInfo(common.Address{1}, AccountInfo{Nonce: common.ToNonce(1)})
-			trie.SetAccountInfo(common.Address{2}, AccountInfo{Nonce: common.ToNonce(2)})
-			trie.SetAccountInfo(common.Address{3}, AccountInfo{Nonce: common.ToNonce(3)})
+			require.NoError(t, trie.SetAccountInfo(common.Address{1}, AccountInfo{Nonce: common.ToNonce(1)}))
+			require.NoError(t, trie.SetAccountInfo(common.Address{2}, AccountInfo{Nonce: common.ToNonce(2)}))
+			require.NoError(t, trie.SetAccountInfo(common.Address{3}, AccountInfo{Nonce: common.ToNonce(3)}))
 
-			trie.SetValue(common.Address{1}, common.Key{1}, common.Value{1})
+			require.NoError(t, trie.SetValue(common.Address{1}, common.Key{1}, common.Value{1}))
 
-			trie.SetValue(common.Address{2}, common.Key{1}, common.Value{1})
-			trie.SetValue(common.Address{2}, common.Key{2}, common.Value{1})
+			require.NoError(t, trie.SetValue(common.Address{2}, common.Key{1}, common.Value{1}))
+			require.NoError(t, trie.SetValue(common.Address{2}, common.Key{2}, common.Value{1}))
 
-			trie.SetValue(common.Address{3}, common.Key{1}, common.Value{1})
-			trie.SetValue(common.Address{3}, common.Key{2}, common.Value{1})
-			trie.SetValue(common.Address{3}, common.Key{3}, common.Value{1})
+			require.NoError(t, trie.SetValue(common.Address{3}, common.Key{1}, common.Value{1}))
+			require.NoError(t, trie.SetValue(common.Address{3}, common.Key{2}, common.Value{1}))
+			require.NoError(t, trie.SetValue(common.Address{3}, common.Key{3}, common.Value{1}))
 
 			// Delete some data.
-			trie.SetAccountInfo(common.Address{2}, AccountInfo{})
+			require.NoError(t, trie.SetAccountInfo(common.Address{2}, AccountInfo{}))
 
 			if err := trie.Close(); err != nil {
 				t.Fatalf("failed to close trie: %v", err)

--- a/go/database/mpt/nodes.go
+++ b/go/database/mpt/nodes.go
@@ -793,8 +793,8 @@ func (EmptyNode) Check(NodeSource, *NodeReference, []Nibble) error {
 }
 
 func (EmptyNode) Dump(out io.Writer, _ NodeSource, thisRef *NodeReference, indent string) error {
-	fmt.Fprintf(out, "%s-empty- (ID: %v)\n", indent, thisRef.Id())
-	return nil
+	_, err := fmt.Fprintf(out, "%s-empty- (ID: %v)\n", indent, thisRef.Id())
+	return err
 }
 
 func (EmptyNode) Visit(_ NodeManager, ref *NodeReference, depth int, mode AccessMode, visitor NodeVisitor) (bool, error) {
@@ -1143,7 +1143,9 @@ func (n *BranchNode) Check(source NodeSource, thisRef *NodeReference, _ []Nibble
 
 func (n *BranchNode) Dump(out io.Writer, source NodeSource, thisRef *NodeReference, indent string) error {
 	errs := []error{}
-	fmt.Fprintf(out, "%sBranch (ID: %v, dirty: %t, frozen: %t, Dirty: %016b, Embedded: %016b, Frozen: %016b, Hash: %v, hashState: %v):\n", indent, thisRef.Id(), n.IsDirty(), n.IsFrozen(), n.dirtyHashes, n.embeddedChildren, n.frozenChildren, formatHashForDump(n.hash), n.getHashStatus())
+	if _, err := fmt.Fprintf(out, "%sBranch (ID: %v, dirty: %t, frozen: %t, Dirty: %016b, Embedded: %016b, Frozen: %016b, Hash: %v, hashState: %v):\n", indent, thisRef.Id(), n.IsDirty(), n.IsFrozen(), n.dirtyHashes, n.embeddedChildren, n.frozenChildren, formatHashForDump(n.hash), n.getHashStatus()); err != nil {
+		errs = append(errs, err)
+	}
 	for i := range n.children {
 		child := &n.children[i]
 		if child.Id().IsEmpty() {
@@ -1155,7 +1157,9 @@ func (n *BranchNode) Dump(out io.Writer, source NodeSource, thisRef *NodeReferen
 				errs = append(errs, err)
 			}
 		} else {
-			fmt.Fprintf(out, "%s  ERROR: unable to load node %v: %v", indent, child, err)
+			if _, err := fmt.Fprintf(out, "%s  ERROR: unable to load node %v: %v", indent, child, err); err != nil {
+				errs = append(errs, err)
+			}
 			errs = append(errs, err)
 		}
 	}
@@ -1607,14 +1611,18 @@ func (n *ExtensionNode) Check(source NodeSource, thisRef *NodeReference, _ []Nib
 
 func (n *ExtensionNode) Dump(out io.Writer, source NodeSource, thisRef *NodeReference, indent string) error {
 	errs := []error{}
-	fmt.Fprintf(out, "%sExtension (ID: %v/%t, nextHashDirty: %t, Embedded: %t, Hash: %v, hashState: %v): %v\n", indent, thisRef.Id(), n.IsFrozen(), n.nextHashDirty, n.nextIsEmbedded, formatHashForDump(n.hash), n.getHashStatus(), &n.path)
+	if _, err := fmt.Fprintf(out, "%sExtension (ID: %v/%t, nextHashDirty: %t, Embedded: %t, Hash: %v, hashState: %v): %v\n", indent, thisRef.Id(), n.IsFrozen(), n.nextHashDirty, n.nextIsEmbedded, formatHashForDump(n.hash), n.getHashStatus(), &n.path); err != nil {
+		errs = append(errs, err)
+	}
 	if handle, err := source.getViewAccess(&n.next); err == nil {
 		defer handle.Release()
 		if err := handle.Get().Dump(out, source, &n.next, indent+"  "); err != nil {
 			errs = append(errs, err)
 		}
 	} else {
-		fmt.Fprintf(out, "%s  ERROR: unable to load node %v: %v", indent, n.next, err)
+		if _, err := fmt.Fprintf(out, "%s  ERROR: unable to load node %v: %v", indent, n.next, err); err != nil {
+			errs = append(errs, err)
+		}
 		errs = append(errs, err)
 	}
 	return errors.Join(errs...)
@@ -1808,7 +1816,10 @@ func splitLeafNode(
 	thisIsFrozen := this.IsFrozen()
 	remainingPathLength := byte(len(partialPath)-commonPrefixLength) - 1
 	if manager.getConfig().TrackSuffixLengthsInLeafNodes {
-		sibling.setPathLength(manager, siblingRef, siblingHandle, remainingPathLength)
+		_, _, err := sibling.setPathLength(manager, siblingRef, siblingHandle, remainingPathLength)
+		if err != nil {
+			return NodeReference{}, err
+		}
 		ref, _, err := this.setPathLength(manager, thisRef, thisHandle, remainingPathLength)
 		if err != nil {
 			return NodeReference{}, err
@@ -2036,9 +2047,11 @@ func (n *AccountNode) Check(source NodeSource, thisRef *NodeReference, path []Ni
 
 func (n *AccountNode) Dump(out io.Writer, source NodeSource, thisRef *NodeReference, indent string) error {
 	errs := []error{}
-	fmt.Fprintf(out, "%sAccount (ID: %v, dirty: %t, frozen: %t, path length: %v, Hash: %v, hashState: %v): %v - %v\n", indent, thisRef.Id(), n.IsDirty(), n.IsFrozen(), n.pathLength, formatHashForDump(n.hash), n.getHashStatus(), n.address, n.info)
+	if _, err := fmt.Fprintf(out, "%sAccount (ID: %v, dirty: %t, frozen: %t, path length: %v, Hash: %v, hashState: %v): %v - %v\n", indent, thisRef.Id(), n.IsDirty(), n.IsFrozen(), n.pathLength, formatHashForDump(n.hash), n.getHashStatus(), n.address, n.info); err != nil {
+		errs = append(errs, err)
+	}
 	if n.storage.Id().IsEmpty() {
-		return nil
+		return errors.Join(errs...)
 	}
 	if node, err := source.getViewAccess(&n.storage); err == nil {
 		defer node.Release()
@@ -2046,7 +2059,9 @@ func (n *AccountNode) Dump(out io.Writer, source NodeSource, thisRef *NodeRefere
 			errs = append(errs, err)
 		}
 	} else {
-		fmt.Fprintf(out, "%s  ERROR: unable to load node %v: %v", indent, n.storage, err)
+		if _, err := fmt.Fprintf(out, "%s  ERROR: unable to load node %v: %v", indent, n.storage, err); err != nil {
+			errs = append(errs, err)
+		}
 		errs = append(errs, err)
 	}
 	return errors.Join(errs...)
@@ -2248,8 +2263,8 @@ func (n *ValueNode) Check(source NodeSource, thisRef *NodeReference, path []Nibb
 }
 
 func (n *ValueNode) Dump(out io.Writer, source NodeSource, thisRef *NodeReference, indent string) error {
-	fmt.Fprintf(out, "%sValue (ID: %v/%t/%d, Hash: %v, hashState: %v): %v - %x\n", indent, thisRef.Id(), n.IsFrozen(), n.pathLength, formatHashForDump(n.hash), n.getHashStatus(), n.key, n.value)
-	return nil
+	_, err := fmt.Fprintf(out, "%sValue (ID: %v/%t/%d, Hash: %v, hashState: %v): %v - %x\n", indent, thisRef.Id(), n.IsFrozen(), n.pathLength, formatHashForDump(n.hash), n.getHashStatus(), n.key, n.value)
+	return err
 }
 
 func formatHashForDump(hash common.Hash) string {
@@ -2549,13 +2564,15 @@ func (AccountNodeWithPathLengthEncoderWithNodeHash) GetEncodedSize() int {
 }
 
 func (AccountNodeWithPathLengthEncoderWithNodeHash) Store(dst []byte, node *AccountNode) error {
-	AccountNodeEncoderWithNodeHash{}.Store(dst, node)
+	// AccountNodeEncoderWithNodeHash.Store only performs copy operations and cannot fail.
+	_ = AccountNodeEncoderWithNodeHash{}.Store(dst, node)
 	dst[len(dst)-1] = node.pathLength
 	return nil
 }
 
 func (AccountNodeWithPathLengthEncoderWithNodeHash) Load(src []byte, node *AccountNode) error {
-	AccountNodeEncoderWithNodeHash{}.Load(src, node)
+	// AccountNodeEncoderWithNodeHash.Load only performs copy operations and cannot fail.
+	_ = AccountNodeEncoderWithNodeHash{}.Load(src, node)
 	node.pathLength = src[len(src)-1]
 	return nil
 }
@@ -2567,13 +2584,15 @@ func (AccountNodeWithPathLengthEncoderWithChildHash) GetEncodedSize() int {
 }
 
 func (AccountNodeWithPathLengthEncoderWithChildHash) Store(dst []byte, node *AccountNode) error {
-	AccountNodeEncoderWithChildHash{}.Store(dst, node)
+	// AccountNodeEncoderWithChildHash.Store only performs copy operations and cannot fail.
+	_ = AccountNodeEncoderWithChildHash{}.Store(dst, node)
 	dst[len(dst)-1] = node.pathLength
 	return nil
 }
 
 func (AccountNodeWithPathLengthEncoderWithChildHash) Load(src []byte, node *AccountNode) error {
-	AccountNodeEncoderWithChildHash{}.Load(src, node)
+	// AccountNodeEncoderWithChildHash.Load only performs copy operations and cannot fail.
+	_ = AccountNodeEncoderWithChildHash{}.Load(src, node)
 	node.pathLength = src[len(src)-1]
 	return nil
 }
@@ -2612,14 +2631,16 @@ func (ValueNodeEncoderWithNodeHash) Store(dst []byte, node *ValueNode) error {
 	if !node.hasCleanHash() {
 		panic("unable to store value node with dirty hash")
 	}
-	ValueNodeEncoderWithoutNodeHash{}.Store(dst, node)
+	// ValueNodeEncoderWithoutNodeHash.Store only performs copy operations and cannot fail.
+	_ = ValueNodeEncoderWithoutNodeHash{}.Store(dst, node)
 	dst = dst[ValueNodeEncoderWithoutNodeHash{}.GetEncodedSize():]
 	copy(dst, node.hash[:])
 	return nil
 }
 
 func (ValueNodeEncoderWithNodeHash) Load(src []byte, node *ValueNode) error {
-	ValueNodeEncoderWithoutNodeHash{}.Load(src, node)
+	// ValueNodeEncoderWithoutNodeHash.Load only performs copy operations and cannot fail.
+	_ = ValueNodeEncoderWithoutNodeHash{}.Load(src, node)
 	src = src[ValueNodeEncoderWithoutNodeHash{}.GetEncodedSize():]
 	copy(node.hash[:], src)
 	node.hashStatus = hashStatusClean
@@ -2633,13 +2654,15 @@ func (ValueNodeWithPathLengthEncoderWithoutNodeHash) GetEncodedSize() int {
 }
 
 func (ValueNodeWithPathLengthEncoderWithoutNodeHash) Store(dst []byte, node *ValueNode) error {
-	ValueNodeEncoderWithoutNodeHash{}.Store(dst, node)
+	// ValueNodeEncoderWithoutNodeHash.Store only performs copy operations and cannot fail.
+	_ = ValueNodeEncoderWithoutNodeHash{}.Store(dst, node)
 	dst[len(dst)-1] = node.pathLength
 	return nil
 }
 
 func (ValueNodeWithPathLengthEncoderWithoutNodeHash) Load(src []byte, node *ValueNode) error {
-	ValueNodeEncoderWithoutNodeHash{}.Load(src, node)
+	// ValueNodeEncoderWithoutNodeHash.Load only performs copy operations and cannot fail.
+	_ = ValueNodeEncoderWithoutNodeHash{}.Load(src, node)
 	node.pathLength = src[len(src)-1]
 	return nil
 }
@@ -2651,13 +2674,15 @@ func (ValueNodeWithPathLengthEncoderWithNodeHash) GetEncodedSize() int {
 }
 
 func (ValueNodeWithPathLengthEncoderWithNodeHash) Store(dst []byte, node *ValueNode) error {
-	ValueNodeEncoderWithNodeHash{}.Store(dst, node)
+	// ValueNodeEncoderWithNodeHash.Store only performs copy operations and cannot fail.
+	_ = ValueNodeEncoderWithNodeHash{}.Store(dst, node)
 	dst[len(dst)-1] = node.pathLength
 	return nil
 }
 
 func (ValueNodeWithPathLengthEncoderWithNodeHash) Load(src []byte, node *ValueNode) error {
-	ValueNodeEncoderWithNodeHash{}.Load(src, node)
+	// ValueNodeEncoderWithNodeHash.Load only performs copy operations and cannot fail.
+	_ = ValueNodeEncoderWithNodeHash{}.Load(src, node)
 	node.pathLength = src[len(src)-1]
 	return nil
 }

--- a/go/database/mpt/nodes_test.go
+++ b/go/database/mpt/nodes_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/common/amount"
 	"github.com/0xsoniclabs/carmen/go/database/mpt/shared"
+	"github.com/stretchr/testify/require"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -4617,9 +4618,9 @@ func TestAccountNodeEncoderWithNodeHash(t *testing.T) {
 	}
 	encoder := AccountNodeEncoderWithNodeHash{}
 	buffer := make([]byte, encoder.GetEncodedSize())
-	encoder.Store(buffer, &node)
+	require.NoError(t, encoder.Store(buffer, &node))
 	recovered := AccountNode{}
-	encoder.Load(buffer, &recovered)
+	require.NoError(t, encoder.Load(buffer, &recovered))
 	node.storageHashDirty = true
 	if !reflect.DeepEqual(node, recovered) {
 		t.Errorf("encoding/decoding failed, wanted %v, got %v", node, recovered)
@@ -4638,9 +4639,9 @@ func TestAccountNodeEncoderWithChildHash(t *testing.T) {
 	}
 	encoder := AccountNodeEncoderWithChildHash{}
 	buffer := make([]byte, encoder.GetEncodedSize())
-	encoder.Store(buffer, &node)
+	require.NoError(t, encoder.Store(buffer, &node))
 	recovered := AccountNode{}
-	encoder.Load(buffer, &recovered)
+	require.NoError(t, encoder.Load(buffer, &recovered))
 	node.hashStatus = hashStatusUnknown
 	if !reflect.DeepEqual(node, recovered) {
 		t.Errorf("encoding/decoding failed, wanted %v, got %v", node, recovered)
@@ -4662,9 +4663,9 @@ func TestAccountNodeWithPathLengthEncoderWithNodeHash(t *testing.T) {
 	}
 	encoder := AccountNodeWithPathLengthEncoderWithNodeHash{}
 	buffer := make([]byte, encoder.GetEncodedSize())
-	encoder.Store(buffer, &node)
+	require.NoError(t, encoder.Store(buffer, &node))
 	recovered := AccountNode{}
-	encoder.Load(buffer, &recovered)
+	require.NoError(t, encoder.Load(buffer, &recovered))
 	node.storageHashDirty = true
 	if !reflect.DeepEqual(node, recovered) {
 		t.Errorf("encoding/decoding failed, wanted %v, got %v", node, recovered)
@@ -4696,9 +4697,9 @@ func TestBranchNodeEncoderWithChildHashes(t *testing.T) {
 	}
 	encoder := BranchNodeEncoderWithChildHashes{}
 	buffer := make([]byte, encoder.GetEncodedSize())
-	encoder.Store(buffer, &node)
+	require.NoError(t, encoder.Store(buffer, &node))
 	recovered := BranchNode{}
-	encoder.Load(buffer, &recovered)
+	require.NoError(t, encoder.Load(buffer, &recovered))
 	node.hashStatus = hashStatusUnknown
 	if !reflect.DeepEqual(node, recovered) {
 		t.Errorf("encoding/decoding failed, wanted %v, got %v", node, recovered)
@@ -4733,9 +4734,9 @@ func TestBranchNodeEncoderWithNodeHash(t *testing.T) {
 	}
 	encoder := BranchNodeEncoderWithNodeHash{}
 	buffer := make([]byte, encoder.GetEncodedSize())
-	encoder.Store(buffer, &node)
+	require.NoError(t, encoder.Store(buffer, &node))
 	recovered := BranchNode{}
-	encoder.Load(buffer, &recovered)
+	require.NoError(t, encoder.Load(buffer, &recovered))
 	node.dirtyHashes = ^uint16(0)
 	node.embeddedChildren = 0
 	if !reflect.DeepEqual(node, recovered) {
@@ -4755,9 +4756,9 @@ func TestExtensionNodeEncoderWithChildHash(t *testing.T) {
 	}
 	encoder := ExtensionNodeEncoderWithChildHash{}
 	buffer := make([]byte, encoder.GetEncodedSize())
-	encoder.Store(buffer, &node)
+	require.NoError(t, encoder.Store(buffer, &node))
 	recovered := ExtensionNode{}
-	encoder.Load(buffer, &recovered)
+	require.NoError(t, encoder.Load(buffer, &recovered))
 	node.hashStatus = hashStatusUnknown
 	if !reflect.DeepEqual(node, recovered) {
 		t.Errorf("encoding/decoding failed, wanted %v, got %v", node, recovered)
@@ -4778,9 +4779,9 @@ func TestExtensionNodeEncoderWithNodeHash(t *testing.T) {
 	}
 	encoder := ExtensionNodeEncoderWithNodeHash{}
 	buffer := make([]byte, encoder.GetEncodedSize())
-	encoder.Store(buffer, &node)
+	require.NoError(t, encoder.Store(buffer, &node))
 	recovered := ExtensionNode{}
-	encoder.Load(buffer, &recovered)
+	require.NoError(t, encoder.Load(buffer, &recovered))
 	node.nextHashDirty = true
 	node.nextIsEmbedded = false
 	if !reflect.DeepEqual(node, recovered) {
@@ -4795,9 +4796,9 @@ func TestValueNodeEncoderWithoutNodeHash(t *testing.T) {
 	}
 	encoder := ValueNodeEncoderWithoutNodeHash{}
 	buffer := make([]byte, encoder.GetEncodedSize())
-	encoder.Store(buffer, &node)
+	require.NoError(t, encoder.Store(buffer, &node))
 	recovered := ValueNode{}
-	encoder.Load(buffer, &recovered)
+	require.NoError(t, encoder.Load(buffer, &recovered))
 	node.hashStatus = hashStatusUnknown
 	if !reflect.DeepEqual(node, recovered) {
 		t.Errorf("encoding/decoding failed, wanted %v, got %v", node, recovered)
@@ -4815,9 +4816,9 @@ func TestValueNodeEncoderWithNodeHash(t *testing.T) {
 	}
 	encoder := ValueNodeEncoderWithNodeHash{}
 	buffer := make([]byte, encoder.GetEncodedSize())
-	encoder.Store(buffer, &node)
+	require.NoError(t, encoder.Store(buffer, &node))
 	recovered := ValueNode{}
-	encoder.Load(buffer, &recovered)
+	require.NoError(t, encoder.Load(buffer, &recovered))
 	if !reflect.DeepEqual(node, recovered) {
 		t.Errorf("encoding/decoding failed, wanted %v, got %v", node, recovered)
 	}
@@ -4831,9 +4832,9 @@ func TestValueNodeWithPathLengthEncoderWithoutNodeHash(t *testing.T) {
 	}
 	encoder := ValueNodeWithPathLengthEncoderWithoutNodeHash{}
 	buffer := make([]byte, encoder.GetEncodedSize())
-	encoder.Store(buffer, &node)
+	require.NoError(t, encoder.Store(buffer, &node))
 	recovered := ValueNode{}
-	encoder.Load(buffer, &recovered)
+	require.NoError(t, encoder.Load(buffer, &recovered))
 	node.hashStatus = hashStatusUnknown
 	if !reflect.DeepEqual(node, recovered) {
 		t.Errorf("encoding/decoding failed, wanted %v, got %v", node, recovered)
@@ -4852,9 +4853,9 @@ func TestValueNodeWithPathLengthEncoderWithNodeHash(t *testing.T) {
 	}
 	encoder := ValueNodeWithPathLengthEncoderWithNodeHash{}
 	buffer := make([]byte, encoder.GetEncodedSize())
-	encoder.Store(buffer, &node)
+	require.NoError(t, encoder.Store(buffer, &node))
 	recovered := ValueNode{}
-	encoder.Load(buffer, &recovered)
+	require.NoError(t, encoder.Load(buffer, &recovered))
 	if !reflect.DeepEqual(node, recovered) {
 		t.Errorf("encoding/decoding failed, wanted %v, got %v", node, recovered)
 	}
@@ -6521,7 +6522,7 @@ func markModifiedAsDirty(t *testing.T, ctxt *nodeContext, before, after NodeRefe
 	}
 
 	handle, _ := ctxt.getViewAccess(&after)
-	handle.Get().Visit(ctxt, &after, 0, WriteAccess{}, MakeVisitor(func(n Node, i NodeInfo) VisitResponse {
+	abort, err := handle.Get().Visit(ctxt, &after, 0, WriteAccess{}, MakeVisitor(func(n Node, i NodeInfo) VisitResponse {
 		// If the current node is not equivalent to a node that was present before,
 		// then it is a new node and should have a dirty hash.
 		if !isReused(n) {
@@ -6575,6 +6576,8 @@ func markModifiedAsDirty(t *testing.T, ctxt *nodeContext, before, after NodeRefe
 		}
 		return VisitResponseContinue
 	}))
+	require.False(t, abort)
+	require.NoError(t, err)
 	handle.Release()
 }
 
@@ -7066,7 +7069,7 @@ func markReusedAsFrozen(t *testing.T, ctxt *nodeContext, before, after NodeRefer
 	}
 
 	handle, _ := ctxt.getViewAccess(&after)
-	handle.Get().Visit(ctxt, &after, 0, WriteAccess{}, MakeVisitor(func(n Node, i NodeInfo) VisitResponse {
+	abort, err := handle.Get().Visit(ctxt, &after, 0, WriteAccess{}, MakeVisitor(func(n Node, i NodeInfo) VisitResponse {
 		// Update the wanted node expected to be frozen.
 		if isReused(n) {
 			n.MarkFrozen()
@@ -7087,6 +7090,8 @@ func markReusedAsFrozen(t *testing.T, ctxt *nodeContext, before, after NodeRefer
 		}
 		return VisitResponseContinue
 	}))
+	require.False(t, abort)
+	require.NoError(t, err)
 	handle.Release()
 }
 
@@ -8268,7 +8273,7 @@ func (c *nodeContext) Check(t *testing.T, ref NodeReference) {
 		handle := c.tryGetNode(t, ref.Id())
 		defer handle.Release()
 		out := &bytes.Buffer{}
-		handle.Get().Dump(out, c, &ref, "")
+		_ = handle.Get().Dump(out, c, &ref, "")
 		t.Fatalf("inconsistent node structure encountered:\n%v\n%s", err, out.String())
 	}
 }
@@ -8276,7 +8281,7 @@ func (c *nodeContext) Check(t *testing.T, ref NodeReference) {
 func (c *nodeContext) Print(ref NodeReference) string {
 	out := &bytes.Buffer{}
 	handle, _ := c.getReadAccess(&ref)
-	handle.Get().Dump(out, c, &ref, "")
+	_ = handle.Get().Dump(out, c, &ref, "")
 	handle.Release()
 	return out.String()
 }
@@ -8284,7 +8289,7 @@ func (c *nodeContext) Print(ref NodeReference) string {
 func (c *nodeContext) Freeze(ref NodeReference) {
 	handle, _ := c.getWriteAccess(&ref)
 	defer handle.Release()
-	handle.Get().Freeze(c, handle)
+	_ = handle.Get().Freeze(c, handle)
 }
 
 func (c *nodeContext) tryGetNode(t *testing.T, id NodeId) shared.ReadHandle[Node] {
@@ -8322,10 +8327,10 @@ func (c *nodeContext) ExpectEqualTries(t *testing.T, want, got NodeReference) {
 	}
 	if len(diffs) > 0 {
 		print := &bytes.Buffer{}
-		wantHandle.Get().Dump(print, c, &want, "")
+		_ = wantHandle.Get().Dump(print, c, &want, "")
 		t.Errorf("Want:\n%s", print.String())
 		have := &bytes.Buffer{}
-		gotHandle.Get().Dump(have, c, &got, "")
+		_ = gotHandle.Get().Dump(have, c, &got, "")
 		t.Errorf("Have:\n%s", have.String())
 		t.Errorf("unexpected resulting node structure")
 		t.Errorf("differences:\n")

--- a/go/database/mpt/nodes_test.go
+++ b/go/database/mpt/nodes_test.go
@@ -6426,6 +6426,40 @@ func TestTransitions_StatesAreDumpable(t *testing.T) {
 	}
 }
 
+func TestTransitions_DumpPropagatesWriterErrors(t *testing.T) {
+	injectedErr := errors.New("injected write error")
+	writer := &errWriter{err: injectedErr}
+
+	tests := map[string]NodeDesc{
+		"Empty":               Empty{},
+		"Value":               &Value{key: common.Key{1}, value: common.Value{2}},
+		"Branch":              &Branch{children: Children{1: &Value{key: common.Key{1}, value: common.Value{2}}}},
+		"Extension":           &Extension{path: []Nibble{1, 2}, next: &Value{key: common.Key{1}, value: common.Value{2}}},
+		"Account":             &Account{address: common.Address{1}, info: AccountInfo{Nonce: common.ToNonce(1)}, storage: &Value{key: common.Key{1}, value: common.Value{2}}},
+		"AccountEmptyStorage": &Account{address: common.Address{1}, info: AccountInfo{Nonce: common.ToNonce(1)}},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			ctxt := newNiceNodeContext(t, ctrl)
+
+			ref, node := ctxt.Build(tc)
+			handle := node.GetViewHandle()
+			err := handle.Get().Dump(writer, ctxt, &ref, "")
+			handle.Release()
+
+			require.Error(t, err)
+			require.ErrorIs(t, err, injectedErr)
+		})
+	}
+}
+
+// errWriter is an io.Writer that always returns an error.
+type errWriter struct{ err error }
+
+func (w *errWriter) Write([]byte) (int, error) { return 0, w.err }
+
 func TestTransitions_MutableTransitionHaveExpectedEffect(t *testing.T) {
 	testTransitions_MutableTransitionHaveExpectedEffect(t, S4LiveConfig)
 }

--- a/go/database/mpt/root_hash_test.go
+++ b/go/database/mpt/root_hash_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/common/amount"
+	"github.com/stretchr/testify/require"
 )
 
 // The reference hashes in this file have been generated using Geth's MPT.
@@ -60,8 +61,8 @@ func TestS5RootHash_SingleAccount(t *testing.T) {
 	}()
 
 	balance := amount.New(12)
-	state.SetNonce(common.Address{1}, common.ToNonce(10))
-	state.SetBalance(common.Address{1}, balance)
+	require.NoError(t, state.SetNonce(common.Address{1}, common.ToNonce(10)))
+	require.NoError(t, state.SetBalance(common.Address{1}, balance))
 	hash, err := state.GetHash()
 	if err != nil {
 		t.Fatalf("failed to get hash for empty state: %v", err)
@@ -86,9 +87,9 @@ func TestS5RootHash_SingleAccountWithSingleValue(t *testing.T) {
 	}()
 
 	balance := amount.New(12)
-	state.SetNonce(common.Address{1}, common.ToNonce(10))
-	state.SetBalance(common.Address{1}, balance)
-	state.SetStorage(common.Address{1}, common.Key{1}, common.Value{2})
+	require.NoError(t, state.SetNonce(common.Address{1}, common.ToNonce(10)))
+	require.NoError(t, state.SetBalance(common.Address{1}, balance))
+	require.NoError(t, state.SetStorage(common.Address{1}, common.Key{1}, common.Value{2}))
 	hash, err := state.GetHash()
 	if err != nil {
 		t.Fatalf("failed to get hash for empty state: %v", err)
@@ -113,8 +114,8 @@ func TestS5RootHash_TwoAccounts(t *testing.T) {
 	}()
 
 	balance := amount.New(12)
-	state.SetNonce(common.Address{1}, common.ToNonce(10))
-	state.SetBalance(common.Address{2}, balance)
+	require.NoError(t, state.SetNonce(common.Address{1}, common.ToNonce(10)))
+	require.NoError(t, state.SetBalance(common.Address{2}, balance))
 	hash, err := state.GetHash()
 	if err != nil {
 		t.Fatalf("failed to get hash for empty state: %v", err)
@@ -139,13 +140,13 @@ func TestS5RootHash_TwoAccountsWithValues(t *testing.T) {
 	}()
 
 	balance := amount.New(12)
-	state.SetNonce(common.Address{1}, common.ToNonce(10))
-	state.trie.SetValue(common.Address{1}, common.Key{1}, common.Value{0, 0, 1})
-	state.trie.SetValue(common.Address{1}, common.Key{2}, common.Value{2})
+	require.NoError(t, state.SetNonce(common.Address{1}, common.ToNonce(10)))
+	require.NoError(t, state.trie.SetValue(common.Address{1}, common.Key{1}, common.Value{0, 0, 1}))
+	require.NoError(t, state.trie.SetValue(common.Address{1}, common.Key{2}, common.Value{2}))
 
-	state.SetBalance(common.Address{2}, balance)
-	state.trie.SetValue(common.Address{2}, common.Key{1}, common.Value{0, 0, 1})
-	state.trie.SetValue(common.Address{2}, common.Key{2}, common.Value{2})
+	require.NoError(t, state.SetBalance(common.Address{2}, balance))
+	require.NoError(t, state.trie.SetValue(common.Address{2}, common.Key{1}, common.Value{0, 0, 1}))
+	require.NoError(t, state.trie.SetValue(common.Address{2}, common.Key{2}, common.Value{2}))
 	hash, err := state.GetHash()
 	if err != nil {
 		t.Fatalf("failed to get hash for empty state: %v", err)
@@ -177,8 +178,8 @@ func TestS5RootHash_TwoAccountsWithExtensionNodeWithEvenLength(t *testing.T) {
 	}()
 
 	balance := amount.New(12)
-	state.SetNonce(addr1, common.ToNonce(10))
-	state.SetBalance(addr2, balance)
+	require.NoError(t, state.SetNonce(addr1, common.ToNonce(10)))
+	require.NoError(t, state.SetBalance(addr2, balance))
 	hash, err := state.GetHash()
 	if err != nil {
 		t.Fatalf("failed to get hash for empty state: %v", err)
@@ -210,8 +211,8 @@ func TestS5RootHash_TwoAccountsWithExtensionNodeWithOddLength(t *testing.T) {
 	}()
 
 	balance := amount.New(12)
-	state.SetNonce(addr1, common.ToNonce(10))
-	state.SetBalance(addr2, balance)
+	require.NoError(t, state.SetNonce(addr1, common.ToNonce(10)))
+	require.NoError(t, state.SetBalance(addr2, balance))
 	hash, err := state.GetHash()
 	if err != nil {
 		t.Fatalf("failed to get hash for empty state: %v", err)
@@ -372,8 +373,8 @@ func TestHashing_S5EmbeddedValuesAreHandledCorrectly(t *testing.T) {
 	// These keys have a common hash prefix of 4 bytes. Thus, there are only 28 bytes
 	// to be encoded in value nodes if they are stored in a branch node, causing the
 	// values to be small enough to be embedded.
-	key1 := hexToKey("c76547ce3912f8c25a9943819c2992169865dfd500bed5213c8a92ceff5db5e3")
-	key2 := hexToKey("2968f9295ca3ab4960ae553a18f47567e56f2777ad762ee1d639421728926a37")
+	key1, _ := hexToKey("c76547ce3912f8c25a9943819c2992169865dfd500bed5213c8a92ceff5db5e3")
+	key2, _ := hexToKey("2968f9295ca3ab4960ae553a18f47567e56f2777ad762ee1d639421728926a37")
 
 	hash1 := common.Keccak256ForKey(key1)
 	hash2 := common.Keccak256ForKey(key2)
@@ -401,9 +402,9 @@ func TestHashing_S5EmbeddedValuesAreHandledCorrectly(t *testing.T) {
 		}
 
 		addr := common.Address{}
-		state.SetNonce(addr, common.Nonce{1})
-		state.SetStorage(addr, key1, val1)
-		state.SetStorage(addr, key2, val1)
+		require.NoError(t, state.SetNonce(addr, common.Nonce{1}))
+		require.NoError(t, state.SetStorage(addr, key1, val1))
+		require.NoError(t, state.SetStorage(addr, key2, val1))
 
 		hash, _, err := state.UpdateHashes()
 		if err != nil {
@@ -434,7 +435,7 @@ func TestHashing_S5EmbeddedValuesAreHandledCorrectly(t *testing.T) {
 		// Only one value is updated, the other remains untouched. The bug was
 		// that the untouched value was incorrectly considered non-embedded as a
 		// side-effect.
-		state.SetStorage(addr, key1, val2)
+		require.NoError(t, state.SetStorage(addr, key1, val2))
 
 		hash, _, err = state.UpdateHashes()
 		if err != nil {
@@ -453,8 +454,8 @@ func TestHashing_S5EmbeddedValuesAreHandledCorrectly(t *testing.T) {
 	}
 }
 
-func hexToKey(s string) common.Key {
+func hexToKey(s string) (common.Key, error) {
 	var key common.Key
-	hex.Decode(key[:], []byte(s))
-	return key
+	_, err := hex.Decode(key[:], []byte(s))
+	return key, err
 }

--- a/go/database/mpt/state_test.go
+++ b/go/database/mpt/state_test.go
@@ -26,6 +26,7 @@ import (
 	"unsafe"
 
 	"github.com/0xsoniclabs/carmen/go/common/amount"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/crypto/sha3"
 	"golang.org/x/exp/maps"
@@ -174,6 +175,7 @@ func BenchmarkStorageChanges(b *testing.B) {
 				mode = "with_hashing"
 			}
 			b.Run(fmt.Sprintf("%s/%s", config.Name, mode), func(b *testing.B) {
+				require := require.New(b)
 				state, err := OpenGoMemoryState(b.TempDir(), config, NodeCacheConfig{Capacity: 1024})
 				if err != nil {
 					b.Fail()
@@ -185,7 +187,7 @@ func BenchmarkStorageChanges(b *testing.B) {
 				}()
 
 				address := common.Address{}
-				_ = state.SetNonce(address, common.ToNonce(12))
+				require.NoError(state.SetNonce(address, common.ToNonce(12)))
 
 				key := common.Key{}
 				value := common.Value{}
@@ -193,9 +195,10 @@ func BenchmarkStorageChanges(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					binary.BigEndian.PutUint64(key[:], uint64(i%1024))
 					binary.BigEndian.PutUint64(value[:], uint64(i))
-					_ = state.SetStorage(address, key, value)
+					require.NoError(state.SetStorage(address, key, value))
 					if withHashing {
-						_, _ = state.GetHash()
+						_, err = state.GetHash()
+						require.NoError(err)
 					}
 				}
 			})

--- a/go/database/mpt/state_test.go
+++ b/go/database/mpt/state_test.go
@@ -185,7 +185,7 @@ func BenchmarkStorageChanges(b *testing.B) {
 				}()
 
 				address := common.Address{}
-				state.SetNonce(address, common.ToNonce(12))
+				_ = state.SetNonce(address, common.ToNonce(12))
 
 				key := common.Key{}
 				value := common.Value{}
@@ -193,9 +193,9 @@ func BenchmarkStorageChanges(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					binary.BigEndian.PutUint64(key[:], uint64(i%1024))
 					binary.BigEndian.PutUint64(value[:], uint64(i))
-					state.SetStorage(address, key, value)
+					_ = state.SetStorage(address, key, value)
 					if withHashing {
-						state.GetHash()
+						_, _ = state.GetHash()
 					}
 				}
 			})

--- a/go/database/mpt/tool/check.go
+++ b/go/database/mpt/tool/check.go
@@ -11,6 +11,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/0xsoniclabs/carmen/go/common/diagnostics"
@@ -53,20 +54,20 @@ func check(context *cli.Context) error {
 	return err
 }
 
-func checkLiveDB(dir string, info io.MptInfo) error {
+func checkLiveDB(dir string, info io.MptInfo) (retErr error) {
 	live, err := mpt.OpenFileLiveTrie(dir, info.Config, mpt.NodeCacheConfig{})
 	if err != nil {
 		return err
 	}
-	defer live.Close()
+	defer func() { retErr = errors.Join(retErr, live.Close()) }()
 	return live.Check()
 }
 
-func checkArchive(dir string, info io.MptInfo) error {
+func checkArchive(dir string, info io.MptInfo) (retErr error) {
 	archive, err := mpt.OpenArchiveTrie(dir, info.Config, mpt.NodeCacheConfig{}, mpt.ArchiveConfig{})
 	if err != nil {
 		return err
 	}
-	defer archive.Close()
+	defer func() { retErr = errors.Join(retErr, archive.Close()) }()
 	return archive.Check()
 }

--- a/go/database/mpt/tool/reset.go
+++ b/go/database/mpt/tool/reset.go
@@ -71,7 +71,9 @@ func reset(context *cli.Context) error {
 			return fmt.Errorf("failed to unlock directory: %v", err)
 		}
 	} else {
-		lock.Release()
+		if err := lock.Release(); err != nil {
+			return fmt.Errorf("failed to release lock: %v", err)
+		}
 	}
 
 	fmt.Printf("Resetting archive in %s to block %d ...\n", dir, block)

--- a/go/database/mpt/tool/stress.go
+++ b/go/database/mpt/tool/stress.go
@@ -192,7 +192,11 @@ func createTestState(db *mpt.MptState, directory string) *stressTestState {
 
 func (s *stressTestState) ReportProgress() {
 	memUsage := getMemoryUsage()
-	used := getDirectorySize(s.directory)
+	used, err := getDirectorySize(s.directory)
+	if err != nil {
+		log.Printf("failed to get directory size: %v\n", err)
+		return
+	}
 	free, err := getFreeSpace(s.directory)
 	if err != nil {
 		log.Printf("failed to get free space: %v\n", err)
@@ -383,9 +387,9 @@ func getMemoryUsage() uint64 {
 }
 
 // getDirectorySize computes the size of all files in the given directory in bytes.
-func getDirectorySize(directory string) int64 {
+func getDirectorySize(directory string) (int64, error) {
 	var sum int64 = 0
-	filepath.Walk(directory, func(path string, info fs.FileInfo, err error) error {
+	err := filepath.Walk(directory, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
 			return nil
 		}
@@ -394,5 +398,5 @@ func getDirectorySize(directory string) int64 {
 		}
 		return nil
 	})
-	return sum
+	return sum, err
 }

--- a/go/database/mpt/tool/stress.go
+++ b/go/database/mpt/tool/stress.go
@@ -12,11 +12,9 @@ package main
 
 import (
 	"fmt"
-	"io/fs"
 	"log"
 	"math/rand"
 	"os"
-	"path/filepath"
 	"runtime"
 	"sync"
 	"syscall"
@@ -192,7 +190,7 @@ func createTestState(db *mpt.MptState, directory string) *stressTestState {
 
 func (s *stressTestState) ReportProgress() {
 	memUsage := getMemoryUsage()
-	used, err := getDirectorySize(s.directory)
+	used, err := common.GetDirectorySize(s.directory)
 	if err != nil {
 		log.Printf("failed to get directory size: %v\n", err)
 		return
@@ -384,19 +382,4 @@ func getMemoryUsage() uint64 {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
 	return m.Alloc
-}
-
-// getDirectorySize computes the size of all files in the given directory in bytes.
-func getDirectorySize(directory string) (int64, error) {
-	var sum int64 = 0
-	err := filepath.Walk(directory, func(path string, info fs.FileInfo, retErr error) error {
-		if retErr != nil {
-			return nil
-		}
-		if !info.IsDir() {
-			sum += info.Size()
-		}
-		return nil
-	})
-	return sum, err
 }

--- a/go/database/mpt/tool/stress.go
+++ b/go/database/mpt/tool/stress.go
@@ -389,8 +389,8 @@ func getMemoryUsage() uint64 {
 // getDirectorySize computes the size of all files in the given directory in bytes.
 func getDirectorySize(directory string) (int64, error) {
 	var sum int64 = 0
-	err := filepath.Walk(directory, func(path string, info fs.FileInfo, err error) error {
-		if err != nil {
+	err := filepath.Walk(directory, func(path string, info fs.FileInfo, retErr error) error {
+		if retErr != nil {
 			return nil
 		}
 		if !info.IsDir() {

--- a/go/database/mpt/tool/stress_test.go
+++ b/go/database/mpt/tool/stress_test.go
@@ -33,7 +33,8 @@ func TestGetDirectorySize(t *testing.T) {
 	err := os.WriteFile(file, data, 0644)
 	require.NoError(t, err)
 
-	size := getDirectorySize(dir)
+	size, err := getDirectorySize(dir)
+	require.NoError(t, err)
 	require.Equal(t, int64(len(data)), size, "directory size should match file size")
 }
 
@@ -88,7 +89,7 @@ func TestStressTest_ZeroBlocks(t *testing.T) {
 }
 
 func TestGetDirectorySize_NonExistentDirectory(t *testing.T) {
-	size := getDirectorySize("/path/does/not/exist")
+	size, _ := getDirectorySize("/path/does/not/exist")
 	require.Equal(t, int64(0), size, "size should be zero for non-existent directory")
 }
 
@@ -97,7 +98,8 @@ func TestGetDirectorySize_FilePath(t *testing.T) {
 	data := []byte("data")
 	err := os.WriteFile(file, data, 0644)
 	require.NoError(t, err)
-	size := getDirectorySize(file)
+	size, err := getDirectorySize(file)
+	require.NoError(t, err)
 	require.Equal(t, len(data), int(size), "size should match file size")
 }
 

--- a/go/database/mpt/tool/stress_test.go
+++ b/go/database/mpt/tool/stress_test.go
@@ -11,8 +11,6 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
 	"syscall"
 	"testing"
 	"time"
@@ -24,18 +22,6 @@ import (
 func TestGetMemoryUsage(t *testing.T) {
 	mem := getMemoryUsage()
 	require.Greater(t, mem, uint64(0), "memory usage should be greater than zero")
-}
-
-func TestGetDirectorySize(t *testing.T) {
-	dir := t.TempDir()
-	file := filepath.Join(dir, "testfile")
-	data := []byte("hello world")
-	err := os.WriteFile(file, data, 0644)
-	require.NoError(t, err)
-
-	size, err := getDirectorySize(dir)
-	require.NoError(t, err)
-	require.Equal(t, int64(len(data)), size, "directory size should match file size")
 }
 
 func TestStressTest_BasicRun(t *testing.T) {
@@ -86,21 +72,6 @@ func TestStressTest_ZeroBlocks(t *testing.T) {
 		"--num-blocks=0",
 	})
 	require.NoError(t, err, "should not error with zero blocks")
-}
-
-func TestGetDirectorySize_NonExistentDirectory(t *testing.T) {
-	size, _ := getDirectorySize("/path/does/not/exist")
-	require.Equal(t, int64(0), size, "size should be zero for non-existent directory")
-}
-
-func TestGetDirectorySize_FilePath(t *testing.T) {
-	file := filepath.Join(t.TempDir(), "testfile")
-	data := []byte("data")
-	err := os.WriteFile(file, data, 0644)
-	require.NoError(t, err)
-	size, err := getDirectorySize(file)
-	require.NoError(t, err)
-	require.Equal(t, len(data), int(size), "size should match file size")
 }
 
 func TestGetFreeSpace_ValidPath(t *testing.T) {

--- a/go/database/mpt/verification.go
+++ b/go/database/mpt/verification.go
@@ -73,7 +73,7 @@ func VerifyMptState(ctx context.Context, directory string, config MptConfig, roo
 	if err != nil {
 		return err
 	}
-	defer source.Close()
+	defer func() { res = errors.Join(res, source.Close()) }()
 
 	err = verifyContractCodes(directory, source, observer)
 	if err != nil {
@@ -109,7 +109,7 @@ func verifyFileForest(ctx context.Context, directory string, config MptConfig, r
 	if err != nil {
 		return err
 	}
-	defer source.Close()
+	defer func() { res = errors.Join(res, source.Close()) }()
 	return verifyForest(directory, config, roots, source, observer)
 }
 
@@ -687,7 +687,7 @@ type verificationNodeSource struct {
 	numberOfNodesIterated uint64
 }
 
-func openVerificationNodeSource(ctx context.Context, directory string, config MptConfig) (*verificationNodeSource, error) {
+func openVerificationNodeSource(ctx context.Context, directory string, config MptConfig) (_ *verificationNodeSource, retErr error) {
 	lock, err := openStateDirectory(directory)
 	if err != nil {
 		return nil, err
@@ -701,7 +701,7 @@ func openVerificationNodeSource(ctx context.Context, directory string, config Mp
 	}
 	defer func() {
 		if !success {
-			branches.Close()
+			retErr = errors.Join(retErr, branches.Close())
 		}
 	}()
 	extensions, err := file.OpenStock[uint64, ExtensionNode](extensionEncoder, directory+"/extensions")
@@ -710,7 +710,7 @@ func openVerificationNodeSource(ctx context.Context, directory string, config Mp
 	}
 	defer func() {
 		if !success {
-			extensions.Close()
+			retErr = errors.Join(retErr, extensions.Close())
 		}
 	}()
 	accounts, err := file.OpenStock[uint64, AccountNode](accountEncoder, directory+"/accounts")
@@ -719,7 +719,7 @@ func openVerificationNodeSource(ctx context.Context, directory string, config Mp
 	}
 	defer func() {
 		if !success {
-			accounts.Close()
+			retErr = errors.Join(retErr, accounts.Close())
 		}
 	}()
 	values, err := file.OpenStock[uint64, ValueNode](valueEncoder, directory+"/values")
@@ -728,7 +728,7 @@ func openVerificationNodeSource(ctx context.Context, directory string, config Mp
 	}
 	defer func() {
 		if !success {
-			values.Close()
+			retErr = errors.Join(retErr, values.Close())
 		}
 	}()
 	accountIds, err := accounts.GetIds()

--- a/go/database/mpt/visitor.go
+++ b/go/database/mpt/visitor.go
@@ -14,6 +14,7 @@ package mpt
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -55,12 +56,12 @@ const (
 
 // VisitForestNodes load the nodes of the forest stored in the given directory and
 // applies the visitor on each of those.
-func VisitForestNodes(directory string, config MptConfig, visitor NodeVisitor) error {
+func VisitForestNodes(directory string, config MptConfig, visitor NodeVisitor) (retErr error) {
 	source, err := openVerificationNodeSource(context.TODO(), directory, config)
 	if err != nil {
 		return err
 	}
-	defer source.Close()
+	defer func() { retErr = errors.Join(retErr, source.Close()) }()
 	return source.forAllNodes(func(id NodeId, node Node) error {
 		visitor.Visit(node, NodeInfo{Id: id})
 		return nil

--- a/go/database/mpt/visitor_test.go
+++ b/go/database/mpt/visitor_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNodeStatistics_CollectTrieStatisticsWorks(t *testing.T) {
@@ -21,7 +22,7 @@ func TestNodeStatistics_CollectTrieStatisticsWorks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create empty trie: %v", err)
 	}
-	defer trie.Close()
+	defer func() { require.NoError(t, trie.Close()) }()
 
 	stats, err := GetTrieNodeStatistics(trie)
 	if err != nil {
@@ -31,9 +32,9 @@ func TestNodeStatistics_CollectTrieStatisticsWorks(t *testing.T) {
 		t.Errorf("invalid stats for empty trie: %v", stats)
 	}
 
-	trie.SetAccountInfo(common.Address{}, AccountInfo{Nonce: common.ToNonce(12)})
-	trie.SetValue(common.Address{}, common.Key{1}, common.Value{1})
-	trie.SetValue(common.Address{}, common.Key{2}, common.Value{2})
+	require.NoError(t, trie.SetAccountInfo(common.Address{}, AccountInfo{Nonce: common.ToNonce(12)}))
+	require.NoError(t, trie.SetValue(common.Address{}, common.Key{1}, common.Value{1}))
+	require.NoError(t, trie.SetValue(common.Address{}, common.Key{2}, common.Value{2}))
 
 	stats, err = GetTrieNodeStatistics(trie)
 	if err != nil {
@@ -67,7 +68,7 @@ func TestNodeStatistics_CollectForestStatisticsWorks(t *testing.T) {
 		t.Fatalf("failed to re-open empty archive: %v", err)
 	}
 
-	archive.Add(2, common.Update{
+	require.NoError(t, archive.Add(2, common.Update{
 		Nonces: []common.NonceUpdate{
 			{Account: common.Address{1}, Nonce: common.ToNonce(12)},
 		},
@@ -75,7 +76,7 @@ func TestNodeStatistics_CollectForestStatisticsWorks(t *testing.T) {
 			{Account: common.Address{1}, Key: common.Key{1}, Value: common.Value{1}},
 			{Account: common.Address{1}, Key: common.Key{2}, Value: common.Value{2}},
 		},
-	}, nil)
+	}, nil))
 
 	if err := archive.Close(); err != nil {
 		t.Fatalf("failed to close archive: %v", err)

--- a/go/database/mpt/write_buffer_test.go
+++ b/go/database/mpt/write_buffer_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/0xsoniclabs/carmen/go/database/mpt/shared"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -27,7 +28,7 @@ func TestWriteBuffer_CanBeFlushedWhenEmpty(t *testing.T) {
 	sink := NewMockNodeSink(ctrl)
 
 	buffer := MakeWriteBuffer(sink)
-	defer buffer.Close()
+	defer func() { require.NoError(t, buffer.Close()) }()
 
 	if err := buffer.Flush(); err != nil {
 		t.Errorf("failed to flush buffer: %v", err)
@@ -45,7 +46,7 @@ func TestWriteBuffer_CanFlushASingleElement(t *testing.T) {
 	view.Release()
 
 	buffer := MakeWriteBuffer(sink)
-	defer buffer.Close()
+	defer func() { require.NoError(t, buffer.Close()) }()
 
 	buffer.Add(id, node)
 	if err := buffer.Flush(); err != nil {
@@ -58,8 +59,8 @@ func TestWriteBuffer_CanBeClosedMultipleTimes(t *testing.T) {
 	sink := NewMockNodeSink(ctrl)
 
 	buffer := MakeWriteBuffer(sink)
-	buffer.Close()
-	buffer.Close()
+	require.NoError(t, buffer.Close())
+	require.NoError(t, buffer.Close())
 }
 
 func TestWriteBuffer_EnqueuedElementCanBeCanceled(t *testing.T) {
@@ -73,7 +74,7 @@ func TestWriteBuffer_EnqueuedElementCanBeCanceled(t *testing.T) {
 	sink.EXPECT().Write(id, gomock.Any()).MaxTimes(1)
 
 	buffer := MakeWriteBuffer(sink)
-	defer buffer.Close()
+	defer func() { require.NoError(t, buffer.Close()) }()
 
 	buffer.Add(id, node)
 
@@ -98,7 +99,7 @@ func TestWriteBuffer_CanFlushLargeNumberOfElements(t *testing.T) {
 	}
 
 	buffer := makeWriteBuffer(sink, N/10)
-	defer buffer.Close()
+	defer func() { require.NoError(t, buffer.Close()) }()
 
 	// Send in N nodes to be written to the sink.
 	for i := 0; i < N; i++ {
@@ -116,7 +117,7 @@ func TestWriteBuffer_AllQueuedEntriesArePresentUntilWritten(t *testing.T) {
 
 	N := 1000
 	buffer := makeWriteBuffer(sink, N/10).(*writeBuffer)
-	defer buffer.Close()
+	defer func() { require.NoError(t, buffer.Close()) }()
 
 	enqueued := map[NodeId]bool{}
 	enqueuedLock := sync.Mutex{}
@@ -169,7 +170,7 @@ func TestWriteBuffer_CheckThatLockedNodesAreWaitedFor(t *testing.T) {
 	view2.Release()
 
 	buffer := makeWriteBuffer(sink, 100)
-	defer buffer.Close()
+	defer func() { require.NoError(t, buffer.Close()) }()
 
 	write := value2.GetWriteHandle()
 	done := false
@@ -202,7 +203,7 @@ func TestWriteBuffer_AFailedFlushIsReported(t *testing.T) {
 	view.Release()
 
 	buffer := MakeWriteBuffer(sink)
-	defer buffer.Close()
+	defer func() { require.Error(t, buffer.Close()) }()
 
 	buffer.Add(id, node)
 	if got := buffer.Flush(); !errors.Is(got, err) {
@@ -223,7 +224,7 @@ func TestWriteBuffer_ElementsCanBeAddedInParallel(t *testing.T) {
 	}
 
 	buffer := makeWriteBuffer(sink, N/10)
-	defer buffer.Close()
+	defer func() { require.NoError(t, buffer.Close()) }()
 
 	// Send in N nodes in parallel.
 	var wg sync.WaitGroup
@@ -253,7 +254,7 @@ func TestWriteBuffer_ElementsCanBeAddedAndCanceledInParallel(t *testing.T) {
 	sink.EXPECT().Write(gomock.Any(), gomock.Any()).AnyTimes()
 
 	buffer := makeWriteBuffer(sink, N/10)
-	defer buffer.Close()
+	defer func() { require.NoError(t, buffer.Close()) }()
 
 	// Send in N nodes in parallel.
 	var wg sync.WaitGroup
@@ -292,7 +293,7 @@ func TestWriteBuffer_FlushedElementsAreMarkedAsClean(t *testing.T) {
 	view.Release()
 
 	buffer := MakeWriteBuffer(sink)
-	defer buffer.Close()
+	defer func() { require.NoError(t, buffer.Close()) }()
 
 	buffer.Add(id, node)
 	if err := buffer.Flush(); err != nil {
@@ -313,7 +314,7 @@ func TestWriteBuffer_CleanNodesAreNotWritten(t *testing.T) {
 	// Note: no write to the sink is expected.
 
 	buffer := MakeWriteBuffer(sink)
-	defer buffer.Close()
+	defer func() { require.NoError(t, buffer.Close()) }()
 
 	buffer.Add(id, node)
 	if err := buffer.Flush(); err != nil {
@@ -326,7 +327,7 @@ func TestWriteBuffer_ZeroCap(t *testing.T) {
 	sink := NewMockNodeSink(ctrl)
 
 	buffer := makeWriteBuffer(sink, 0)
-	defer buffer.Close()
+	defer func() { require.NoError(t, buffer.Close()) }()
 
 	if got, want := buffer.(*writeBuffer).capacity, 1; got != want {
 		t.Errorf("default capacity does not match: %d != %d", got, want)
@@ -338,7 +339,7 @@ func TestWriteBuffer_contains(t *testing.T) {
 	sink := NewMockNodeSink(ctrl)
 
 	buffer := makeWriteBuffer(sink, 0)
-	defer buffer.Close()
+	defer func() { require.NoError(t, buffer.Close()) }()
 
 	buffer.Add(BranchId(123), nil)
 	if got, want := buffer.(*writeBuffer).contains(BranchId(123)), true; got != want {

--- a/go/database/vt/reference/state_test.go
+++ b/go/database/vt/reference/state_test.go
@@ -325,7 +325,10 @@ func TestState_Export_PanicsAsNotImplemented(t *testing.T) {
 	require := require.New(t)
 	state := newState()
 	require.Panics(
-		func() { state.Export(t.Context(), nil) },
+		func() {
+			_, err := state.Export(t.Context(), nil)
+			require.NoError(err)
+		},
 		"Export should panic as it is not implemented",
 	)
 }
@@ -363,14 +366,16 @@ func TestState_StateWithContentHasExpectedCommitment(t *testing.T) {
 	}
 
 	state := newState()
-	state.Apply(0, update)
+	_, err := state.Apply(0, update)
+	require.NoError(err)
 
 	hash, err := state.GetCommitment().Await().Get()
 	require.NoError(err)
 
 	reference, err := newRefState(t)
 	require.NoError(err)
-	reference.Apply(0, update)
+	_, err = reference.Apply(0, update)
+	require.NoError(err)
 	want, err := reference.GetCommitment().Await().Get()
 	require.NoError(err)
 
@@ -457,11 +462,13 @@ func TestState_IncrementalStateUpdatesResultInSameCommitments(t *testing.T) {
 	require.NoError(err)
 
 	for _, update := range updates {
-		state.Apply(0, update)
+		_, err = state.Apply(0, update)
+		require.NoError(err)
 		hash, err := state.GetCommitment().Await().Get()
 		require.NoError(err)
 
-		reference.Apply(0, update)
+		_, err = reference.Apply(0, update)
+		require.NoError(err)
 		want, err := reference.GetCommitment().Await().Get()
 		require.NoError(err)
 

--- a/go/database/vt/utils/verkle.go
+++ b/go/database/vt/utils/verkle.go
@@ -123,8 +123,9 @@ func GetTreeKey(address []byte, treeIndex *uint256.Int, subIndex byte) []byte {
 
 	// 32-byte address, interpreted as two little endian
 	// 16-byte numbers.
-	verkle.FromLEBytes(&poly[1], address[:16])
-	verkle.FromLEBytes(&poly[2], address[16:])
+	// FromLEBytes cannot fail: 16-byte inputs are always smaller than the 256-bit field modulus.
+	_ = verkle.FromLEBytes(&poly[1], address[:16])
+	_ = verkle.FromLEBytes(&poly[2], address[16:])
 
 	// treeIndex must be interpreted as a 32-byte aligned little-endian integer.
 	// e.g: if treeIndex is 0xAABBCC, we need the byte representation to be 0xCCBBAA00...00.
@@ -161,8 +162,9 @@ func GetTreeKeyWithEvaluatedAddress(evaluated *verkle.Point, treeIndex *uint256.
 	for i := 0; i < len(treeIndex); i++ {
 		binary.LittleEndian.PutUint64(index[i*8:(i+1)*8], treeIndex[i])
 	}
-	verkle.FromLEBytes(&poly[3], index[:16])
-	verkle.FromLEBytes(&poly[4], index[16:])
+	// FromLEBytes cannot fail: 16-byte inputs are always smaller than the 256-bit field modulus.
+	_ = verkle.FromLEBytes(&poly[3], index[:16])
+	_ = verkle.FromLEBytes(&poly[4], index[16:])
 
 	cfg := verkle.GetConfig()
 	ret := cfg.CommitToPoly(poly[:], 0)
@@ -287,8 +289,9 @@ func evaluateAddressPoint(address []byte) *verkle.Point {
 
 	// 32-byte address, interpreted as two little endian
 	// 16-byte numbers.
-	verkle.FromLEBytes(&poly[1], address[:16])
-	verkle.FromLEBytes(&poly[2], address[16:])
+	// FromLEBytes cannot fail: 16-byte inputs are always smaller than the 256-bit field modulus.
+	_ = verkle.FromLEBytes(&poly[1], address[:16])
+	_ = verkle.FromLEBytes(&poly[2], address[16:])
 
 	cfg := verkle.GetConfig()
 	ret := cfg.CommitToPoly(poly[:], 0)

--- a/go/state/configurations_test.go
+++ b/go/state/configurations_test.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/0xsoniclabs/carmen/go/state/externalstate"
 	_ "github.com/0xsoniclabs/carmen/go/state/gostate"
 	_ "github.com/0xsoniclabs/carmen/go/state/gostate/experimental"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStateConfigs_ContainsConfigurations(t *testing.T) {
@@ -104,7 +105,7 @@ func getFilesIn(t *testing.T, path string) []string {
 	if err != nil {
 		t.Fatalf("failed to open directory %s: %v", path, err)
 	}
-	defer file.Close()
+	defer func() { require.NoError(t, file.Close()) }()
 	_, err = file.Stat()
 	if err != nil {
 		t.Fatalf("failed to open file information for %s: %v", path, err)

--- a/go/state/flush_benchmark_test.go
+++ b/go/state/flush_benchmark_test.go
@@ -11,12 +11,12 @@
 package state
 
 import (
+	"testing"
 	"time"
 
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/common/amount"
-
-	"testing"
+	"github.com/stretchr/testify/require"
 )
 
 // To run this benchmarks, use the following command:
@@ -34,7 +34,7 @@ func BenchmarkFlushGoState(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer state.Close()
+	defer func() { require.NoError(b, state.Close()) }()
 
 	for n := uint64(0); n < uint64(b.N); n++ {
 		update := common.Update{}

--- a/go/state/gostate/configurations_test.go
+++ b/go/state/gostate/configurations_test.go
@@ -57,8 +57,8 @@ func TestOpenArchive_FailsForNoArchiveIfTheArchiveDirectoryCanNotBeAccessed(t *t
 	require.Nil(cleanup)
 
 	// If the empty archive can not be accessed, an error should be returned.
-	os.Chmod(path, 0000)
-	defer os.Chmod(path, 0755)
+	require.NoError(os.Chmod(path, 0000))
+	defer func() { require.NoError(os.Chmod(path, 0755)) }()
 
 	_, _, err = openArchive(params)
 	require.Error(err)

--- a/go/state/gostate/go_state_test.go
+++ b/go/state/gostate/go_state_test.go
@@ -86,7 +86,7 @@ func TestMissingKeys(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to initialize state %s; %s", config.name(), err)
 			}
-			defer state.Close()
+			defer func() { require.NoError(t, state.Close()) }()
 
 			accountState, err := state.Exists(address1)
 			if err != nil || accountState != false {
@@ -123,7 +123,7 @@ func TestBasicOperations(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to initialize state %s; %s", config.name(), err)
 			}
-			defer state.Close()
+			defer func() { require.NoError(t, state.Close()) }()
 
 			// fill-in values
 			_, err = state.Apply(12, common.Update{
@@ -191,7 +191,7 @@ func TestDeletingAccounts(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to initialize state %s; %s", config.name(), err)
 			}
-			defer state.Close()
+			defer func() { require.NoError(t, state.Close()) }()
 
 			// fill-in values
 			update := common.Update{
@@ -229,7 +229,7 @@ func TestMoreInserts(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to initialize state %s; %s", config.name(), err)
 			}
-			defer state.Close()
+			defer func() { require.NoError(t, state.Close()) }()
 
 			update := common.Update{
 				// create accounts since setting values to non-existing accounts may be ignored
@@ -284,20 +284,22 @@ func TestHashing(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to initialize state %s; %v", config.name(), err)
 			}
-			defer state.Close()
+			defer func() { require.NoError(t, state.Close()) }()
 
 			initialHash, err := state.GetCommitment().Await().Get()
 			if err != nil {
 				t.Fatalf("unable to get state hash; %v", err)
 			}
 
-			state.Apply(1, common.Update{Balances: []common.BalanceUpdate{{Account: address1, Balance: balance1}}})
+			_, err = state.Apply(1, common.Update{Balances: []common.BalanceUpdate{{Account: address1, Balance: balance1}}})
+			require.NoError(t, err)
 			hash1, err := state.GetCommitment().Await().Get()
 			if err != nil {
 				t.Fatalf("unable to get state hash; %v", err)
 			}
 
-			state.Apply(2, common.Update{Slots: []common.SlotUpdate{{Account: address1, Key: key1, Value: val1}}})
+			_, err = state.Apply(2, common.Update{Slots: []common.SlotUpdate{{Account: address1, Key: key1, Value: val1}}})
+			require.NoError(t, err)
 			hash2, err := state.GetCommitment().Await().Get()
 			if err != nil {
 				t.Fatalf("unable to get state hash; %v", err)
@@ -306,7 +308,8 @@ func TestHashing(t *testing.T) {
 				t.Errorf("hash of changed state not changed")
 			}
 
-			state.Apply(3, common.Update{Balances: []common.BalanceUpdate{{Account: address1, Balance: balance2}}})
+			_, err = state.Apply(3, common.Update{Balances: []common.BalanceUpdate{{Account: address1, Balance: balance2}}})
+			require.NoError(t, err)
 			hash3, err := state.GetCommitment().Await().Get()
 			if err != nil {
 				t.Fatalf("unable to get state hash; %v", err)
@@ -319,7 +322,8 @@ func TestHashing(t *testing.T) {
 				t.Errorf("hash of changed state not changed")
 			}
 
-			state.Apply(4, common.Update{Codes: []common.CodeUpdate{{Account: address1, Code: []byte{0x12, 0x34, 0x56, 0x78}}}})
+			_, err = state.Apply(4, common.Update{Codes: []common.CodeUpdate{{Account: address1, Code: []byte{0x12, 0x34, 0x56, 0x78}}}})
+			require.NoError(t, err)
 			hash4, err := state.GetCommitment().Await().Get()
 			if err != nil {
 				t.Fatalf("unable to get state hash; %v", err)
@@ -381,7 +385,7 @@ func TestGoState_FlushFlushesLiveDbAndArchive(t *testing.T) {
 	archive.EXPECT().Flush()
 
 	state := newGoState(live, archive, nil)
-	state.Flush()
+	require.NoError(t, state.Flush())
 }
 
 func TestGoState_CloseClosesLiveDbAndArchive(t *testing.T) {
@@ -399,7 +403,7 @@ func TestGoState_CloseClosesLiveDbAndArchive(t *testing.T) {
 	)
 
 	state := newGoState(live, archive, nil)
-	state.Close()
+	require.NoError(t, state.Close())
 }
 
 func TestStateDB_AddBlock_Errors_Propagated_MultipleStateInstances(t *testing.T) {
@@ -722,7 +726,7 @@ func TestGoState_StateError_AccessFromMainAndArchiveGoroutine(t *testing.T) {
 		archiveDB.EXPECT().Close()
 
 		db := newGoState(liveDB, archiveDB, nil)
-		defer db.Close()
+		defer func() { require.Error(t, db.Close()) }()
 
 		// Send an update to the archive writer goroutine.
 		_, err := db.Apply(1, common.Update{})

--- a/go/state/state_db_and_state_test.go
+++ b/go/state/state_db_and_state_test.go
@@ -139,7 +139,7 @@ func TestCarmen_CanHandleMaximumBalance(t *testing.T) {
 					t.Fatalf("failed to fetch block %d from archive: %v", expectation.block, err)
 				}
 				defer func() {
-					if block.Close(); err != nil {
+					if err := block.Close(); err != nil {
 						t.Errorf("failed to close block %d: %v", expectation.block, err)
 					}
 				}()

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -3965,7 +3965,7 @@ func TestStateDB_BulkLoadReachesState(t *testing.T) {
 	load.SetState(address1, key1, val1)
 	load.SetCode(address1, code)
 
-	load.Close()
+	require.NoError(t, load.Close())
 }
 
 func TestStateDB_BulkLoadApplyDetectsInconsistencies(t *testing.T) {

--- a/go/state/state_test.go
+++ b/go/state/state_test.go
@@ -128,7 +128,7 @@ func testHashAfterModification(t *testing.T, mod func(t *testing.T, schema state
 		if err != nil {
 			t.Fatalf("failed to create reference state: %v", err)
 		}
-		mod(nil, s, ref)
+		mod(t, s, ref)
 		hash, err := ref.GetHash()
 		if err != nil {
 			t.Fatalf("failed to get hash of reference state: %v", err)
@@ -162,21 +162,23 @@ func TestEmptyHash(t *testing.T) {
 
 func TestAddressHashes(t *testing.T) {
 	testHashAfterModification(t, func(t *testing.T, schema state.Schema, s state.State) {
-		s.Apply(0, common.Update{
+		_, err := s.Apply(0, common.Update{
 			Balances: []common.BalanceUpdate{{Account: common.Address{0x01}, Balance: amount.New(100)}},
 		})
+		require.NoError(t, err)
 	})
 }
 
 func TestMultipleAddressHashes(t *testing.T) {
 	testHashAfterModification(t, func(t *testing.T, schema state.Schema, s state.State) {
-		s.Apply(0, common.Update{
+		_, err := s.Apply(0, common.Update{
 			Balances: []common.BalanceUpdate{
 				{Account: address1, Balance: balance1},
 				{Account: address2, Balance: balance2},
 				{Account: address3, Balance: balance3},
 			},
 		})
+		require.NoError(t, err)
 	})
 }
 
@@ -185,96 +187,105 @@ func TestDeletedAddressHashes(t *testing.T) {
 		if t != nil && schema == 6 {
 			t.Skipf("schema %d not supported", schema)
 		}
-		s.Apply(0, common.Update{
+		_, err := s.Apply(0, common.Update{
 			Balances:        []common.BalanceUpdate{{Account: address1, Balance: balance1}},
 			DeletedAccounts: []common.Address{address1, address2},
 		})
+		require.NoError(t, err)
 	})
 }
 
 func TestStorageHashes(t *testing.T) {
-	testHashAfterModification(t, func(t *testing.T, chema state.Schema, s state.State) {
-		s.Apply(0, common.Update{
+	testHashAfterModification(t, func(t *testing.T, schema state.Schema, s state.State) {
+		_, err := s.Apply(0, common.Update{
 			Slots: []common.SlotUpdate{{Account: address1, Key: key2, Value: val3}},
 		})
+		require.NoError(t, err)
 	})
 }
 
 func TestMultipleStorageHashes(t *testing.T) {
 	testHashAfterModification(t, func(t *testing.T, schema state.Schema, s state.State) {
-		s.Apply(0, common.Update{
+		_, err := s.Apply(0, common.Update{
 			Slots: []common.SlotUpdate{
 				{Account: address1, Key: key2, Value: val3},
 				{Account: address2, Key: key3, Value: val1},
 				{Account: address3, Key: key1, Value: val2},
 			},
 		})
+		require.NoError(t, err)
 	})
 }
 
 func TestBalanceUpdateHashes(t *testing.T) {
 	testHashAfterModification(t, func(t *testing.T, schema state.Schema, s state.State) {
-		s.Apply(0, common.Update{
+		_, err := s.Apply(0, common.Update{
 			Balances: []common.BalanceUpdate{
 				{Account: address1, Balance: balance1},
 			},
 		})
+		require.NoError(t, err)
 	})
 }
 
 func TestMultipleBalanceUpdateHashes(t *testing.T) {
 	testHashAfterModification(t, func(t *testing.T, schema state.Schema, s state.State) {
-		s.Apply(0, common.Update{
+		_, err := s.Apply(0, common.Update{
 			Balances: []common.BalanceUpdate{
 				{Account: address1, Balance: balance1},
 				{Account: address2, Balance: balance2},
 				{Account: address3, Balance: balance3},
 			},
 		})
+		require.NoError(t, err)
 	})
 }
 
 func TestNonceUpdateHashes(t *testing.T) {
 	testHashAfterModification(t, func(t *testing.T, schema state.Schema, s state.State) {
-		s.Apply(0, common.Update{
+		_, err := s.Apply(0, common.Update{
 			Nonces: []common.NonceUpdate{
 				{Account: address1, Nonce: nonce1},
 			},
 		})
+		require.NoError(t, err)
 	})
 }
 
 func TestMultipleNonceUpdateHashes(t *testing.T) {
 	testHashAfterModification(t, func(t *testing.T, schema state.Schema, s state.State) {
-		s.Apply(0, common.Update{
+		_, err := s.Apply(0, common.Update{
 			Nonces: []common.NonceUpdate{
 				{Account: address1, Nonce: nonce1},
 				{Account: address2, Nonce: nonce2},
 				{Account: address3, Nonce: nonce3},
 			},
 		})
+		require.NoError(t, err)
 	})
 }
 
 func TestCodeUpdateHashes(t *testing.T) {
 	testHashAfterModification(t, func(t *testing.T, schema state.Schema, s state.State) {
-		s.Apply(0, common.Update{
+		_, err := s.Apply(0, common.Update{
 			Codes: []common.CodeUpdate{
 				{Account: address1, Code: []byte{1}},
 			},
 		})
+		require.NoError(t, err)
 	})
 }
 
 func TestMultipleCodeUpdateHashes(t *testing.T) {
 	testHashAfterModification(t, func(t *testing.T, schema state.Schema, s state.State) {
-		s.Apply(0, common.Update{
+		_, err := s.Apply(0, common.Update{
 			Codes: []common.CodeUpdate{
 				{Account: address1, Code: []byte{1}},
 				{Account: address2, Code: []byte{1, 2}},
 				{Account: address3, Code: []byte{1, 2, 3}},
 			},
 		})
+		require.NoError(t, err)
 	})
 }
 
@@ -294,7 +305,8 @@ func TestLargeStateHashes(t *testing.T) {
 			update.Nonces = append(update.Nonces, common.NonceUpdate{Account: address, Nonce: common.Nonce{byte(i + 1)}})
 			update.Codes = append(update.Codes, common.CodeUpdate{Account: address, Code: []byte{byte(i), byte(i * 2), byte(i*3 + 2)}})
 		}
-		s.Apply(0, update)
+		_, err := s.Apply(0, update)
+		require.NoError(t, err)
 	})
 }
 
@@ -382,6 +394,7 @@ func TestCodeCanBeUpdated(t *testing.T) {
 
 func TestCodeHashesMatchCodes(t *testing.T) {
 	testEachConfiguration(t, func(t *testing.T, config *namedStateConfig, s state.State) {
+		require := require.New(t)
 		// account must exist (not aut-created in Verkle Trie)
 		if _, err := s.Apply(0, common.Update{
 			Balances: []common.BalanceUpdate{{Account: address1, Balance: balance1}},
@@ -402,7 +415,8 @@ func TestCodeHashesMatchCodes(t *testing.T) {
 		// Update code to non-empty code updates hash accordingly.
 		code := []byte{1, 2, 3, 4}
 		hashOfTestCode := common.GetKeccak256Hash(code)
-		s.Apply(1, common.Update{Codes: []common.CodeUpdate{{Account: address1, Code: code}}})
+		_, err = s.Apply(1, common.Update{Codes: []common.CodeUpdate{{Account: address1, Code: code}}})
+		require.NoError(err)
 		hash, err = s.GetCodeHash(address1)
 		if err != nil {
 			t.Fatalf("error fetching code hash: %v", err)
@@ -412,7 +426,8 @@ func TestCodeHashesMatchCodes(t *testing.T) {
 		}
 
 		// Reset code to empty code updates hash accordingly.
-		s.Apply(2, common.Update{Codes: []common.CodeUpdate{{Account: address1, Code: []byte{}}}})
+		_, err = s.Apply(2, common.Update{Codes: []common.CodeUpdate{{Account: address1, Code: []byte{}}}})
+		require.NoError(err)
 		hash, err = s.GetCodeHash(address1)
 		if err != nil {
 			t.Fatalf("error fetching code hash: %v", err)
@@ -501,7 +516,7 @@ func TestArchive(t *testing.T) {
 					t.Fatalf("failed to initialize state %s; %s", config.name(), err)
 				}
 			}
-			defer s.Close()
+			defer func() { require.NoError(t, s.Close()) }()
 
 			balance12 := amount.New(0x12)
 			balance34 := amount.New(0x34)
@@ -546,13 +561,13 @@ func TestArchive(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to get state of block 0; %v", err)
 			}
-			defer state1.Close()
+			defer func() { require.NoError(t, state1.Close()) }()
 
 			state2, err := s.GetArchiveState(1)
 			if err != nil {
 				t.Fatalf("failed to get state of block 1; %v", err)
 			}
-			defer state2.Close()
+			defer func() { require.NoError(t, state2.Close()) }()
 
 			if as, err := state1.Exists(address1); err != nil || as != true {
 				t.Errorf("invalid account state at block 0: %t, %v", as, err)
@@ -618,7 +633,7 @@ func TestLastArchiveBlock(t *testing.T) {
 					t.Fatalf("failed to initialize state %s; %s", config.name(), err)
 				}
 			}
-			defer s.Close()
+			defer func() { require.NoError(t, s.Close()) }()
 
 			_, empty, err := s.GetArchiveBlockHeight()
 			if err != nil {

--- a/go/state/tool/benchmark.go
+++ b/go/state/tool/benchmark.go
@@ -169,7 +169,8 @@ func runBenchmark(
 	signal.Notify(c, os.Interrupt)
 	go func() {
 		for range c {
-			pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
+			// Error is ignored because the process is about to exit immediately.
+			_ = pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
 			fmt.Printf("signal: interrupt")
 			os.Exit(1)
 		}
@@ -218,7 +219,11 @@ func runBenchmark(
 			observer("Failed to close state: %v", err)
 		}
 		observer("Closing state took %v", time.Since(start))
-		observer("Final disk usage: %d", getDirectorySize(path))
+		if size, err := getDirectorySize(path); err != nil {
+			observer("Failed to get disk usage: %v", err)
+		} else {
+			observer("Final disk usage: %d", size)
+		}
 	}()
 
 	return runBenchmarkState(state, path, params, observer)
@@ -277,7 +282,10 @@ func runBenchmarkState(
 
 			throughput := float64(reportingInterval*numInsertsPerBlock) / startReporting.Sub(lastReportTime).Seconds()
 			memory := state.GetMemoryFootprint().Total()
-			disk := getDirectorySize(path)
+			disk, err := getDirectorySize(path)
+			if err != nil {
+				observer("Failed to get disk usage: %v", err)
+			}
 			observer(
 				"Reached block %d, memory %.2f GB, disk %.2f GB, %.2f inserts/second",
 				i+1,
@@ -313,10 +321,10 @@ func runBenchmarkState(
 	return res, nil
 }
 
-// GetDirectorySize computes the size of all files in the given directory in bytes.
-func getDirectorySize(directory string) int64 {
+// getDirectorySize computes the size of all files in the given directory in bytes.
+func getDirectorySize(directory string) (int64, error) {
 	var sum int64 = 0
-	filepath.Walk(directory, func(path string, info fs.FileInfo, err error) error {
+	err := filepath.Walk(directory, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
 			return nil
 		}
@@ -325,5 +333,5 @@ func getDirectorySize(directory string) int64 {
 		}
 		return nil
 	})
-	return sum
+	return sum, err
 }

--- a/go/state/tool/benchmark.go
+++ b/go/state/tool/benchmark.go
@@ -12,11 +12,9 @@ package main
 
 import (
 	"fmt"
-	"io/fs"
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"runtime"
 	"runtime/pprof"
 	"time"
@@ -219,7 +217,7 @@ func runBenchmark(
 			observer("Failed to close state: %v", err)
 		}
 		observer("Closing state took %v", time.Since(start))
-		if size, err := getDirectorySize(path); err != nil {
+		if size, err := common.GetDirectorySize(path); err != nil {
 			observer("Failed to get disk usage: %v", err)
 		} else {
 			observer("Final disk usage: %d", size)
@@ -282,9 +280,9 @@ func runBenchmarkState(
 
 			throughput := float64(reportingInterval*numInsertsPerBlock) / startReporting.Sub(lastReportTime).Seconds()
 			memory := state.GetMemoryFootprint().Total()
-			disk, err := getDirectorySize(path)
+			disk, err := common.GetDirectorySize(path)
 			if err != nil {
-				observer("Failed to get disk usage: %v", err)
+				return res, fmt.Errorf("failed to get disk usage: %v", err)
 			}
 			observer(
 				"Reached block %d, memory %.2f GB, disk %.2f GB, %.2f inserts/second",
@@ -319,19 +317,4 @@ func runBenchmarkState(
 	res.reportTime = reportingTime
 
 	return res, nil
-}
-
-// getDirectorySize computes the size of all files in the given directory in bytes.
-func getDirectorySize(directory string) (int64, error) {
-	var sum int64 = 0
-	err := filepath.Walk(directory, func(path string, info fs.FileInfo, err error) error {
-		if err != nil {
-			return nil
-		}
-		if !info.IsDir() {
-			sum += info.Size()
-		}
-		return nil
-	})
-	return sum, err
 }

--- a/go/state/tool/benchmark_test.go
+++ b/go/state/tool/benchmark_test.go
@@ -160,12 +160,13 @@ func TestGetDirectorySize_Normal(t *testing.T) {
 	data := []byte("abcde")
 	require.NoError(t, os.WriteFile(file, data, 0644))
 
-	size := getDirectorySize(dir)
+	size, err := getDirectorySize(dir)
+	require.NoError(t, err)
 	require.Equal(t, int64(len(data)), size)
 }
 
 func TestGetDirectorySize_NonExistentDir(t *testing.T) {
-	size := getDirectorySize("/path/does/not/exist")
+	size, _ := getDirectorySize("/path/does/not/exist")
 	require.Equal(t, int64(0), size)
 }
 
@@ -175,7 +176,8 @@ func TestGetDirectorySize_UnreadableFile(t *testing.T) {
 	data := []byte("xyz")
 	require.NoError(t, os.WriteFile(file, data, 0000)) // No permissions
 
-	size := getDirectorySize(dir)
+	size, err := getDirectorySize(dir)
+	require.NoError(t, err)
 	// Should skip unreadable file and not panic
 	require.GreaterOrEqual(t, size, int64(0))
 }

--- a/go/state/tool/benchmark_test.go
+++ b/go/state/tool/benchmark_test.go
@@ -154,34 +154,6 @@ func TestBenchmark_SupportsDifferentModes(t *testing.T) {
 	}
 }
 
-func TestGetDirectorySize_Normal(t *testing.T) {
-	dir := t.TempDir()
-	file := filepath.Join(dir, "file1")
-	data := []byte("abcde")
-	require.NoError(t, os.WriteFile(file, data, 0644))
-
-	size, err := getDirectorySize(dir)
-	require.NoError(t, err)
-	require.Equal(t, int64(len(data)), size)
-}
-
-func TestGetDirectorySize_NonExistentDir(t *testing.T) {
-	size, _ := getDirectorySize("/path/does/not/exist")
-	require.Equal(t, int64(0), size)
-}
-
-func TestGetDirectorySize_UnreadableFile(t *testing.T) {
-	dir := t.TempDir()
-	file := filepath.Join(dir, "file2")
-	data := []byte("xyz")
-	require.NoError(t, os.WriteFile(file, data, 0000)) // No permissions
-
-	size, err := getDirectorySize(dir)
-	require.NoError(t, err)
-	// Should skip unreadable file and not panic
-	require.GreaterOrEqual(t, size, int64(0))
-}
-
 func TestBenchmark_CLIAction(t *testing.T) {
 	tmpDirs := map[string]struct {
 		tmpdir     func() string

--- a/go/state/tool/benchmark_test.go
+++ b/go/state/tool/benchmark_test.go
@@ -83,12 +83,12 @@ func TestBenchmark_RunExampleBenchmark(t *testing.T) {
 		}
 	}
 
-	filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
+	require.NoError(t, filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
 		if strings.HasPrefix(info.Name(), "mpt_") {
 			t.Errorf("temporary DB was not deleted")
 		}
 		return nil
-	})
+	}))
 }
 
 func TestBenchmark_KeepStateRetainsState(t *testing.T) {
@@ -107,12 +107,12 @@ func TestBenchmark_KeepStateRetainsState(t *testing.T) {
 	}
 
 	found := false
-	filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
+	require.NoError(t, filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
 		if strings.HasPrefix(info.Name(), "state_") {
 			found = true
 		}
 		return nil
-	})
+	}))
 
 	if !found {
 		t.Errorf("temporary MPT was not retained")
@@ -140,12 +140,12 @@ func TestBenchmark_SupportsDifferentModes(t *testing.T) {
 			}
 
 			found := false
-			filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
+			require.NoError(t, filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
 				if strings.HasPrefix(info.Name(), "archive") {
 					found = true
 				}
 				return nil
-			})
+			}))
 
 			if found != mode {
 				t.Errorf("unexpected presence of archive, wanted %t, got %t", mode, found)


### PR DESCRIPTION
This PR fixes all the errcheck lints found by golangci-lint-v2.
In tests, they are treated with the `require` library.

This was partially automated