### PR TITLE
Add go lint to CI

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,0 +1,46 @@
+# Copyright 2026 Sonic Operations Ltd
+# This file is part of the Sonic Client
+#
+# Sonic is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Sonic is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+name: Go
+
+permissions:
+  contents: read
+  checks: write
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ "**" ]
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+    - name: setup go
+      uses: actions/setup-go@v5
+      with:
+        go-version: "1.26.0"
+        cache-dependency-path: go/go.sum
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v9
+      with:
+        version: v2.12.2
+        working-directory: go

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,19 +1,3 @@
-# Copyright 2026 Sonic Operations Ltd
-# This file is part of the Sonic Client
-#
-# Sonic is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Sonic is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with Sonic. If not, see <http://www.gnu.org/licenses/>.
-
 name: Go
 
 permissions:
@@ -23,13 +7,20 @@ permissions:
 on:
   push:
     branches: [ main ]
+    paths:
+       - ".github/workflows/go.yaml"
+       - "go/**"
   pull_request:
     branches: [ "**" ]
+    paths:
+       - ".github/workflows/go.yaml"
+       - "go/**"
 
 jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
     - name: checkout

--- a/go/backend/stock/stock_fuzzing_utils_test.go
+++ b/go/backend/stock/stock_fuzzing_utils_test.go
@@ -257,7 +257,7 @@ func TestFuzzing_Deserialize_Expensive_ops_Skipped(t *testing.T) {
 		stream = append(stream, item.Serialize()...)
 	}
 
-	// three expensive ops in row will be skipped, and all expensive after 20 occurances
+	// three expensive ops in row will be skipped, and all expensive after 20 occurrences
 	want := []fuzzing.Operation[stockFuzzContext]{
 		&opNewId{}, &opGetIds{}, &opGetIds{}, &opGetIds{}, &opGet{0}}
 

--- a/go/backend/utils/buffered_file_test.go
+++ b/go/backend/utils/buffered_file_test.go
@@ -367,7 +367,7 @@ func TestBufferedFile_WrittenDataCanBeRead(t *testing.T) {
 					t.Fatalf("failed to read at position %d: %v", i, err)
 				}
 				if dst[0] != byte(i) {
-					t.Errorf("invalid data read at postion %d, wanted %d, got %d", i, byte(i), dst[0])
+					t.Errorf("invalid data read at position %d, wanted %d, got %d", i, byte(i), dst[0])
 				}
 			}
 
@@ -409,7 +409,7 @@ func TestBufferedFile_DataIsPersistent(t *testing.T) {
 					t.Fatalf("failed to read at position %d: %v", i, err)
 				}
 				if dst[0] != byte(i+1) {
-					t.Errorf("invalid data read at postion %d, wanted %d, got %d", i, byte(i+1), dst[0])
+					t.Errorf("invalid data read at position %d, wanted %d, got %d", i, byte(i+1), dst[0])
 				}
 			}
 
@@ -427,7 +427,7 @@ func TestBufferedFile_ReadAndWriteCanHandleUnalignedData(t *testing.T) {
 		t.Fatalf("failed to open buffered file: %v", err)
 	}
 
