### PR TITLE
Fix missing variable in `go_state_test.go`

### DIFF
--- a/go/state/gostate/go_state_test.go
+++ b/go/state/gostate/go_state_test.go
@@ -45,6 +45,7 @@ var (
 	val3 = common.Value{0x03}
 
 	balance1 = amount.New(1)
+	balance2 = amount.New(2)
 
 	nonce1 = common.Nonce{0x01}
 )


### PR DESCRIPTION
For some reason, a variable was missing which made tests fail. 
I am not sure how did it pass CI, maybe one of the automatic rebase from the GitHub UI