### PR TITLE
Fix ineffassign lints

### DIFF
--- a/go/.golangci.yml
+++ b/go/.golangci.yml
@@ -1,0 +1,56 @@
+# Copyright (c) 2025 Sonic Operations Ltd
+#
+# Use of this software is governed by the Business Source License included
+# in the LICENSE file and at soniclabs.com/bsl11.
+#
+# Change Date: 2028-4-16
+#
+# On the date above, in accordance with the Business Source License, use of
+# this software will be governed by the GNU Lesser General Public License v3.
+
+version: "2"
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - misspell
+    - staticcheck
+    - unused
+
+  settings:
+    staticcheck:
+      checks:
+        - "all"
+        # Ignored rules
+        - "-ST1000" # Incorrect or missing package comment.
+        - "-ST1003" # Poorly chosen identifier.
+        # rules ST1023 and QF1011 have few findings, but in those cases adding
+        # the type to the declaration improves readability.
+        - "-ST1023" # Redundant type in variable declaration.
+        - "-QF1011" # Omit redundant type from variable declaration.
+
+
+formatters:
+  # Enable specific formatter.
+  enable:
+    - gofmt
+
+issues:
+  # do not limit number of findings per linter
+  max-issues-per-linter: 0
+  # do not limit number of same finding
+  max-same-issues: 0
+  # do not limit number of issues per line
+  uniq-by-line: false
+
+output:
+  formats:
+    text:
+      # for CI or automated processing
+      path: ./build/golangci-lint-report.txt
+    html:
+      # for human consumption
+      path: ./build/golangci-lint-report.html
+    tab:
+      path: stdout

--- a/go/common/cache_test.go
+++ b/go/common/cache_test.go
@@ -62,7 +62,7 @@ func TestCache_GetOrSet(t *testing.T) {
 				t.Errorf("key 1 should exist")
 			}
 
-			val, exists, _, _, _ = c.GetOrSet(2, 22)
+			_, exists, _, _, _ = c.GetOrSet(2, 22)
 			if exists {
 				t.Errorf("key 2 should not exist")
 			}

--- a/go/database/mpt/hasher.go
+++ b/go/database/mpt/hasher.go
@@ -829,6 +829,7 @@ func getLowerBoundForEncodedSizeAccount(node *AccountNode, limit int, nodes Node
 
 func getLowerBoundForEncodedSizeBranch(node *BranchNode, limit int, nodes NodeSource) (int, error) {
 	var emptySize = len(emptyStringRlpEncoded)
+	//nolint:ineffassign
 	sum := 1        // children are encoded as elements of a list and the list adds at least 1 byte for the size
 	sum = emptySize // the 17th element.
 

--- a/go/database/mpt/proof_test.go
+++ b/go/database/mpt/proof_test.go
@@ -1273,7 +1273,7 @@ func TestCreateWitnessProof_GetStorageElementsOfEmptyAccount_IsZerosHash(t *test
 		t.Errorf("unexpected storage root: got %v, want %v", storageRoot, common.Hash{})
 	}
 
-	elements, complete := proof.GetStorageElements(rootHash, address, common.Key{})
+	elements, _ := proof.GetStorageElements(rootHash, address, common.Key{})
 	if len(elements) != 1 {
 		t.Fatalf("unexpected number of elements: got %d, want 1", len(elements))
 	}


### PR DESCRIPTION
This PR fixers all the ineffassign lints found by golangci-lint-v2.
The double initialization in hasher.go has been explicitly ignored