-	// By writting data of length 3 we are sometimes writing data crossing
+	// By writing data of length 3 we are sometimes writing data crossing
 	// the internal aligned buffer-page boundary.
 	for i := 0; i < 1000; i++ {
 		if _, err := file.WriteAt([]byte{byte(i), byte(i + 1), byte(i + 2)}, int64(i)*3); err != nil {
@@ -442,7 +442,7 @@ func TestBufferedFile_ReadAndWriteCanHandleUnalignedData(t *testing.T) {
 		}
 		want := []byte{byte(i), byte(i + 1), byte(i + 2)}
 		if !bytes.Equal(dst, want) {
-			t.Errorf("invalid data read at postion %d, wanted %d, got %d", i, want, dst)
+			t.Errorf("invalid data read at position %d, wanted %d, got %d", i, want, dst)
 		}
 	}
 

--- a/go/carmen/block_test.go
+++ b/go/carmen/block_test.go
@@ -205,7 +205,7 @@ func TestHeadBlockContext_CannotCommit_WhenTransactionRunning(t *testing.T) {
 	}
 
 	if err := block.Commit(); !errors.Is(err, errTransactionRunning) {
-		t.Errorf("commit should fail when transaction is not commited")
+		t.Errorf("commit should fail when transaction is not committed")
 	}
 
 	if err := tx.Abort(); err != nil {

--- a/go/carmen/carmen.go
+++ b/go/carmen/carmen.go
@@ -187,7 +187,7 @@ type HeadBlockContext interface {
 
 // HistoricBlockContext provides access to the world state of a block of a blockchain.
 // This context allows the caller to open a transaction
-// and query state of the blockchain as it was for this particular block withing the history.
+// and query state of the blockchain as it was for this particular block within the history.
 // The caller can as well modify the context via a transaction, i.e. simulating
 // an alternative history.
 // These changes cannot be, however, committed as this context can not be committed, only be closed.

--- a/go/carmen/example_test.go
+++ b/go/carmen/example_test.go
@@ -71,7 +71,7 @@ func ExampleDatabase_BeginBlock() {
 		log.Fatalf("cannot begin block: %v", err)
 	}
 
-	// Begin a new transaction withing the block
+	// Begin a new transaction within the block
 	tctx, err := bctx.BeginTransaction()
 	if err != nil {
 		log.Fatalf("cannot begin transaction: %v", err)

--- a/go/common/distribution.go
+++ b/go/common/distribution.go
@@ -23,7 +23,7 @@ const (
 	Exponential distribution = 2
 )
 
-// Distribution wraps a Label of the distribution and a function to get a next value withing the given distribution
+// Distribution wraps a Label of the distribution and a function to get a next value within the given distribution
 type Distribution struct {
 	Label   string
 	GetNext func() uint32

--- a/go/common/mem_footprint_test.go
+++ b/go/common/mem_footprint_test.go
@@ -95,7 +95,7 @@ func TestMemoryFootprintPrintsDataInPostfixOrder(t *testing.T) {
 		t.Fatalf("Failed to match regex: %v", err)
 	}
 	if !match {
-		t.Errorf("Parent is not after componentes:\n%v", print)
+		t.Errorf("Parent is not after components:\n%v", print)
 	}
 }
 func TestMemoryFootprintPrintIsAligned(t *testing.T) {

--- a/go/common/tribool/tribool_test.go
+++ b/go/common/tribool/tribool_test.go
@@ -104,7 +104,7 @@ func TestTribool_All_Elements_Are_Comparable(t *testing.T) {
 	for i, a := range items {
 		for j, b := range items {
 			if got, want := a == b, i == j; got != want {
-				t.Errorf("unexpected tribool [%v, %v] comparision: got: %v, want %v", a, b, got, want)
+				t.Errorf("unexpected tribool [%v, %v] comparison: got: %v, want %v", a, b, got, want)
 			}
 		}
 	}

--- a/go/common/types.go
+++ b/go/common/types.go
@@ -239,7 +239,7 @@ func (a Key) String() string {
 	return fmt.Sprintf("%x", a[:])
 }
 
-// HashFromString converst a 64-character long hex string into a hash.
+// HashFromString converts a 64-character long hex string into a hash.
 // The operation is slow and mainly intended for producing readable test
 // cases. The operation will panic if the provided hash is mailformed.
 func HashFromString(str string) Hash {

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -523,7 +523,6 @@ func TestArchiveTrie_VisitAccount(t *testing.T) {
 			)
 
 			// insert growing number of keys in several accounts
-			accounts := make([]common.Address, 0, Addresses)
 			nonces := make([]common.NonceUpdate, 0, Addresses)
 			slotUpdates := make([]common.SlotUpdate, 0, Addresses*Addresses)
 			for i := 0; i < Addresses; i++ {
@@ -532,7 +531,6 @@ func TestArchiveTrie_VisitAccount(t *testing.T) {
 				for j := 0; j < i+1; j++ {
 					slots = append(slots, common.SlotUpdate{Account: addr, Key: common.Key{byte(j)}, Value: common.Value{byte(j)}})
 				}
-				accounts = append(accounts, addr)
 				nonces = append(nonces, common.NonceUpdate{Account: addr, Nonce: common.Nonce{1}})
 				slotUpdates = append(slotUpdates, slots...)
 			}

--- a/go/database/mpt/decoder_test.go
+++ b/go/database/mpt/decoder_test.go
@@ -176,9 +176,7 @@ func TestDecoder_DecodeEmbeddedNode_CanDecode(t *testing.T) {
 	}
 
 	expectedValueNode := ValueNode{key: common.Key{0x12, 0x34}, value: commonValue, pathLength: 4}
-	if matchNodesRlpDecoded(t, &expectedValueNode, got); err != nil {
-		t.Fatalf("failed to match nodes: %v", err)
-	}
+	matchNodesRlpDecoded(t, &expectedValueNode, got)
 }
 
 func TestDecoder_CorruptedRlp(t *testing.T) {

--- a/go/database/mpt/node_id.go
+++ b/go/database/mpt/node_id.go
@@ -31,7 +31,7 @@ import (
 //   - the value has a binary suffix of 111 ... extension node
 //
 // This allows to address 2^63 different branch nodes, 2^62 different values
-// and 2^61 account and extension nodes, sufficient for any forseeable future.
+// and 2^61 account and extension nodes, sufficient for any foreseeable future.
 type NodeId uint64
 
 // EmptyId returns the node ID representing the empty node.

--- a/go/database/mpt/path.go
+++ b/go/database/mpt/path.go
@@ -82,7 +82,7 @@ func (p *Path) Get(pos int) Nibble {
 }
 
 // Set updates the value of a Nibble on this path or ignores the call if
-// the position is not on the path, thus not in the range [0,Lenght()-1].
+// the position is not on the path, thus not in the range [0,Length()-1].
 func (p *Path) Set(pos int, val Nibble) {
 	if pos < 0 || pos >= int(p.length) {
 		panic(fmt.Sprintf("out-of-range path update at %d in range [%d,%d)", pos, 0, p.length))

--- a/go/database/vt/benchmark_test.go
+++ b/go/database/vt/benchmark_test.go
@@ -78,7 +78,7 @@ func Benchmark_VerkleTrie_Commit_To_LeafNode_Update_All_Values(b *testing.B) {
 		b.Fatalf("failed to create test node: %v", err)
 	}
 
-	// tree is commited at the beginning
+	// tree is committed at the beginning
 	root.Commit()
 
 	var counter int
@@ -103,7 +103,7 @@ func Benchmark_VerkleTrie_Commit_To_LeafNode_Update_Single_Value(b *testing.B) {
 		b.Fatalf("failed to create test node: %v", err)
 	}
 
-	// tree is commited at the beginning
+	// tree is committed at the beginning
 	root.Commit()
 
 	var counter int

--- a/go/database/vt/reference/state.go
+++ b/go/database/vt/reference/state.go
@@ -63,7 +63,7 @@ func (s *State) TrieConfig() any {
 func (s *State) Exists(address common.Address) (bool, error) {
 	key := s.embedding.getBasicDataKey(address)
 	value := s.trie.Get(key)
-	var empty [24]byte // nonce and balance are layed out in bytes 8-32
+	var empty [24]byte // nonce and balance are laid out in bytes 8-32
 	return !bytes.Equal(value[8:32], empty[:]), nil
 
 }

--- a/go/fuzzing/fuzzing_test.go
+++ b/go/fuzzing/fuzzing_test.go
@@ -242,6 +242,6 @@ func applyAndMatch(input, expected OperationSequence[testContext], apply func(ra
 	}
 
 	if !slices.Equal(*got, want) {
-		t.Errorf("exectued operations do not match: got: %v != want: %v", *got, want)
+		t.Errorf("executed operations do not match: got: %v != want: %v", *got, want)
 	}
 }

--- a/go/state/gostate/go_state_test.go
+++ b/go/state/gostate/go_state_test.go
@@ -39,15 +39,12 @@ var (
 	key2 = common.Key{0x02}
 	key3 = common.Key{0x03}
 
-	val0 = common.Value{0x00}
 	val1 = common.Value{0x01}
 	val2 = common.Value{0x02}
 	val3 = common.Value{0x03}
 
 	balance1 = amount.New(1)
 	balance2 = amount.New(2)
-
-	nonce1 = common.Nonce{0x01}
 )
 
 type namedStateConfig struct {

--- a/go/state/state_test.go
+++ b/go/state/state_test.go
@@ -40,7 +40,6 @@ var (
 	key2 = common.Key{0x02}
 	key3 = common.Key{0x03}
 
-	val0 = common.Value{0x00}
 	val1 = common.Value{0x01}
 	val2 = common.Value{0x02}
 	val3 = common.Value{0x03}


### PR DESCRIPTION
While we should technically add this to Jenkins for consistency, I think gihtub CI is more fit for running simple lints.

This also fixes a couple of lints that went undetencted in previous PRs.