### PR TITLE
Remove `Exists` from `State` implementations

### DIFF
--- a/bindings/state/c_state.h
+++ b/bindings/state/c_state.h
@@ -109,11 +109,6 @@ DUPLICATE_FOR_LANGS(enum Result,
 DUPLICATE_FOR_LANGS(enum Result, GetArchiveBlockHeight(C_Database database,
                                                        int64_t* out_block));
 
-// ------------------------------- Accounts -----------------------------------
-
-// Checks if the given account exists.
-DUPLICATE_FOR_LANGS(enum Result, AccountExists(C_State state, C_Address addr,
-                                               C_AccountState out_state));
 
 // -------------------------------- Balance -----------------------------------
 

--- a/go/database/flat/flat.go
+++ b/go/database/flat/flat.go
@@ -174,11 +174,6 @@ func WrapFactory(innerFactory state.StateFactory) state.StateFactory {
 
 // --- State Interface Implementation ---
 
-func (s *State) Exists(address common.Address) (bool, error) {
-	_, found := s.accounts[address]
-	return found, nil
-}
-
 func (s *State) GetBalance(address common.Address) (amount.Amount, error) {
 	return s.accounts[address].balance, nil
 }

--- a/go/database/flat/flat_test.go
+++ b/go/database/flat/flat_test.go
@@ -190,23 +190,6 @@ func TestState_Close_IssueDuringCloseIsReported(t *testing.T) {
 	require.ErrorIs(t, err, issue)
 }
 
-func TestState_Exists_ReturnsFromLocalMap(t *testing.T) {
-	require := require.New(t)
-	addr := common.Address{0x01}
-	state := &State{
-		accounts: map[common.Address]account{
-			addr: {},
-		},
-	}
-
-	exists, err := state.Exists(addr)
-	require.NoError(err)
-	require.True(exists)
-	exists, err = state.Exists(common.Address{0x03})
-	require.NoError(err)
-	require.False(exists)
-}
-
 func TestState_GetBalance_ReturnsFromLocalMap(t *testing.T) {
 	require := require.New(t)
 	addr := common.Address{0x01}
@@ -388,25 +371,25 @@ func TestState_Apply_DeletesAccounts(t *testing.T) {
 	backend.EXPECT().Close().Return(nil)
 
 	address := common.Address{0x01}
-	state, err := NewState(t.TempDir(), backend)
+	s, err := NewState(t.TempDir(), backend)
 	require.NoError(err)
 
-	require.False(state.Exists(address))
+	require.True(state.IsEmptyAccount(s, address))
 
-	_, err = state.Apply(1, common.Update{
+	_, err = s.Apply(1, common.Update{
 		Balances: []common.BalanceUpdate{{Account: address, Balance: amount.New(10)}},
 	})
 	require.NoError(err)
 
-	require.True(state.Exists(address))
+	require.False(state.IsEmptyAccount(s, address))
 
-	_, err = state.Apply(2, common.Update{
+	_, err = s.Apply(2, common.Update{
 		DeletedAccounts: []common.Address{address},
 	})
 	require.NoError(err)
 
-	require.False(state.Exists(address))
-	require.NoError(state.Close())
+	require.True(state.IsEmptyAccount(s, address))
+	require.NoError(s.Close())
 }
 
 func TestState_Apply_IsForwardedToBackend(t *testing.T) {

--- a/go/database/flat/flat_test.go
+++ b/go/database/flat/flat_test.go
@@ -374,21 +374,27 @@ func TestState_Apply_DeletesAccounts(t *testing.T) {
 	s, err := NewState(t.TempDir(), backend)
 	require.NoError(err)
 
-	require.True(state.IsEmptyAccount(s, address))
+	isEmpty, err := state.IsEmptyAccount(s, address)
+	require.NoError(err)
+	require.True(isEmpty)
 
 	_, err = s.Apply(1, common.Update{
 		Balances: []common.BalanceUpdate{{Account: address, Balance: amount.New(10)}},
 	})
 	require.NoError(err)
 
-	require.False(state.IsEmptyAccount(s, address))
+	isEmpty, err = state.IsEmptyAccount(s, address)
+	require.NoError(err)
+	require.False(isEmpty)
 
 	_, err = s.Apply(2, common.Update{
 		DeletedAccounts: []common.Address{address},
 	})
 	require.NoError(err)
 
-	require.True(state.IsEmptyAccount(s, address))
+	isEmpty, err = state.IsEmptyAccount(s, address)
+	require.NoError(err)
+	require.True(isEmpty)
 	require.NoError(s.Close())
 }
 

--- a/go/database/mpt/io/live_test.go
+++ b/go/database/mpt/io/live_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/common/amount"
 	"github.com/0xsoniclabs/carmen/go/database/mpt"
+	"github.com/0xsoniclabs/carmen/go/state"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,10 +44,10 @@ func TestIO_ExportAndImportAsLiveDb(t *testing.T) {
 	}
 	defer func() { require.NoError(t, db.Close()) }()
 
-	if exists, err := db.Exists(common.Address{1}); err != nil || !exists {
+	if empty := isEmptyAccount(t, db, common.Address{1}); empty {
 		t.Fatalf("restored DB does not contain account 1")
 	}
-	if exists, err := db.Exists(common.Address{2}); err != nil || !exists {
+	if empty := isEmptyAccount(t, db, common.Address{2}); empty {
 		t.Fatalf("restored DB does not contain account 2")
 	}
 
@@ -457,4 +458,21 @@ func TestIO_Live_Import_IncorrectMagicNumberIsNoticed(t *testing.T) {
 	if !strings.EqualFold(got, want) {
 		t.Errorf("unexpected error message\ngot: %v\nwant:%v", got, want)
 	}
+}
+
+func isEmptyAccount(t *testing.T, db state.LiveDB, addr common.Address) bool {
+	t.Helper()
+	balance, err := db.GetBalance(addr)
+	if err != nil {
+		t.Fatalf("failed to get balance: %v", err)
+	}
+	nonce, err := db.GetNonce(addr)
+	if err != nil {
+		t.Fatalf("failed to get nonce: %v", err)
+	}
+	code, err := db.GetCode(addr)
+	if err != nil {
+		t.Fatalf("failed to get code: %v", err)
+	}
+	return balance == (amount.Amount{}) && nonce == (common.Nonce{}) && len(code) == 0
 }

--- a/go/database/mpt/state.go
+++ b/go/database/mpt/state.go
@@ -198,14 +198,6 @@ func OpenGoFileState(directory string, config MptConfig, cacheConfig NodeCacheCo
 	return newMptState(directory, lock, trie)
 }
 
-func (s *MptState) Exists(address common.Address) (bool, error) {
-	_, exists, err := s.trie.GetAccountInfo(address)
-	if err != nil {
-		return false, err
-	}
-	return exists, nil
-}
-
 func (s *MptState) DeleteAccount(address common.Address) error {
 	return s.trie.SetAccountInfo(address, AccountInfo{})
 }

--- a/go/database/mpt/state_mocks.go
+++ b/go/database/mpt/state_mocks.go
@@ -561,21 +561,6 @@ func (mr *MockLiveStateMockRecorder) DeleteAccount(address any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccount", reflect.TypeOf((*MockLiveState)(nil).DeleteAccount), address)
 }
 
-// Exists mocks base method.
-func (m *MockLiveState) Exists(address common.Address) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Exists", address)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Exists indicates an expected call of Exists.
-func (mr *MockLiveStateMockRecorder) Exists(address any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockLiveState)(nil).Exists), address)
-}
-
 // Flush mocks base method.
 func (m *MockLiveState) Flush() error {
 	m.ctrl.T.Helper()

--- a/go/database/mpt/state_test.go
+++ b/go/database/mpt/state_test.go
@@ -315,9 +315,6 @@ func TestState_StateModifications_Failing(t *testing.T) {
 		}
 	}()
 
-	if _, err := state.Exists(common.Address{1}); !errors.Is(err, injectedErr) {
-		t.Errorf("accessing data should fail")
-	}
 	if err := state.DeleteAccount(common.Address{1}); !errors.Is(err, injectedErr) {
 		t.Errorf("accessing data should fail")
 	}
@@ -415,9 +412,6 @@ func TestState_StateModificationsWithoutErrorHaveExpectedEffects(t *testing.T) {
 			if err := state.SetBalance(common.Address{1}, balance); err != nil {
 				t.Errorf("error to set balance: %s", err)
 			}
-			if exists, err := state.Exists(common.Address{1}); err != nil || !exists {
-				t.Errorf("account should exist: %v err: %s", exists, err)
-			}
 			if got, err := state.GetBalance(common.Address{1}); err != nil || balance != got {
 				t.Errorf("wrong balance: %v != %v err: %s", got, balance, err)
 			}
@@ -459,10 +453,6 @@ func TestState_StateModificationsWithoutErrorHaveExpectedEffects(t *testing.T) {
 			if err := state.DeleteAccount(common.Address{1}); err != nil {
 				t.Errorf("error to access data: %s", err)
 			}
-			if exists, err := state.Exists(common.Address{1}); err != nil || exists {
-				t.Errorf("account should not exist: %v err: %s", exists, err)
-			}
-
 			emptyBalance := amount.New()
 			if got, err := state.GetBalance(common.Address{1}); err != nil || got != emptyBalance {
 				t.Errorf("wrong balance: %v != %v err: %s", got, emptyBalance, err)

--- a/go/database/vt/geth/state.go
+++ b/go/database/vt/geth/state.go
@@ -124,16 +124,6 @@ func _newStateWithSource(source NodeSource) (_ *verkleState, err error) {
 }
 
 // --- State interface implementation ---
-
-func (s *verkleState) Exists(address common.Address) (bool, error) {
-	account, _, err := s.getAccount(address)
-	if err != nil {
-		return false, err
-	}
-
-	return account != nil, nil
-}
-
 func (s *verkleState) GetBalance(address common.Address) (amount.Amount, error) {
 	account, err := s.getAccountData(address)
 	if err != nil {

--- a/go/database/vt/reference/state.go
+++ b/go/database/vt/reference/state.go
@@ -11,7 +11,6 @@
 package reference
 
 import (
-	"bytes"
 	"context"
 	"encoding/binary"
 	"fmt"
@@ -58,14 +57,6 @@ func NewStateUsing(trie Trie) state.State {
 
 func (s *State) TrieConfig() any {
 	return s.trie.Config()
-}
-
-func (s *State) Exists(address common.Address) (bool, error) {
-	key := s.embedding.getBasicDataKey(address)
-	value := s.trie.Get(key)
-	var empty [24]byte // nonce and balance are laid out in bytes 8-32
-	return !bytes.Equal(value[8:32], empty[:]), nil
-
 }
 
 func (s *State) GetBalance(address common.Address) (amount.Amount, error) {

--- a/go/database/vt/reference/state_test.go
+++ b/go/database/vt/reference/state_test.go
@@ -55,13 +55,6 @@ func TestState_TrieConfig_ReturnsTheUnderlyingTrieConfig(t *testing.T) {
 	require.Equal(want, got)
 }
 
-func TestState_Exists(t *testing.T) {
-	state := newState()
-	exists, err := state.Exists(common.Address{1})
-	require.NoError(t, err)
-	require.False(t, exists, "Expected Exists to return false for non-existing address")
-}
-
 func TestState_CanStoreAndRestoreNonces(t *testing.T) {
 	require := require.New(t)
 

--- a/go/database/vt/state_test.go
+++ b/go/database/vt/state_test.go
@@ -371,13 +371,6 @@ type comparingState struct {
 	t           *testing.T
 }
 
-func (s *comparingState) Exists(address common.Address) (bool, error) {
-	s.t.Helper()
-	return getCmpStateValue(s, func(state state.State) (bool, error) {
-		return state.Exists(address)
-	})
-}
-
 func (s *comparingState) GetNonce(address common.Address) (common.Nonce, error) {
 	s.t.Helper()
 	return getCmpStateValue(s, func(state state.State) (common.Nonce, error) {

--- a/go/state/externalstate/external_state.go
+++ b/go/state/externalstate/external_state.go
@@ -51,7 +51,6 @@ type externalBindings interface {
 	GetLiveState(database unsafe.Pointer, outState *unsafe.Pointer) C.enum_Result
 	GetArchiveState(database unsafe.Pointer, block C.uint64_t, outState *unsafe.Pointer) C.enum_Result
 	GetArchiveBlockHeight(database unsafe.Pointer, outBlock *C.int64_t) C.enum_Result
-	AccountExists(state unsafe.Pointer, address unsafe.Pointer, outExists unsafe.Pointer) C.enum_Result
 	GetBalance(state unsafe.Pointer, address unsafe.Pointer, outBalance unsafe.Pointer) C.enum_Result
 	GetNonce(state unsafe.Pointer, address unsafe.Pointer, outNonce unsafe.Pointer) C.enum_Result
 	GetStorageValue(state unsafe.Pointer, address unsafe.Pointer, key unsafe.Pointer, outValue unsafe.Pointer) C.enum_Result
@@ -122,15 +121,6 @@ func (s *ExternalState) CreateAccount(address common.Address) error {
 	update := common.Update{}
 	_, err := s.Apply(0, update)
 	return err
-}
-
-func (s *ExternalState) Exists(address common.Address) (bool, error) {
-	var res common.AccountState
-	result := s.bindings.AccountExists(s.state, unsafe.Pointer(&address[0]), unsafe.Pointer(&res))
-	if result != C.kResult_Success {
-		return false, fmt.Errorf("failed to check if account exists (error code %v)", result)
-	}
-	return res == common.Exists, nil
 }
 
 func (s *ExternalState) DeleteAccount(address common.Address) error {

--- a/go/state/externalstate/external_state_mocks.go
+++ b/go/state/externalstate/external_state_mocks.go
@@ -58,20 +58,6 @@ func (m *MockexternalBindings) EXPECT() *MockexternalBindingsMockRecorder {
 	return m.recorder
 }
 
-// AccountExists mocks base method.
-func (m *MockexternalBindings) AccountExists(state, address, outExists unsafe.Pointer) C.enum_Result {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AccountExists", state, address, outExists)
-	ret0, _ := ret[0].(C.enum_Result)
-	return ret0
-}
-
-// AccountExists indicates an expected call of AccountExists.
-func (mr *MockexternalBindingsMockRecorder) AccountExists(state, address, outExists any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AccountExists", reflect.TypeOf((*MockexternalBindings)(nil).AccountExists), state, address, outExists)
-}
-
 // Apply mocks base method.
 func (m *MockexternalBindings) Apply(state unsafe.Pointer, block C.uint64_t, update unsafe.Pointer, updateLength C.uint64_t) C.enum_Result {
 	m.ctrl.T.Helper()

--- a/go/state/externalstate/external_state_test.go
+++ b/go/state/externalstate/external_state_test.go
@@ -33,26 +33,25 @@ var (
 )
 
 func TestAccountsAreInitiallyUnknown(t *testing.T) {
-	runForEachExternalConfig(t, func(t *testing.T, state state.State, config state.Configuration) {
-		account_state, _ := state.Exists(address1)
-		if account_state != false {
-			t.Errorf("Initial account is not unknown, got %v", account_state)
-		}
+	runForEachExternalConfig(t, func(t *testing.T, s state.State, config state.Configuration) {
+		empty, err := state.IsEmptyAccount(s, address1)
+		require.NoError(t, err)
+		require.True(t, empty)
 	})
 }
 
 func TestAccountsCanBeDeleted(t *testing.T) {
-	runForEachExternalConfig(t, func(t *testing.T, state state.State, config state.Configuration) {
+	runForEachExternalConfig(t, func(t *testing.T, s state.State, config state.Configuration) {
 		if config.Schema == 6 {
 			t.Skip("Schema 6 does not support account existence checks")
 		}
 
-		state.Apply(0, common.Update{Balances: []common.BalanceUpdate{{Account: address1, Balance: balance1}}})
-		state.Apply(1, common.Update{DeletedAccounts: []common.Address{address1}})
-		account_state, _ := state.Exists(address1)
-		if account_state != false {
-			t.Errorf("Deleted account is not deleted, got %v", account_state)
-		}
+		require := require.New(t)
+		s.Apply(0, common.Update{Balances: []common.BalanceUpdate{{Account: address1, Balance: balance1}}})
+		s.Apply(1, common.Update{DeletedAccounts: []common.Address{address1}})
+		empty, err := state.IsEmptyAccount(s, address1)
+		require.NoError(err)
+		require.True(empty)
 	})
 }
 

--- a/go/state/externalstate/rust_connector.go
+++ b/go/state/externalstate/rust_connector.go
@@ -67,10 +67,6 @@ func (r rustBindings) GetArchiveBlockHeight(database unsafe.Pointer, outHeight *
 	return C.Carmen_Rust_GetArchiveBlockHeight(database, outHeight)
 }
 
-func (r rustBindings) AccountExists(state unsafe.Pointer, address unsafe.Pointer, outExists unsafe.Pointer) C.enum_Result {
-	return C.Carmen_Rust_AccountExists(state, address, outExists)
-}
-
 func (r rustBindings) GetBalance(state unsafe.Pointer, address unsafe.Pointer, outBalance unsafe.Pointer) C.enum_Result {
 	return C.Carmen_Rust_GetBalance(state, address, outBalance)
 }

--- a/go/state/gostate/archive_state_test.go
+++ b/go/state/gostate/archive_state_test.go
@@ -37,15 +37,6 @@ func TestState_ArchiveState_FailingOperation_InvalidatesArchive(t *testing.T) {
 		setup  func(archive *archive.MockArchive, injectedErr error)
 		action func(stateArchive state.State) error
 	}{
-		"exists": {
-			func(archive *archive.MockArchive, injectedErr error) {
-				archive.EXPECT().Exists(gomock.Any(), gomock.Any()).Return(false, injectedErr)
-			},
-			func(stateArchive state.State) error {
-				_, err := stateArchive.Exists(common.Address{})
-				return err
-			},
-		},
 		"balance": {
 			func(archive *archive.MockArchive, injectedErr error) {
 				archive.EXPECT().GetBalance(gomock.Any(), gomock.Any()).Return(amount.New(), injectedErr)

--- a/go/state/gostate/go_state.go
+++ b/go/state/gostate/go_state.go
@@ -110,18 +110,6 @@ type archiveUpdate = struct {
 	done        chan<- error    // a channel for the archive to signal when the update was processed
 }
 
-func (s *GoState) Exists(address common.Address) (bool, error) {
-	if err := s.getStateError(); err != nil {
-		return false, err
-	}
-
-	exist, err := s.live.Exists(address)
-	if err != nil {
-		s.addStateError(err)
-	}
-	return exist, s.getStateError()
-}
-
 func (s *GoState) GetBalance(address common.Address) (amount.Amount, error) {
 	if err := s.getStateError(); err != nil {
 		return amount.New(), err

--- a/go/state/gostate/go_state_test.go
+++ b/go/state/gostate/go_state_test.go
@@ -79,33 +79,33 @@ func initGoStates() []namedStateConfig {
 func TestMissingKeys(t *testing.T) {
 	for _, config := range initGoStates() {
 		t.Run(config.name(), func(t *testing.T) {
-			state, err := config.createState(t.TempDir())
+			s, err := config.createState(t.TempDir())
 			if err != nil {
 				t.Fatalf("failed to initialize state %s; %s", config.name(), err)
 			}
-			defer func() { require.NoError(t, state.Close()) }()
+			defer func() { require.NoError(t, s.Close()) }()
 
-			accountState, err := state.Exists(address1)
-			if err != nil || accountState != false {
+			accountState, err := state.IsEmptyAccount(s, address1)
+			if err != nil || accountState != true {
 				t.Errorf("Account must not exist in the initial state, but it exists. err: %s", err)
 			}
-			balance, err := state.GetBalance(address1)
+			balance, err := s.GetBalance(address1)
 			if err != nil || !balance.IsZero() {
 				t.Errorf("Balance must be empty. It is: %s, err: %s", balance, err)
 			}
-			nonce, err := state.GetNonce(address1)
+			nonce, err := s.GetNonce(address1)
 			if (err != nil || nonce != common.Nonce{}) {
 				t.Errorf("Nonce must be empty. It is: %s, err: %s", nonce, err)
 			}
-			value, err := state.GetStorage(address1, key1)
+			value, err := s.GetStorage(address1, key1)
 			if (err != nil || value != common.Value{}) {
 				t.Errorf("Value must be empty. It is: %s, err: %s", value, err)
 			}
-			code, err := state.GetCode(address1)
+			code, err := s.GetCode(address1)
 			if err != nil || len(code) != 0 {
 				t.Errorf("Value must be empty. It is: %s, err: %s", value, err)
 			}
-			size, err := state.GetCodeSize(address1)
+			size, err := s.GetCodeSize(address1)
 			if err != nil || size != 0 {
 				t.Errorf("Value must be 0. It is: %d, err: %s", value, err)
 			}
@@ -116,14 +116,14 @@ func TestMissingKeys(t *testing.T) {
 func TestBasicOperations(t *testing.T) {
 	for _, config := range initGoStates() {
 		t.Run(config.name(), func(t *testing.T) {
-			state, err := config.createState(t.TempDir())
+			s, err := config.createState(t.TempDir())
 			if err != nil {
 				t.Fatalf("failed to initialize state %s; %s", config.name(), err)
 			}
-			defer func() { require.NoError(t, state.Close()) }()
+			defer func() { require.NoError(t, s.Close()) }()
 
 			// fill-in values
-			_, err = state.Apply(12, common.Update{
+			_, err = s.Apply(12, common.Update{
 				Nonces:   []common.NonceUpdate{{Account: address1, Nonce: common.Nonce{123}}},
 				Balances: []common.BalanceUpdate{{Account: address2, Balance: amount.New(45)}},
 				Slots:    []common.SlotUpdate{{Account: address1, Key: key1, Value: common.Value{67}}},
@@ -134,22 +134,19 @@ func TestBasicOperations(t *testing.T) {
 			}
 
 			// fetch values
-			if val, err := state.Exists(address1); err != nil || val != true {
-				t.Errorf("Created account does not exists: Val: %t, Err: %v", val, err)
-			}
-			if val, err := state.GetNonce(address1); (err != nil || val != common.Nonce{123}) {
+			if val, err := s.GetNonce(address1); (err != nil || val != common.Nonce{123}) {
 				t.Errorf("Invalid value or error returned: Val: %v, Err: %v", val, err)
 			}
-			if val, err := state.GetBalance(address2); err != nil || val != amount.New(45) {
+			if val, err := s.GetBalance(address2); err != nil || val != amount.New(45) {
 				t.Errorf("Invalid value or error returned: Val: %v, Err: %v", val, err)
 			}
-			if val, err := state.GetStorage(address1, key1); (err != nil || val != common.Value{67}) {
+			if val, err := s.GetStorage(address1, key1); (err != nil || val != common.Value{67}) {
 				t.Errorf("Invalid value or error returned: Val: %v, Err: %v", val, err)
 			}
-			if val, err := state.GetCode(address1); err != nil || !bytes.Equal(val, []byte{0x12, 0x34}) {
+			if val, err := s.GetCode(address1); err != nil || !bytes.Equal(val, []byte{0x12, 0x34}) {
 				t.Errorf("Invalid value or error returned: Val: %v, Err: %v", val, err)
 			}
-			if val, err := state.GetCodeSize(address1); err != nil || val != 2 {
+			if val, err := s.GetCodeSize(address1); err != nil || val != 2 {
 				t.Errorf("Invalid code size or error returned: Val: %d, Err: %v", val, err)
 			}
 
@@ -161,16 +158,16 @@ func TestBasicOperations(t *testing.T) {
 			}
 
 			// delete account
-			_, err = state.Apply(14, common.Update{DeletedAccounts: []common.Address{address1}})
+			_, err = s.Apply(14, common.Update{DeletedAccounts: []common.Address{address1}})
 			if err != nil {
 				t.Errorf("Error: %s", err)
 			}
-			if val, err := state.Exists(address1); err != nil || val != false {
+			if val, err := state.IsEmptyAccount(s, address1); err != nil || val != true {
 				t.Errorf("Deleted account is not deleted: Val: %t, Err: %s", val, err)
 			}
 
 			// fetch wrong combinations
-			if val, err := state.GetStorage(address1, key1); (err != nil || val != common.Value{}) {
+			if val, err := s.GetStorage(address1, key1); (err != nil || val != common.Value{}) {
 				t.Errorf("Invalid value or error returned: Val: %v, Err: %v", val, err)
 			}
 		})
@@ -184,11 +181,11 @@ func TestDeletingAccounts(t *testing.T) {
 				t.Skipf("scheme %d not supported", config.config.Schema)
 			}
 
-			state, err := config.createState(t.TempDir())
+			s, err := config.createState(t.TempDir())
 			if err != nil {
 				t.Fatalf("failed to initialize state %s; %s", config.name(), err)
 			}
-			defer func() { require.NoError(t, state.Close()) }()
+			defer func() { require.NoError(t, s.Close()) }()
 
 			// fill-in values
 			update := common.Update{
@@ -196,12 +193,12 @@ func TestDeletingAccounts(t *testing.T) {
 				Balances: []common.BalanceUpdate{{Account: address2, Balance: amount.New(45)}},
 				Codes:    []common.CodeUpdate{{Account: address1, Code: []byte{0x12, 0x34}}},
 			}
-			if _, err := state.Apply(1, update); err != nil {
+			if _, err := s.Apply(1, update); err != nil {
 				t.Errorf("failed to update state: %v", err)
 			}
 
 			// fetch values
-			if val, err := state.Exists(address1); err != nil || val != true {
+			if val, err := state.IsEmptyAccount(s, address1); err != nil || val != false {
 				t.Errorf("Created account does not exists: Val: %t, Err: %v", val, err)
 			}
 
@@ -209,10 +206,10 @@ func TestDeletingAccounts(t *testing.T) {
 			update = common.Update{
 				DeletedAccounts: []common.Address{address1},
 			}
-			if _, err := state.Apply(2, update); err != nil {
+			if _, err := s.Apply(2, update); err != nil {
 				t.Errorf("failed to apply update: %v", err)
 			}
-			if val, err := state.Exists(address1); err != nil || val != false {
+			if val, err := state.IsEmptyAccount(s, address1); err != nil || val != true {
 				t.Errorf("Deleted account is not deleted: Val: %t, Err: %s", val, err)
 			}
 		})
@@ -407,8 +404,6 @@ func TestStateDB_AddBlock_Errors_Propagated_MultipleStateInstances(t *testing.T)
 	ctrl := gomock.NewController(t)
 	liveDB := state.NewMockLiveDB(ctrl)
 
-	liveDB.EXPECT().Exists(gomock.Any()).AnyTimes()
-
 	injectedErr := fmt.Errorf("injectedError")
 	// The First attempt to call Apply() will fail
 	// while next calls will not happen at all.
@@ -417,6 +412,9 @@ func TestStateDB_AddBlock_Errors_Propagated_MultipleStateInstances(t *testing.T)
 	// will not be executed because the
 	// state is already corrupted.
 	liveDB.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, injectedErr)
+	liveDB.EXPECT().GetBalance(gomock.Any()).Return(amount.New(0), nil).AnyTimes()
+	liveDB.EXPECT().GetNonce(gomock.Any()).Return(common.Nonce{}, nil).AnyTimes()
+	liveDB.EXPECT().GetCodeSize(gomock.Any()).Return(int(0), nil).AnyTimes()
 
 	db := newGoState(liveDB, nil, []func(){})
 
@@ -438,8 +436,10 @@ func TestStateDB_AddBlock_Errors_Propagated_From_Archive_MultipleStateInstances(
 	liveDB := state.NewMockLiveDB(ctrl)
 	archiveDB := archive.NewMockArchive(ctrl)
 
-	liveDB.EXPECT().Exists(gomock.Any()).AnyTimes()
 	liveDB.EXPECT().Apply(gomock.Any(), gomock.Any())
+	liveDB.EXPECT().GetBalance(gomock.Any()).Return(amount.New(0), nil).AnyTimes()
+	liveDB.EXPECT().GetNonce(gomock.Any()).Return(common.Nonce{}, nil).AnyTimes()
+	liveDB.EXPECT().GetCodeSize(gomock.Any()).Return(int(0), nil).AnyTimes()
 
 	archiveDB.EXPECT().Flush().AnyTimes()
 
@@ -478,12 +478,13 @@ func TestStateDB_AddBlock_CannotCallRepeatedly_OnError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	liveDB := state.NewMockLiveDB(ctrl)
 
-	liveDB.EXPECT().Exists(gomock.Any()).AnyTimes()
-
 	injectedErr := fmt.Errorf("injectedError")
 
 	// will be called only once as repeated calls will not get triggered.
 	liveDB.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, injectedErr)
+	liveDB.EXPECT().GetBalance(gomock.Any()).Return(amount.New(0), nil).AnyTimes()
+	liveDB.EXPECT().GetNonce(gomock.Any()).Return(common.Nonce{}, nil).AnyTimes()
+	liveDB.EXPECT().GetCodeSize(gomock.Any()).Return(int(0), nil).AnyTimes()
 
 	db := newGoState(liveDB, nil, []func(){})
 
@@ -500,7 +501,6 @@ func TestState_Flush_Or_Close_Corrupted_State_Detected(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	liveDB := state.NewMockLiveDB(ctrl)
 
-	liveDB.EXPECT().Exists(gomock.Any()).AnyTimes()
 	liveDB.EXPECT().Flush().AnyTimes()
 	liveDB.EXPECT().Close().AnyTimes()
 
@@ -562,8 +562,6 @@ func TestState_Flush_Or_Close_Corrupted_Archive_Detected(t *testing.T) {
 func TestState_Apply_CannotCallRepeatedly_OnError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	liveDB := state.NewMockLiveDB(ctrl)
-
-	liveDB.EXPECT().Exists(gomock.Any()).AnyTimes()
 
 	injectedErr := fmt.Errorf("injectedError")
 
@@ -751,7 +749,7 @@ func TestState_All_Live_Operations_May_Cause_Failure(t *testing.T) {
 	key := common.Key{0xB}
 	injectedErr := fmt.Errorf("injectedError")
 
-	const loops = 11
+	const loops = 10
 	for i := 0; i < loops; i++ {
 		i := i
 		t.Run(fmt.Sprintf("operation_%d", i), func(t *testing.T) {
@@ -761,17 +759,16 @@ func TestState_All_Live_Operations_May_Cause_Failure(t *testing.T) {
 
 			ctrl := gomock.NewController(t)
 			liveDB := state.NewMockLiveDB(ctrl)
-			liveDB.EXPECT().Exists(addr).Return(false, results[0]).AnyTimes()
-			liveDB.EXPECT().GetBalance(addr).Return(amount.New(), results[1]).AnyTimes()
-			liveDB.EXPECT().GetNonce(addr).Return(common.Nonce{}, results[2]).AnyTimes()
-			liveDB.EXPECT().GetStorage(addr, key).Return(common.Value{}, results[3]).AnyTimes()
-			liveDB.EXPECT().GetCode(addr).Return(make([]byte, 0), results[4]).AnyTimes()
-			liveDB.EXPECT().GetCodeSize(addr).Return(0, results[5]).AnyTimes()
-			liveDB.EXPECT().GetCodeHash(addr).Return(common.Hash{}, results[6]).AnyTimes()
-			liveDB.EXPECT().GetHash().Return(common.Hash{}, results[7]).AnyTimes()
-			liveDB.EXPECT().HasEmptyStorage(gomock.Any()).Return(false, results[8]).AnyTimes()
-			liveDB.EXPECT().Flush().Return(results[9]).AnyTimes()
-			liveDB.EXPECT().Close().Return(results[10]).AnyTimes()
+			liveDB.EXPECT().GetBalance(addr).Return(amount.New(), results[0]).AnyTimes()
+			liveDB.EXPECT().GetNonce(addr).Return(common.Nonce{}, results[1]).AnyTimes()
+			liveDB.EXPECT().GetStorage(addr, key).Return(common.Value{}, results[2]).AnyTimes()
+			liveDB.EXPECT().GetCode(addr).Return(make([]byte, 0), results[3]).AnyTimes()
+			liveDB.EXPECT().GetCodeSize(addr).Return(0, results[4]).AnyTimes()
+			liveDB.EXPECT().GetCodeHash(addr).Return(common.Hash{}, results[5]).AnyTimes()
+			liveDB.EXPECT().GetHash().Return(common.Hash{}, results[6]).AnyTimes()
+			liveDB.EXPECT().HasEmptyStorage(gomock.Any()).Return(false, results[7]).AnyTimes()
+			liveDB.EXPECT().Flush().Return(results[8]).AnyTimes()
+			liveDB.EXPECT().Close().Return(results[9]).AnyTimes()
 
 			db := newGoState(liveDB, nil, []func(){})
 			// calls must succeed until the first failure,
@@ -779,42 +776,38 @@ func TestState_All_Live_Operations_May_Cause_Failure(t *testing.T) {
 			var shouldFail bool
 			for i := 0; i < 2; i++ {
 				shouldFail = shouldFail || errors.Is(results[0], injectedErr)
-				if _, err := db.Exists(addr); shouldFail && !errors.Is(err, injectedErr) {
-					t.Errorf("operation should fail")
-				}
-				shouldFail = shouldFail || errors.Is(results[1], injectedErr)
 				if _, err := db.GetBalance(addr); shouldFail && !errors.Is(err, injectedErr) {
 					t.Errorf("operation should fail")
 				}
-				shouldFail = shouldFail || errors.Is(results[2], injectedErr)
+				shouldFail = shouldFail || errors.Is(results[1], injectedErr)
 				if _, err := db.GetNonce(addr); shouldFail && !errors.Is(err, injectedErr) {
 					t.Errorf("operation should fail")
 				}
-				shouldFail = shouldFail || errors.Is(results[3], injectedErr)
+				shouldFail = shouldFail || errors.Is(results[2], injectedErr)
 				if _, err := db.GetStorage(addr, key); shouldFail && !errors.Is(err, injectedErr) {
 					t.Errorf("operation should fail")
 				}
-				shouldFail = shouldFail || errors.Is(results[4], injectedErr)
+				shouldFail = shouldFail || errors.Is(results[3], injectedErr)
 				if _, err := db.GetCode(addr); shouldFail && !errors.Is(err, injectedErr) {
 					t.Errorf("operation should fail")
 				}
-				shouldFail = shouldFail || errors.Is(results[5], injectedErr)
+				shouldFail = shouldFail || errors.Is(results[4], injectedErr)
 				if _, err := db.GetCodeSize(addr); shouldFail && !errors.Is(err, injectedErr) {
 					t.Errorf("operation should fail")
 				}
-				shouldFail = shouldFail || errors.Is(results[6], injectedErr)
+				shouldFail = shouldFail || errors.Is(results[5], injectedErr)
 				if _, err := db.GetCodeHash(addr); shouldFail && !errors.Is(err, injectedErr) {
 					t.Errorf("operation should fail")
 				}
-				shouldFail = shouldFail || errors.Is(results[7], injectedErr)
+				shouldFail = shouldFail || errors.Is(results[6], injectedErr)
 				if _, err := db.GetCommitment().Await().Get(); shouldFail && !errors.Is(err, injectedErr) {
 					t.Errorf("operation should fail")
 				}
-				shouldFail = shouldFail || errors.Is(results[8], injectedErr)
+				shouldFail = shouldFail || errors.Is(results[7], injectedErr)
 				if _, err := db.HasEmptyStorage(addr); shouldFail && !errors.Is(err, injectedErr) {
 					t.Errorf("operation should fail")
 				}
-				shouldFail = shouldFail || errors.Is(results[9], injectedErr)
+				shouldFail = shouldFail || errors.Is(results[8], injectedErr)
 				if err := db.Flush(); shouldFail && !errors.Is(err, injectedErr) {
 					t.Errorf("operation should fail")
 				}

--- a/go/state/state.go
+++ b/go/state/state.go
@@ -29,9 +29,6 @@ const NoArchiveError = common.ConstError("state does not maintain archive data")
 
 // State interfaces provides access to accounts and smart contract values memory.
 type State interface {
-	// Exists obtains the current state of the provided account.
-	Exists(address common.Address) (bool, error)
-
 	// GetBalance provides balance for the input account address.
 	GetBalance(address common.Address) (amount.Amount, error)
 
@@ -107,7 +104,6 @@ type State interface {
 }
 
 type LiveDB interface {
-	Exists(address common.Address) (bool, error)
 	GetBalance(address common.Address) (balance amount.Amount, err error)
 	GetNonce(address common.Address) (nonce common.Nonce, err error)
 	GetStorage(address common.Address, key common.Key) (value common.Value, err error)

--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -740,10 +740,10 @@ func (s *stateDB) GetNonce(addr common.Address) uint64 {
 }
 
 func (s *stateDB) SetNonce(addr common.Address, nonce uint64) {
-	s.setNonceInternal(addr, nonce)
 	if s.createAccountIfNotExists(addr) && nonce == 0 {
 		s.emptyCandidates = append(s.emptyCandidates, addr)
 	}
+	s.setNonceInternal(addr, nonce)
 }
 
 func (s *stateDB) setNonceInternal(addr common.Address, nonce uint64) {

--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -503,11 +503,8 @@ func (s *stateDB) Exist(addr common.Address) bool {
 	if val, exists := s.accounts[addr]; exists {
 		return val.current == accountExists || val.current == accountSelfDestructed // self-destructed accounts still exist till the end of the transaction.
 	}
-	exists, err := s.state.Exists(addr)
-	if err != nil {
-		s.trackErrors(fmt.Errorf("failed to get account state for %v: %w", addr, err))
-		return false
-	}
+	exists := !s.Empty(addr)
+
 	state := accountNonExisting
 	if exists {
 		state = accountExists

--- a/go/state/state_db_and_state_test.go
+++ b/go/state/state_db_and_state_test.go
@@ -986,6 +986,57 @@ func TestStateDB_DeleteAccountCreatedInSameTransactionDoesNotChangeState(t *test
 	}
 }
 
+func TestStateDB_Exist_ReturnsTrueForNonEmptyAccount(t *testing.T) {
+	ops := map[string]func(s state.StateDB){
+		"Balance": func(s state.StateDB) {
+			s.AddBalance(address1, amount.New(10))
+		},
+		"Nonce": func(s state.StateDB) {
+			s.SetNonce(address1, 10)
+		},
+		"Code": func(s state.StateDB) {
+			s.SetCode(address1, []byte{0xAC})
+		},
+	}
+	for _, config := range initStates() {
+		for name, op := range ops {
+			t.Run(config.name()+"_"+name, func(t *testing.T) {
+				t.Parallel()
+				require := require.New(t)
+				dir := t.TempDir()
+				s, err := config.createState(dir)
+				require.NoError(err)
+				defer func() {
+					require.NoError(s.Close())
+				}()
+
+				db := state.CreateStateDBUsing(s)
+				db.BeginBlock()
+				db.BeginTransaction()
+				op(db)
+				db.EndTransaction()
+				db.EndBlock(0)
+
+				db.BeginBlock()
+				db.BeginTransaction()
+				require.True(db.Exist(address1))
+				db.EndTransaction()
+				db.EndBlock(1)
+			})
+		}
+	}
+}
+
+func TestStateDB_Exist_ReturnsFalseForEmptyAccount(t *testing.T) {
+	for _, config := range initStates() {
+		t.Run(config.name(), func(t *testing.T) {
+			executeOpOnCleanStateDB(t, config, func(sd state.StateDB) {
+				require.False(t, sd.Exist(address1))
+			})
+		})
+	}
+}
+
 func toVal(key uint64) common.Value {
 	keyBytes := make([]byte, 32)
 	binary.BigEndian.PutUint64(keyBytes, key)

--- a/go/state/state_db_and_state_test.go
+++ b/go/state/state_db_and_state_test.go
@@ -843,8 +843,7 @@ func TestStateDB_CallingExistsAfterAccountIsDeletedReturnsFalse(t *testing.T) {
 			statedb.EndTransaction()
 			statedb.EndBlock(1)
 
-			exists, err := s.Exists(address1)
-			require.NoError(err)
+			exists := statedb.Exist(address1)
 			require.False(exists)
 
 			// Case 2: deleted account because of suicide
@@ -855,8 +854,7 @@ func TestStateDB_CallingExistsAfterAccountIsDeletedReturnsFalse(t *testing.T) {
 			statedb.EndTransaction()
 			statedb.EndBlock(3)
 
-			exists, err = s.Exists(address1)
-			require.NoError(err)
+			exists = statedb.Exist(address1)
 			require.False(exists)
 		})
 	}

--- a/go/state/state_db_and_state_test.go
+++ b/go/state/state_db_and_state_test.go
@@ -966,9 +966,6 @@ func TestStateDB_AccountsAreCreatedImplicitlyWhenSettingState(t *testing.T) {
 
 func TestStateDB_DeleteAccountCreatedInSameTransactionDoesNotChangeState(t *testing.T) {
 	for _, config := range initStates() {
-		if config.config.Schema < 4 {
-			continue
-		}
 		t.Run(config.name(), func(t *testing.T) {
 			t.Parallel()
 			require := require.New(t)

--- a/go/state/state_db_inter_tx_snapshot_test.go
+++ b/go/state/state_db_inter_tx_snapshot_test.go
@@ -33,7 +33,9 @@ func TestStateDB_InterTxSnapshot_ReturnsSnapshotID(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 	db := NewMockState(ctrl)
-	db.EXPECT().Exists(gomock.Any()).Return(false, nil).AnyTimes()
+	db.EXPECT().GetBalance(gomock.Any()).Return(amount.New(), nil).AnyTimes()
+	db.EXPECT().GetNonce(gomock.Any()).Return(common.Nonce{}, nil).AnyTimes()
+	db.EXPECT().GetCodeSize(gomock.Any()).Return(0, nil).AnyTimes()
 	db.EXPECT().Check().Return(nil).AnyTimes()
 	state := createStateDBWith(db, 1, true)
 
@@ -50,7 +52,7 @@ func TestStateDB_InterTxSnapshot_ReturnsSnapshotID(t *testing.T) {
 	state.SetCode(common.Address{}, []byte{0x1})
 	state.EndTransaction()
 	snapshotID3 := state.InterTxSnapshot()
-	require.Equal(InterTxSnapshotID(3), snapshotID3)
+	require.Equal(InterTxSnapshotID(2), snapshotID3)
 }
 
 func TestStateDB_RevertToInterTxSnapshot_RecordsErrorIfInvalidSnapshotID(t *testing.T) {
@@ -58,7 +60,9 @@ func TestStateDB_RevertToInterTxSnapshot_RecordsErrorIfInvalidSnapshotID(t *test
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 	db := NewMockState(ctrl)
-	db.EXPECT().Exists(gomock.Any()).Return(false, nil).AnyTimes()
+	db.EXPECT().GetBalance(gomock.Any()).Return(amount.New(), nil).AnyTimes()
+	db.EXPECT().GetNonce(gomock.Any()).Return(common.Nonce{}, nil).AnyTimes()
+	db.EXPECT().GetCodeSize(gomock.Any()).Return(0, nil).AnyTimes()
 	db.EXPECT().Check().Return(nil).AnyTimes()
 	state := createStateDBWith(db, 1, true)
 
@@ -92,7 +96,6 @@ func TestStateDB_EndTransaction_AddsUndoForRestoreWhen(t *testing.T) {
 				db := NewMockState(ctrl)
 				db.EXPECT().Check().Return(nil).AnyTimes()
 				db.EXPECT().Check().Return(nil).AnyTimes()
-				db.EXPECT().Exists(gomock.Any()).Return(true, nil).AnyTimes()
 				db.EXPECT().GetBalance(gomock.Any()).Return(amount.New(0), nil).AnyTimes()
 				db.EXPECT().GetNonce(gomock.Any()).Return(common.Nonce{0}, nil).AnyTimes()
 				db.EXPECT().GetCode(gomock.Any()).Return(nil, nil).AnyTimes()
@@ -427,7 +430,6 @@ func NewStateDBContext(t *testing.T) *StateDBContext {
 	state := createStateDBWith(db, 1, true)
 
 	// Set expectation in case values are not cached, i.e. they are untouched.
-	db.EXPECT().Exists(any).Return(true, nil).AnyTimes()
 	db.EXPECT().GetBalance(any).Return(defaultBalance, nil).AnyTimes()
 	db.EXPECT().GetNonce(any).Return(defaultNonce, nil).AnyTimes()
 	db.EXPECT().GetCode(any).Return(defaultCode, nil).AnyTimes()

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -1612,7 +1612,6 @@ func TestStateDB_NoncesCanBeWrittenAndReadWithoutStateAccess(t *testing.T) {
 	mock := NewMockState(ctrl)
 	db := CreateStateDBUsing(mock)
 
-	// SetNonce creates the account if it does not exist
 	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 
 	var want uint64 = 12

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -4949,6 +4949,45 @@ func TestStateDB_EndBlock_ClearsUndoList(t *testing.T) {
 	require.Empty(t, stateDB.undo)
 }
 
+func TestStateDB_Exist_ReturnsTrueForNonEmptyAccount(t *testing.T) {
+	testCases := map[string]struct {
+		op func(db StateDB, address common.Address)
+	}{
+		"NonZeroBalance": {op: func(db StateDB, address common.Address) {
+			db.AddBalance(address, amount.New(1))
+		}},
+		"NonZeroNonce": {op: func(db StateDB, address common.Address) {
+			db.SetNonce(address, 1)
+		}},
+		"NonEmptyCode": {op: func(db StateDB, address common.Address) {
+			db.SetCode(address, []byte{1})
+		}},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mock := NewMockState(ctrl)
+			db := CreateStateDBUsing(mock)
+			setExpectationForEmptyAccount(t, mock, address1)
+
+			testCase.op(db, address1)
+
+			require.True(t, db.Exist(address1))
+		})
+	}
+}
+
+func TestStateDB_Exist_ReturnsFalseForEmptyAccount(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mock := NewMockState(ctrl)
+	db := CreateStateDBUsing(mock)
+
+	setExpectationForEmptyAccount(t, mock, address1)
+
+	require.False(t, db.Exist(address1))
+}
+
 func setExpectationForEmptyAccount(t *testing.T, mock *MockState, address common.Address) {
 	t.Helper()
 	mock.EXPECT().GetBalance(address).Return(amount.New(), nil)

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -99,7 +99,7 @@ func TestStateDB_AccountsCanBeCreatedAndDeleted(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// the account creation needs to check whether the account exists
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 	db.CreateAccount(address1)
 
 	if !db.Exist(address1) {
@@ -135,7 +135,7 @@ func TestStateDB_CreateAccountSetsNonceCodeAndBalanceToZero(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// Simulate a non-existing account.
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 
 	db.CreateAccount(address1)
 
@@ -162,7 +162,7 @@ func TestStateDB_CreateAccountSetsStorageToZero(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// Simulate a non-existing account.
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 
 	db.CreateAccount(address1)
 
@@ -177,12 +177,11 @@ func TestStateDB_RecreatingAnAccountSetsStorageToZero(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// Simulate a non-existing account.
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 	mock.EXPECT().Check().AnyTimes()
 	mock.EXPECT().Apply(uint64(1), common.Update{
-		Balances: []common.BalanceUpdate{{Account: address1}},
-		Nonces:   []common.NonceUpdate{{Account: address1}},
-		Codes:    []common.CodeUpdate{{Account: address1, Code: []byte{}}},
+		Nonces: []common.NonceUpdate{{Account: address1}},
+		Codes:  []common.CodeUpdate{{Account: address1, Code: []byte{}}},
 	})
 
 	db.CreateAccount(address1)
@@ -207,7 +206,7 @@ func TestStateDB_RecreatingAccountSetsNonceCodeAndBalanceToZero(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// Simulate a previously deleted account.
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 
 	db.CreateAccount(address1)
 
@@ -235,12 +234,11 @@ func TestStateDB_RecreatingAccountResetsStorage(t *testing.T) {
 	zero := common.Value{}
 
 	// Initially the account is non-existing, it gets recreated.
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 	mock.EXPECT().Check().AnyTimes()
 	mock.EXPECT().Apply(uint64(1), common.Update{
-		Balances: []common.BalanceUpdate{{Account: address1}},
-		Nonces:   []common.NonceUpdate{{Account: address1, Nonce: common.Nonce{0, 0, 0, 0, 0, 0, 0, 1}}},
-		Codes:    []common.CodeUpdate{{Account: address1, Code: []byte{}}},
+		Nonces: []common.NonceUpdate{{Account: address1, Nonce: common.Nonce{0, 0, 0, 0, 0, 0, 0, 1}}},
+		Codes:  []common.CodeUpdate{{Account: address1, Code: []byte{}}},
 	})
 
 	// First transaction creates an account and sets some storage values.
@@ -291,7 +289,7 @@ func TestStateDB_RecreatingAccountResetsStorageButRetainsNewState(t *testing.T) 
 	zero := common.Value{}
 
 	// Initially the account exists with some state.
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().Check().AnyTimes()
 	mock.EXPECT().GetStorage(address1, key1).Return(val1, nil)
 	mock.EXPECT().GetStorage(address1, key2).Return(val2, nil)
@@ -350,7 +348,7 @@ func TestStateDB_DestroyingRecreatedAccountIsNotResettingClearingState(t *testin
 	db := CreateStateDBUsing(mock)
 
 	// Initially the account exists with some state.
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 
 	db.Suicide(address1)
 	if db.(*stateDB).clearedAccounts[address1] != pendingClearing {
@@ -379,7 +377,7 @@ func TestStateDB_StorageOfDestroyedAccountIsStillAccessibleTillEndOfTransaction(
 	zero := common.Value{}
 
 	// Initially the account exists with some values inside.
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().GetStorage(address1, key1).Return(val1, nil)
 	mock.EXPECT().GetStorage(address1, key2).Return(val2, nil)
 
@@ -431,7 +429,7 @@ func TestStateDB_StoreDataCacheIsResetAfterSuicide(t *testing.T) {
 	zero := common.Value{}
 
 	// Initially the account exists and has a slot value set.
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().Check().AnyTimes()
 	mock.EXPECT().GetStorage(address1, key1).Return(val1, nil)
 
@@ -493,7 +491,7 @@ func TestStateDB_RollbackToKnownCommittedStateProducesCorrectResult(t *testing.T
 	mock := NewMockState(ctrl)
 	db := CreateStateDBUsing(mock)
 
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().GetStorage(address1, key1).Return(val2, nil)
 
 	s := db.Snapshot()
@@ -519,7 +517,7 @@ func TestStateDB_ClearedAndTaintedAccountsAreTrackedCorrectly(t *testing.T) {
 	mock := NewMockState(ctrl)
 	db := CreateStateDBUsing(mock)
 
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 
 	db.SetState(address1, key1, val1)
 
@@ -587,7 +585,6 @@ func TestStateDB_RollingBackSuicideRestoresBalance(t *testing.T) {
 	initialBalance := amount.New(5)
 
 	// Initially the account exists with a view stored values.
-	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().GetBalance(address1).Return(initialBalance, nil)
 
 	// In the transaction we delete and restore the account.
@@ -621,7 +618,7 @@ func TestStateDB_RollingBackSuicideRestoresValues(t *testing.T) {
 
 	// Initially the account exists with a view stored values.
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().GetStorage(address1, key1).Return(val1, nil)
 	mock.EXPECT().GetStorage(address1, key2).Return(val2, nil)
 	mock.EXPECT().Apply(uint64(1), common.Update{})
@@ -661,7 +658,7 @@ func TestStateDB_DestroyingAndRecreatingAnAccountInTheSameTransactionCallsDelete
 	db := CreateStateDBUsing(mock)
 
 	// Initially the account exists with a view stored values.
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().Check().AnyTimes()
 
 	// The account is to be re-created.
@@ -694,7 +691,7 @@ func TestStateDB_DoubleDestroyedAccountThatIsOnceRolledBackIsStillCleared(t *tes
 	db := CreateStateDBUsing(mock)
 
 	// Initially the account exists with a view stored values.
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().Check().AnyTimes()
 
 	// The account is to be re-created.
@@ -733,7 +730,6 @@ func TestStateDB_RecreatingExistingAccountSetsNonceAndCodeToZeroAndPreservesBala
 	// Simulate a previously deleted account.
 	b12 := amount.New(12)
 
-	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().GetBalance(address1).Return(b12, nil)
 	db.SetNonce(address1, 14)
 	db.SetCode(address1, []byte{1, 2, 3})
@@ -763,7 +759,7 @@ func TestStateDB_CreateAccountCanBeRolledBack(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// this test will cause one call to the DB to check for the existence of the account
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 
 	snapshot := db.Snapshot()
 
@@ -788,7 +784,7 @@ func TestStateDB_RollingBackAccountCreationRestoresStoredData(t *testing.T) {
 	// a rollback of the account creation.
 	value0 := common.Value{0}
 	value1 := common.Value{1}
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().GetStorage(address1, key1).Return(value1, nil)
 
 	snapshot := db.Snapshot()
@@ -819,7 +815,7 @@ func TestStateDB_SuicideIndicatesExistingAccountAsBeingDeleted(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// Simulate an existing account.
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 
 	// An existing account is indicated as being deleted.
 	if exists := db.Suicide(address1); !exists {
@@ -847,7 +843,7 @@ func TestStateDB_SetCodeShouldNotStopSuicide(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// Simulate an existing account.
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().GetNonce(address1).Return(common.Nonce{1}, nil)
 
 	// An existing account is indicated as being deleted.
@@ -874,7 +870,7 @@ func TestStateDB_RepeatedSuicide(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// Simulate an existing account.
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().Check().AnyTimes()
 
 	// An existing account is indicated as being deleted.
@@ -923,7 +919,7 @@ func TestStateDB_SuicideIndicatesUnknownAccountAsNotBeingDeleted(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// Simulate an unknown account.
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 
 	// An unknown account is indicated as not being deleted.
 	if exists := db.Suicide(address1); exists {
@@ -942,7 +938,7 @@ func TestStateDB_SuicideIndicatesDeletedAccountAsNotBeingDeleted(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// Simulate a deleted account.
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 
 	// An already deleted account is indicated as not being deleted during the suicide.
 	if exists := db.Suicide(address1); exists {
@@ -963,7 +959,6 @@ func TestStateDB_SuicideRemovesBalanceFromAccount(t *testing.T) {
 	// Simulate an existing account.
 	b12 := amount.New(12)
 
-	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().GetBalance(address1).Return(b12, nil)
 
 	if got, want := db.GetBalance(address1), amount.New(12); got != want {
@@ -984,7 +979,6 @@ func TestStateDB_SuicideCanBeRolledBack(t *testing.T) {
 
 	// this test will cause one call to the DB to check for the existence of the account
 	b12 := amount.New(12)
-	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().GetBalance(address1).Return(b12, nil)
 
 	if !db.Exist(address1) {
@@ -1022,7 +1016,7 @@ func TestStateDB_SuicideIsExecutedAtEndOfTransaction(t *testing.T) {
 
 	// the nonce and code will be set at the end of the block since suicide is canceled.
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().Apply(uint64(1), common.Update{
 		DeletedAccounts: []common.Address{address1},
 		Balances:        []common.BalanceUpdate{{Account: address1}},
@@ -1046,7 +1040,7 @@ func TestStateDB_SuicideCanBeCanceledThroughRollback(t *testing.T) {
 
 	// the nonce and code will be set at the end of the block since suicide is canceled.
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().Apply(uint64(1), common.Update{
 		Nonces: []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(5)}},
 		Codes:  []common.CodeUpdate{{Account: address1, Code: []byte{1, 2, 3}}},
@@ -1070,11 +1064,10 @@ func TestStateDB_CreatedAccountsAreStoredAtEndOfBlock(t *testing.T) {
 
 	// The new account is created at the end of the transaction.
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 	mock.EXPECT().Apply(uint64(1), common.Update{
-		Balances: []common.BalanceUpdate{{Account: address1}},
-		Nonces:   []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(1)}},
-		Codes:    []common.CodeUpdate{{Account: address1, Code: []byte{}}},
+		Nonces: []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(1)}},
+		Codes:  []common.CodeUpdate{{Account: address1, Code: []byte{}}},
 	})
 
 	db.CreateAccount(address1)
@@ -1090,11 +1083,10 @@ func TestStateDB_CreatedAccountsAreForgottenAtEndOfBlock(t *testing.T) {
 
 	// The created account is only created once, and nonces and code are initialized.
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 	mock.EXPECT().Apply(uint64(1), common.Update{
-		Balances: []common.BalanceUpdate{{Account: address1}},
-		Nonces:   []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(1)}},
-		Codes:    []common.CodeUpdate{{Account: address1, Code: []byte{}}},
+		Nonces: []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(1)}},
+		Codes:  []common.CodeUpdate{{Account: address1, Code: []byte{}}},
 	})
 	mock.EXPECT().Apply(uint64(2), common.Update{})
 
@@ -1112,7 +1104,7 @@ func TestStateDB_CreatedAccountsAreDiscardedOnEndOfAbortedTransaction(t *testing
 
 	// Needs to check whether the account already existed before the creation.
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 	mock.EXPECT().Apply(uint64(1), common.Update{})
 	mock.EXPECT().Apply(uint64(2), common.Update{})
 
@@ -1129,7 +1121,7 @@ func TestStateDB_DeletedAccountsAreStoredAtEndOfBlock(t *testing.T) {
 
 	// The new account is deleted at the end of the transaction.
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().Apply(uint64(1), common.Update{
 		DeletedAccounts: []common.Address{address1},
 		Balances:        []common.BalanceUpdate{{Account: address1}},
@@ -1149,7 +1141,7 @@ func TestStateDB_DeletedAccountsRetainCodeUntilEndOfTransaction(t *testing.T) {
 
 	// The new account is deleted at the end of the transaction.
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 	mock.EXPECT().Apply(uint64(1), common.Update{})
 
 	code := []byte{1, 2, 3}
@@ -1185,7 +1177,7 @@ func TestStateDB_DeletedAccountsAreIgnoredAtAbortedTransaction(t *testing.T) {
 
 	// Simulate a non-existing account.
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 	mock.EXPECT().Apply(uint64(1), common.Update{})
 
 	db.Suicide(address1)
@@ -1200,7 +1192,7 @@ func TestStateDB_CreatedAndDeletedAccountsAreDeletedAtEndOfTransaction(t *testin
 
 	// The new account is deleted at the end of the transaction.
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 	mock.EXPECT().Apply(uint64(1), common.Update{})
 
 	db.CreateAccount(address1)
@@ -1216,7 +1208,7 @@ func TestStateDB_CreatedAndDeletedAccountsAreIgnoredAtAbortedTransaction(t *test
 
 	// Simulate a non-existing account.
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 	mock.EXPECT().Apply(uint64(1), common.Update{})
 
 	db.CreateAccount(address1)
@@ -1246,7 +1238,6 @@ func TestStateDB_SettingTheBalanceMakesAccountNonEmpty(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// An empty account must have its balance and nonce set to zero.
-	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().GetBalance(address1).Return(amount.New(), nil)
 	mock.EXPECT().GetNonce(address1).Return(common.Nonce{}, nil)
 	mock.EXPECT().GetCodeSize(address1).Return(0, nil)
@@ -1269,7 +1260,7 @@ func TestStateDB_SettingTheBalanceCreatesAccount(t *testing.T) {
 
 	// The account have not existed - must be created by AddBalance call.
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 	mock.EXPECT().Apply(uint64(1), common.Update{
 		Balances: []common.BalanceUpdate{{Account: address1, Balance: addedBalance}},
 	})
@@ -1289,9 +1280,7 @@ func TestStateDB_AddingZeroBalanceCreatesAccountThatIsImplicitlyDeleted(t *testi
 
 	// Initially, the account does not exist, and it is not created, since it remains empty.
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(false, nil)
-	mock.EXPECT().GetNonce(address1).Return(common.Nonce{}, nil)
-	mock.EXPECT().GetCodeSize(address1).Return(0, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 	mock.EXPECT().Apply(uint64(1), common.Update{})
 
 	db.AddBalance(address1, amount.New())
@@ -1309,9 +1298,7 @@ func TestStateDB_SubtractingZeroBalanceCreatesAccountThatIsImplicitlyDeleted(t *
 
 	// Initially, the account does not exist, and it is not created, since it remains empty.
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(false, nil)
-	mock.EXPECT().GetNonce(address1).Return(common.Nonce{}, nil)
-	mock.EXPECT().GetCodeSize(address1).Return(0, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 	mock.EXPECT().Apply(uint64(1), common.Update{})
 
 	db.SubBalance(address1, amount.New())
@@ -1328,7 +1315,7 @@ func TestStateDB_ProducingANegativeBalanceCausesTheBlockToFail(t *testing.T) {
 	mock := NewMockState(ctrl)
 	db := CreateStateDBUsing(mock)
 
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 	mock.EXPECT().Check().AnyTimes()
 
 	db.SubBalance(address1, amount.New(1))
@@ -1345,7 +1332,7 @@ func TestStateDB_IncreasingTheBalanceBeyondItsMaximumValueCausesTheBlockToFail(t
 	mock := NewMockState(ctrl)
 	db := CreateStateDBUsing(mock)
 
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 	mock.EXPECT().Check().AnyTimes()
 
 	db.AddBalance(address1, amount.New(1))
@@ -1365,11 +1352,10 @@ func TestStateDB_SettingTheNonceMakesAccountNonEmpty(t *testing.T) {
 
 	// An empty account must have its nonce and code set to zero.
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 	mock.EXPECT().Apply(uint64(1), common.Update{
-		Balances: []common.BalanceUpdate{{Account: address1}},
-		Nonces:   []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(1)}},
-		Codes:    []common.CodeUpdate{{Account: address1, Code: []byte{}}},
+		Nonces: []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(1)}},
+		Codes:  []common.CodeUpdate{{Account: address1, Code: []byte{}}},
 	})
 
 	db.CreateAccount(address1)
@@ -1391,7 +1377,6 @@ func TestStateDB_SettingTheNonceToZeroMakesAccountEmpty(t *testing.T) {
 
 	// An empty account must have its nonce and code set to zero.
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).AnyTimes().Return(false, nil)
 	mock.EXPECT().GetBalance(address1).Return(amount.New(), nil)
 	mock.EXPECT().GetNonce(address1).Return(common.Nonce{0}, nil)
 	mock.EXPECT().GetCodeSize(address1).Return(0, nil)
@@ -1415,10 +1400,9 @@ func TestStateDB_CreatesAccountOnNonceSetting(t *testing.T) {
 
 	// The account does not exist, is expected to be created automatically.
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 	mock.EXPECT().Apply(uint64(1), common.Update{
-		Balances: []common.BalanceUpdate{{Account: address1}},
-		Nonces:   []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(1)}},
+		Nonces: []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(1)}},
 	})
 
 	db.SetNonce(address1, 1)
@@ -1466,7 +1450,6 @@ func TestStateDB_BalancesCanBeSnapshottedAndReverted(t *testing.T) {
 
 	// Balance is initially 10. This should only be fetched once.
 	want := amount.New(10)
-	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().GetBalance(address1).Return(want, nil)
 
 	snapshot0 := db.Snapshot()
@@ -1519,7 +1502,6 @@ func TestStateDB_BalanceIsWrittenToStateIfChangedAtEndOfBlock(t *testing.T) {
 	// The balance is expected to be read and the updated value to be written to the state.
 	balance := amount.New(10)
 	mock.EXPECT().GetBalance(address1).Return(balance, nil)
-	mock.EXPECT().Exists(address1).Return(true, nil)
 	balance = amount.New(12)
 	mock.EXPECT().Apply(uint64(1), common.Update{
 		Balances: []common.BalanceUpdate{{Account: address1, Balance: balance}},
@@ -1550,7 +1532,6 @@ func TestStateDB_BalanceOnlyFinalValueIsWrittenAtEndOfBlock(t *testing.T) {
 	mock.EXPECT().Apply(uint64(1), common.Update{
 		Balances: []common.BalanceUpdate{{Account: address1, Balance: balance}},
 	})
-	mock.EXPECT().Exists(address1).Return(true, nil)
 
 	db.AddBalance(address1, amount.New(5))
 	db.SubBalance(address1, amount.New(3))
@@ -1570,7 +1551,6 @@ func TestStateDB_BalanceUnchangedValuesAreNotWritten(t *testing.T) {
 	// Balance is only read, never written.
 	balance := amount.New(10)
 	mock.EXPECT().GetBalance(address1).Return(balance, nil)
-	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().Apply(uint64(2), common.Update{})
 
 	db.AddBalance(address1, amount.New(10))
@@ -1590,7 +1570,6 @@ func TestStateDB_BalanceIsNotWrittenToStateIfTransactionIsAborted(t *testing.T) 
 	// Balance is only read, never written.
 	balance := amount.New(10)
 	mock.EXPECT().GetBalance(address1).Return(balance, nil)
-	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().Apply(uint64(1), common.Update{})
 
 	db.AddBalance(address1, amount.New(10))
@@ -1634,7 +1613,7 @@ func TestStateDB_NoncesCanBeWrittenAndReadWithoutStateAccess(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// SetNonce creates the account if it does not exist
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 
 	var want uint64 = 12
 	db.SetNonce(address1, want)
@@ -1669,15 +1648,14 @@ func TestStateDB_NonceOfADeletedAccountIsZero(t *testing.T) {
 
 	// The side-effects of the creation of the account in the first transactions are expected.
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil).Times(1)
 	mock.EXPECT().Apply(uint64(1), common.Update{
-		Balances: []common.BalanceUpdate{{Account: address1}},
-		Nonces:   []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(12)}},
-		Codes:    []common.CodeUpdate{{Account: address1, Code: []byte{}}},
+		Nonces: []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(12)}},
+		Codes:  []common.CodeUpdate{{Account: address1, Code: []byte{}}},
 	})
 
 	// Also the fetch of the Nonce value in the second transaction is expected.
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().GetNonce(address1).Return(common.ToNonce(12), nil)
 
 	// Create an account and set the nonce.
@@ -1715,7 +1693,7 @@ func TestStateDB_NonceOfADeletedAccountGetsResetAtEndOfTransaction(t *testing.T)
 	db := CreateStateDBUsing(mock)
 
 	// Simulate an existing account.
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().GetNonce(address1).Return(common.Nonce{}, nil)
 
 	var want uint64 = 0
@@ -1753,7 +1731,7 @@ func TestStateDB_NoncesCanBeSnapshottedAndReverted(t *testing.T) {
 
 	// Nonce is initially 10. This should only be fetched once.
 	mock.EXPECT().GetNonce(address1).Return(common.ToNonce(10), nil)
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 
 	snapshot0 := db.Snapshot()
 
@@ -1802,7 +1780,7 @@ func TestStateDB_NoncesOnlySetCanBeReverted(t *testing.T) {
 
 	// Nonce is initially 10. This should only be fetched once.
 	mock.EXPECT().GetNonce(address1).Return(common.ToNonce(10), nil)
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 
 	snapshot0 := db.Snapshot()
 
@@ -1832,7 +1810,7 @@ func TestStateDB_NoncesIsWrittenToStateIfChangedAtEndOfBlock(t *testing.T) {
 	})
 	mock.EXPECT().Apply(uint64(2), common.Update{})
 	// SetNonce create the account if it does not exist
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 
 	db.SetNonce(address1, 10)
 	db.EndTransaction()
@@ -1855,7 +1833,7 @@ func TestStateDB_NoncesOnlyFinalValueIsWrittenAtEndOfBlock(t *testing.T) {
 		Nonces: []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(12)}},
 	})
 	// SetNonce create the account if it does not exist
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 
 	db.SetNonce(address1, 10)
 	db.SetNonce(address1, 11)
@@ -1876,7 +1854,7 @@ func TestStateDB_NoncesUnchangedValuesAreNotWritten(t *testing.T) {
 	mock.EXPECT().Apply(uint64(1), common.Update{})
 	mock.EXPECT().GetNonce(address1).Return(common.ToNonce(10), nil)
 	// SetNonce create the account if it does not exist
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 
 	value := db.GetNonce(address1)
 	db.SetNonce(address1, value)
@@ -1891,7 +1869,7 @@ func TestStateDB_NoncesIsNotWrittenToStateIfTransactionIsAborted(t *testing.T) {
 
 	// SetNonce create the account if it does not exist
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().Apply(uint64(1), common.Update{})
 
 	db.SetNonce(address1, 10)
@@ -1942,7 +1920,7 @@ func TestStateDB_CommittedValuesCanBeFetchedAfterValueBeingWritten(t *testing.T)
 	mock := NewMockState(ctrl)
 	db := CreateStateDBUsing(mock)
 
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().GetStorage(address1, key1).Return(val1, nil)
 
 	db.SetState(address1, key1, val2)
@@ -1959,7 +1937,7 @@ func TestStateDB_SettingValuesCreatesAccountsImplicitly(t *testing.T) {
 	mock := NewMockState(ctrl)
 	db := CreateStateDBUsing(mock)
 
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 
 	db.SetState(address1, key1, val1)
 	if !db.Exist(address1) {
@@ -1974,9 +1952,7 @@ func TestStateDB_ImplicitAccountCreatedBySetStateIsDroppedSinceEmptyIfNothingEls
 
 	// The account is not created at the end of the transaction, nor is the value set.
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(false, nil)
-	mock.EXPECT().GetNonce(address1).Return(common.Nonce{}, nil)
-	mock.EXPECT().GetCodeSize(address1).Return(0, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 	mock.EXPECT().Apply(uint64(1), common.Update{})
 
 	db.SetState(address1, key1, val1)
@@ -1992,9 +1968,7 @@ func TestStateDB_EmptyAccountsDeletedAtEndOfTransactionsAreCleaned(t *testing.T)
 	mock := NewMockState(ctrl)
 	db := CreateStateDBUsing(mock)
 
-	mock.EXPECT().Exists(address1).Return(false, nil)
-	mock.EXPECT().GetNonce(address1).Return(common.Nonce{}, nil)
-	mock.EXPECT().GetCodeSize(address1).Return(0, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 
 	db.BeginTransaction()
 	db.SetState(address1, key1, val1)
@@ -2041,7 +2015,7 @@ func TestStateDB_WrittenValuesCanBeRead(t *testing.T) {
 	mock := NewMockState(ctrl)
 	db := CreateStateDBUsing(mock)
 
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 
 	db.SetState(address1, key1, val1)
 	if got := db.GetState(address1, key1); got != val1 {
@@ -2054,7 +2028,7 @@ func TestStateDB_WrittenValuesCanBeUpdated(t *testing.T) {
 	mock := NewMockState(ctrl)
 	db := CreateStateDBUsing(mock)
 
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 
 	db.SetState(address1, key1, val1)
 	if got := db.GetState(address1, key1); got != val1 {
@@ -2072,7 +2046,7 @@ func TestStateDB_WrittenValuesCanBeRolledBack(t *testing.T) {
 	mock := NewMockState(ctrl)
 	db := CreateStateDBUsing(mock)
 
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().GetStorage(address1, key1).Return(val0, nil)
 
 	snapshot0 := db.Snapshot()
@@ -2119,7 +2093,7 @@ func TestStateDB_UpdatedValuesAreCommittedToStateAtEndBlock(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().Apply(uint64(1), sameEffectAs{common.Update{
 		Slots: []common.SlotUpdate{
 			{Account: address1, Key: key1, Value: val1},
@@ -2139,7 +2113,7 @@ func TestStateDB_RevertedValuesAreNotCommitted(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().Apply(uint64(1), common.Update{
 		Slots: []common.SlotUpdate{{Account: address1, Key: key1, Value: val1}},
 	})
@@ -2159,7 +2133,7 @@ func TestStateDB_NothingIsCommittedOnTransactionAbort(t *testing.T) {
 
 	// Should test whether the account exists, nothing else.
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().Apply(uint64(1), common.Update{})
 
 	db.SetState(address1, key1, val1)
@@ -2174,7 +2148,7 @@ func TestStateDB_OnlyFinalValueIsStored(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().Apply(uint64(1), common.Update{
 		Slots: []common.SlotUpdate{{Account: address1, Key: key1, Value: val3}},
 	})
@@ -2194,7 +2168,7 @@ func TestStateDB_UndoneValueUpdateIsNotStored(t *testing.T) {
 
 	// Only expect a read but no update.
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().GetStorage(address1, key1).Return(val1, nil)
 	mock.EXPECT().Apply(uint64(1), common.Update{})
 
@@ -2212,7 +2186,7 @@ func TestStateDB_ValueIsCommittedAtEndOfTransaction(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// Only expect a read but no update.
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().GetStorage(address1, key1).Return(val1, nil)
 
 	if got := db.GetState(address1, key1); got != val1 {
@@ -2249,7 +2223,7 @@ func TestStateDB_CanBeUsedForMultipleBlocks(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Times(3).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Times(3).Return(balance1, nil)
 	mock.EXPECT().Apply(uint64(1), common.Update{
 		Slots: []common.SlotUpdate{{Account: address1, Key: key1, Value: val1}},
 	})
@@ -2289,7 +2263,7 @@ func TestStateDB_CodesCanBeSet(t *testing.T) {
 	mock := NewMockState(ctrl)
 	db := CreateStateDBUsing(mock)
 
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 
 	want := []byte{0xAC, 0xDC}
 	db.SetCode(address1, want)
@@ -2304,7 +2278,7 @@ func TestStateDB_CodeUpdatesCoveredByRollbacks(t *testing.T) {
 	mock := NewMockState(ctrl)
 	db := CreateStateDBUsing(mock)
 
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 
 	want1 := []byte{0xAC, 0xDC}
 	want2 := []byte{0xFE, 0xEF}
@@ -2353,7 +2327,7 @@ func TestStateDB_UpdatedCodesAreStored(t *testing.T) {
 	mock.EXPECT().Check().AnyTimes()
 
 	// SetCode creates the account if it does not exist
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 
 	want := []byte{0xAC, 0xDC}
 	mock.EXPECT().Apply(uint64(1), common.Update{
@@ -2373,7 +2347,7 @@ func TestStateDB_UpdatedCodesAreStoredOnlyOnce(t *testing.T) {
 	mock.EXPECT().Check().AnyTimes()
 
 	// SetCode creates the account if it does not exist
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 
 	want := []byte{0xAC, 0xDC}
 	mock.EXPECT().Apply(uint64(1), common.Update{
@@ -2393,7 +2367,7 @@ func TestStateDB_CodeCanBeUpdated_In_Each_Block(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mock := NewMockState(ctrl)
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(true, nil).AnyTimes()
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil).AnyTimes()
 	db := CreateStateDBUsing(mock)
 
 	codes := [][]byte{{0xAA, 0xAA}, {0xBB, 0xBB, 0xBB}, {0xCC, 0xCC, 0xCC, 0xCC}}
@@ -2431,7 +2405,7 @@ func TestStateDB_CodeCanBeUpdated_In_One_Block(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mock := NewMockState(ctrl)
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(true, nil).AnyTimes()
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil).AnyTimes()
 	db := CreateStateDBUsing(mock)
 
 	codes := [][]byte{{0xAA, 0xAA}, {0xBB, 0xBB, 0xBB}, {0xCC, 0xCC, 0xCC, 0xCC}}
@@ -2465,7 +2439,7 @@ func TestStateDB_CodeCanBeUpdated_In_One_Transaction(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mock := NewMockState(ctrl)
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(true, nil).AnyTimes()
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil).AnyTimes()
 	db := CreateStateDBUsing(mock)
 
 	codes := [][]byte{{0xAA, 0xAA}, {0xBB, 0xBB, 0xBB}, {0xCC, 0xCC, 0xCC, 0xCC}}
@@ -2502,11 +2476,10 @@ func TestStateDB_SettingCodesCreatesAccountsImplicitly(t *testing.T) {
 	mock.EXPECT().Check().AnyTimes()
 
 	// SetCode creates the account if it does not exist
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 	want := []byte{0xAC, 0xDC}
 	mock.EXPECT().Apply(uint64(1), common.Update{
-		Balances: []common.BalanceUpdate{{Account: address1}},
-		Codes:    []common.CodeUpdate{{Account: address1, Code: want}},
+		Codes: []common.CodeUpdate{{Account: address1, Code: want}},
 	})
 
 	db.SetCode(address1, want)
@@ -2533,7 +2506,7 @@ func TestStateDB_CodeSizeCanBeReadAfterModification(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// SetCode creates the account if it does not exist
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 
 	want := []byte{0xAC, 0xDC}
 	db.SetCode(address1, want)
@@ -2562,7 +2535,7 @@ func TestStateDB_CodeSizeOfADeletedAccountIsZeroAfterEndOfTransaction(t *testing
 	db := CreateStateDBUsing(mock)
 
 	// Simulate an existing account.
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 
 	db.SetCode(address1, []byte{1, 2, 3})
 	db.Suicide(address1)
@@ -2588,7 +2561,7 @@ func TestStateDB_CodeHashOfNonExistingAccountIsZero(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// The state DB is asked for the accounts existence, but not for the hash.
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 
 	want := common.Hash{}
 	if got := db.GetCodeHash(address1); got != want {
@@ -2602,7 +2575,7 @@ func TestStateDB_CodeHashOfAnExistingAccountIsTheHashOfTheEmptyCode(t *testing.T
 	db := CreateStateDBUsing(mock)
 
 	// Simulate an existing account with empty code.
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	mock.EXPECT().GetCodeHash(address1).Return(common.GetKeccak256Hash([]byte{}), nil)
 
 	want := common.GetKeccak256Hash([]byte{})
@@ -2617,7 +2590,7 @@ func TestStateDB_CodeHashOfNewlyCreatedAccountIsTheHashOfTheEmptyCode(t *testing
 	db := CreateStateDBUsing(mock)
 
 	// At the start the account does not exist.
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 
 	db.CreateAccount(address1)
 	want := common.GetKeccak256Hash([]byte{})
@@ -2633,7 +2606,7 @@ func TestStateDB_CodeHashCanBeRead(t *testing.T) {
 
 	want := common.Hash{0xAC, 0xDC}
 	mock.EXPECT().GetCodeHash(address1).Return(want, nil)
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 
 	if got := db.GetCodeHash(address1); got != want {
 		t.Errorf("error retrieving code hash, wanted %v, got %v", want, got)
@@ -2646,7 +2619,7 @@ func TestStateDB_SetCodeSizeCanBeRolledBack(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	// SetCode creates the account if it does not exist
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 
 	want := []byte{0xAB, 0xCD}
 	db.SetCode(address1, want)
@@ -2668,7 +2641,7 @@ func TestStateDB_CodeHashCanBeReadAfterModification(t *testing.T) {
 	mock := NewMockState(ctrl)
 	db := CreateStateDBUsing(mock)
 
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 
 	code := []byte{0xAC, 0xDC}
 	db.SetCode(address1, code)
@@ -3101,7 +3074,6 @@ func TestStateDB_DeletesEmptyAccountsEip161(t *testing.T) {
 	mock.EXPECT().Check().AnyTimes()
 
 	// Initially the account exists, its balance is non-zero
-	mock.EXPECT().Exists(address1).Return(true, nil)
 	mock.EXPECT().GetBalance(address1).Return(b12, nil)
 	mock.EXPECT().GetNonce(address1).Return(common.Nonce{}, nil)
 	mock.EXPECT().GetCodeSize(address1).Return(0, nil)
@@ -3132,12 +3104,9 @@ func TestStateDB_NeverCreatesEmptyAccountsEip161(t *testing.T) {
 	db := CreateStateDBUsing(mock)
 
 	mock.EXPECT().Check().AnyTimes()
-	mock.EXPECT().Exists(address1).Return(false, nil)
-	mock.EXPECT().Exists(address2).Return(false, nil)
-	mock.EXPECT().Exists(address3).Return(false, nil)
-	mock.EXPECT().GetNonce(address2).Return(common.Nonce{}, nil)
-	mock.EXPECT().GetNonce(address3).Return(common.Nonce{}, nil)
-	mock.EXPECT().GetCodeSize(address2).Return(0, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
+	setExpectationForEmptyAccount(t, mock, address2)
+	setExpectationForEmptyAccount(t, mock, address3)
 	mock.EXPECT().Apply(uint64(1), common.Update{})
 
 	db.BeginBlock()
@@ -3163,7 +3132,7 @@ func TestStateDB_SuicidedAccountNotRecreatedBySettingBalance(t *testing.T) {
 	mock.EXPECT().Check().AnyTimes()
 
 	// Simulate a existing account.
-	mock.EXPECT().Exists(address1).Return(true, nil)
+	mock.EXPECT().GetBalance(address1).Return(balance1, nil)
 	// The account will be deleted.
 	mock.EXPECT().Apply(uint64(1), common.Update{
 		DeletedAccounts: []common.Address{address1},
@@ -3243,11 +3212,12 @@ func TestStateDB_ResetClearsInternalState(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	state := NewMockState(ctrl)
 	gomock.InOrder(
-		state.EXPECT().Exists(gomock.Any()),
-		state.EXPECT().Exists(gomock.Any()).Return(true, nil),
-		state.EXPECT().Exists(gomock.Any()).Return(false, injectedErr),
-		state.EXPECT().Exists(gomock.Any()),
+		state.EXPECT().GetBalance(gomock.Any()).Return(amount.New(), nil),
+		state.EXPECT().GetBalance(gomock.Any()).Return(balance1, nil),
+		state.EXPECT().GetBalance(gomock.Any()).Return(amount.New(), injectedErr),
 	)
+	state.EXPECT().GetNonce(gomock.Any()).Return(common.Nonce{}, nil).AnyTimes()
+	state.EXPECT().GetCodeSize(gomock.Any()).Return(0, nil).AnyTimes()
 	state.EXPECT().Check().Times(2)
 
 	checkEmpty := func(db NonCommittableStateDB, expectEmpty bool) {
@@ -3566,14 +3536,6 @@ func TestStateDB_CollectsErrorsAndReportsThemDuringACheck(t *testing.T) {
 		setExpectations func(state *MockState)
 		applyOperation  func(db StateDB)
 	}{
-		"exits": {
-			setExpectations: func(state *MockState) {
-				state.EXPECT().Exists(gomock.Any()).Return(false, injectedError)
-			},
-			applyOperation: func(db StateDB) {
-				db.Exist(address1)
-			},
-		},
 		"balance": {
 			setExpectations: func(state *MockState) {
 				state.EXPECT().GetBalance(gomock.Any()).Return(amount.New(), injectedError)
@@ -3600,7 +3562,7 @@ func TestStateDB_CollectsErrorsAndReportsThemDuringACheck(t *testing.T) {
 		},
 		"code-hash": {
 			setExpectations: func(state *MockState) {
-				state.EXPECT().Exists(address1).Return(true, nil)
+				state.EXPECT().GetBalance(address1).Return(balance1, nil)
 				state.EXPECT().GetCodeHash(gomock.Any()).Return(common.Hash{}, injectedError)
 			},
 			applyOperation: func(db StateDB) {
@@ -3625,7 +3587,7 @@ func TestStateDB_CollectsErrorsAndReportsThemDuringACheck(t *testing.T) {
 		},
 		"apply": {
 			setExpectations: func(state *MockState) {
-				state.EXPECT().Exists(address1).Return(true, nil)
+				state.EXPECT().GetBalance(address1).Return(balance1, nil)
 				state.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, injectedError)
 			},
 			applyOperation: func(db StateDB) {
@@ -3920,8 +3882,7 @@ func TestStateDB_ProvidesTransactionChanges(t *testing.T) {
 	mock := NewMockState(ctrl)
 	db := CreateStateDBUsing(mock)
 
-	mock.EXPECT().Exists(gomock.Any()).Return(true, nil).AnyTimes()
-	mock.EXPECT().GetBalance(gomock.Any()).Return(balance1, nil)
+	mock.EXPECT().GetBalance(gomock.Any()).Return(balance1, nil).AnyTimes()
 
 	db.BeginTransaction()
 	db.AddBalance(address1, amount.New(1))
@@ -4108,8 +4069,7 @@ func TestStateDB_GetMemoryFootprintIsReturnedAndNotZero(t *testing.T) {
 	mock := NewMockState(ctrl)
 	db := CreateStateDBUsing(mock)
 
-	mock.EXPECT().Exists(address1).Return(true, nil)
-	mock.EXPECT().Exists(address2).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address2)
 	mock.EXPECT().GetBalance(address1).Return(amount.New(10), nil)
 	mock.EXPECT().GetCode(address1).Return([]byte{1, 2, 3}, nil)
 	mock.EXPECT().GetCodeHash(address1).Return(common.Hash{3, 2, 1}, nil)
@@ -4173,9 +4133,9 @@ func TestBulkLoad_CloseResetsLocalCache(t *testing.T) {
 	db := createStateDBWith(mock, 0, true)
 
 	gomock.InOrder(
-		mock.EXPECT().Exists(address1),
-		mock.EXPECT().Exists(address2),
-		mock.EXPECT().Exists(address3),
+		mock.EXPECT().GetBalance(address1).Return(balance1, nil),
+		mock.EXPECT().GetBalance(address2).Return(balance1, nil),
+		mock.EXPECT().GetBalance(address3).Return(balance1, nil),
 		mock.EXPECT().Apply(uint64(1), gomock.Any()),
 		mock.EXPECT().Flush(),
 		mock.EXPECT().GetCommitment().Return(future.Immediate(result.Ok(common.Hash{}))),
@@ -4235,12 +4195,14 @@ func TestStateDB_EffectsOfBulkLoadAreSeenByStateDB(t *testing.T) {
 	db := createStateDBWith(state, 0, true)
 
 	var addr = common.Address{1}
+	state.EXPECT().GetNonce(addr).Return(common.Nonce{}, nil)
+	state.EXPECT().GetCodeSize(addr).Return(0, nil)
 	gomock.InOrder(
-		state.EXPECT().Exists(addr).Return(false, nil),
+		state.EXPECT().GetBalance(addr).Return(amount.New(), nil),
 		state.EXPECT().Apply(gomock.Any(), gomock.Any()),
 		state.EXPECT().Flush(),
 		state.EXPECT().GetCommitment().Return(future.Immediate(result.Ok(common.Hash{}))),
-		state.EXPECT().Exists(addr).Return(true, nil),
+		state.EXPECT().GetBalance(addr).Return(balance1, nil),
 	)
 
 	// The state is fetched before the bulk-load, causing it to be
@@ -4445,7 +4407,7 @@ func TestStateDB_ContractCanBeCreatedAndDeletedInTheSameTransaction(t *testing.T
 	db := CreateStateDBUsing(mock)
 
 	// the account should not exist prior to CreateContract call
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 
 	require.False(t, db.IsNewContract(address1),
 		"account marked as new before CreateContract call")
@@ -4478,7 +4440,7 @@ func TestStateDB_ContractCanBeCreatedAndDeletedInDifferentTransactions(t *testin
 	db := CreateStateDBUsing(mock)
 
 	// the account should not exist prior to CreateContract call
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 
 	require.False(t, db.IsNewContract(address1),
 		"account marked as new before CreateContract call")
@@ -4524,7 +4486,7 @@ func TestStateDB_ContractCreationAndDeletionCanBeRolledBack(t *testing.T) {
 	ss := db.Snapshot()
 
 	// create new contract
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 	db.CreateContract(address1)
 
 	// revert to snapshot
@@ -4555,7 +4517,7 @@ func TestStateDB_ContractIsNoLongerMarkedAsNewAfterRollback(t *testing.T) {
 	require.False(t, db.IsNewContract(address1),
 		"account marked as new before CreateContract call")
 
-	mock.EXPECT().Exists(address1).Return(false, nil)
+	setExpectationForEmptyAccount(t, mock, address1)
 	db.CreateContract(address1)
 
 	require.True(t, db.IsNewContract(address1),
@@ -4599,7 +4561,7 @@ func TestStateDB_HasEmptyStorage_DestructedContract_ReportEmpty(t *testing.T) {
 
 	// state reports there are data in the storage
 	st.EXPECT().HasEmptyStorage(addr).Return(false, nil).AnyTimes()
-	st.EXPECT().Exists(addr).Return(true, nil)
+	st.EXPECT().GetBalance(addr).Return(balance1, nil)
 
 	statedb := stateDB{
 		accounts:        make(map[common.Address]*accountState),
@@ -4700,7 +4662,7 @@ func TestStateDB_CreateAccount_CreateNonExistingAccount_AddsRemovalOfClearedAcco
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 	db := NewMockState(ctrl)
-	db.EXPECT().Exists(gomock.Any()).AnyTimes()
+	db.EXPECT().GetBalance(gomock.Any()).AnyTimes().Return(amount.New(), nil)
 
 	state := createStateDBWith(db, 1, true)
 
@@ -4721,7 +4683,7 @@ func TestStateDB_CreateAccount_CreateAccountWithClearState_AddsUndoForRestore(t 
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 	db := NewMockState(ctrl)
-	db.EXPECT().Exists(gomock.Any()).AnyTimes()
+	db.EXPECT().GetBalance(gomock.Any()).AnyTimes().Return(amount.New(), nil)
 
 	state := createStateDBWith(db, 1, true)
 
@@ -4743,7 +4705,7 @@ func TestStateDB_Suicide_SuicideNonCachedAccount_AddsUndoForRestore(t *testing.T
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 	db := NewMockState(ctrl)
-	db.EXPECT().Exists(gomock.Any()).AnyTimes().Return(true, nil)
+	db.EXPECT().GetBalance(gomock.Any()).AnyTimes().Return(balance1, nil)
 
 	state := createStateDBWith(db, 1, true)
 	addr := common.Address{1, 2, 3}
@@ -4762,7 +4724,7 @@ func TestStateDB_Suicide_SuicideCachedAccount_AddsUndoForRestore(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 	db := NewMockState(ctrl)
-	db.EXPECT().Exists(gomock.Any()).AnyTimes().Return(true, nil)
+	db.EXPECT().GetBalance(gomock.Any()).AnyTimes().Return(balance1, nil)
 
 	state := createStateDBWith(db, 1, true)
 	addr := common.Address{1, 2, 3}
@@ -4985,4 +4947,11 @@ func TestStateDB_EndBlock_ClearsUndoList(t *testing.T) {
 
 	stateDB.EndBlock(12)
 	require.Empty(t, stateDB.undo)
+}
+
+func setExpectationForEmptyAccount(t *testing.T, mock *MockState, address common.Address) {
+	t.Helper()
+	mock.EXPECT().GetBalance(address).Return(amount.New(), nil)
+	mock.EXPECT().GetNonce(address).Return(common.Nonce{}, nil).AnyTimes()
+	mock.EXPECT().GetCodeSize(address).Return(0, nil).AnyTimes()
 }

--- a/go/state/state_mock.go
+++ b/go/state/state_mock.go
@@ -109,21 +109,6 @@ func (mr *MockStateMockRecorder) CreateWitnessProof(address any, keys ...any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWitnessProof", reflect.TypeOf((*MockState)(nil).CreateWitnessProof), varargs...)
 }
 
-// Exists mocks base method.
-func (m *MockState) Exists(address common.Address) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Exists", address)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Exists indicates an expected call of Exists.
-func (mr *MockStateMockRecorder) Exists(address any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockState)(nil).Exists), address)
-}
-
 // Export mocks base method.
 func (m *MockState) Export(ctx context.Context, out io.Writer) (common.Hash, error) {
 	m.ctrl.T.Helper()
@@ -383,21 +368,6 @@ func (m *MockLiveDB) Close() error {
 func (mr *MockLiveDBMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockLiveDB)(nil).Close))
-}
-
-// Exists mocks base method.
-func (m *MockLiveDB) Exists(address common.Address) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Exists", address)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Exists indicates an expected call of Exists.
-func (mr *MockLiveDBMockRecorder) Exists(address any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockLiveDB)(nil).Exists), address)
 }
 
 // Flush mocks base method.

--- a/go/state/state_test.go
+++ b/go/state/state_test.go
@@ -449,10 +449,10 @@ func TestDeleteNotExistingAccount(t *testing.T) {
 			t.Fatalf("Error: %s", err)
 		}
 
-		if newState, err := s.Exists(address1); err != nil || newState != true {
+		if newState, err := state.IsEmptyAccount(s, address1); err != nil || newState != false {
 			t.Errorf("Unrelated existing state: %t, Error: %s", newState, err)
 		}
-		if newState, err := s.Exists(address2); err != nil || newState != false {
+		if newState, err := state.IsEmptyAccount(s, address2); err != nil || newState != true {
 			t.Errorf("Delete never-existing state: %t, Error: %s", newState, err)
 		}
 	})
@@ -568,10 +568,10 @@ func TestArchive(t *testing.T) {
 			}
 			defer func() { require.NoError(t, state2.Close()) }()
 
-			if as, err := state1.Exists(address1); err != nil || as != true {
+			if as, err := state.IsEmptyAccount(state1, address1); err != nil || as != false {
 				t.Errorf("invalid account state at block 0: %t, %v", as, err)
 			}
-			if as, err := state2.Exists(address1); err != nil || as != true {
+			if as, err := state.IsEmptyAccount(state2, address1); err != nil || as != false {
 				t.Errorf("invalid account state at block 1: %t, %v", as, err)
 			}
 			if balance, err := state1.GetBalance(address1); err != nil || balance != balance12 {
@@ -674,10 +674,10 @@ func TestLastArchiveBlock(t *testing.T) {
 				require.NoError(t, state2.Close())
 			}()
 
-			if as, err := state2.Exists(address1); err != nil || as != true {
+			if as, err := state.IsEmptyAccount(state2, address1); err != nil || as != false {
 				t.Errorf("invalid account state at the last block: %t, %v", as, err)
 			}
-			if as, err := state2.Exists(address2); err != nil || as != true {
+			if as, err := state.IsEmptyAccount(state2, address2); err != nil || as != false {
 				t.Errorf("invalid account state at the last block: %t, %v", as, err)
 			}
 
@@ -755,9 +755,6 @@ func TestStateRead(t *testing.T) {
 		_ = s.Close()
 	}()
 
-	if state, err := s.Exists(address1); err != nil || state != true {
-		t.Errorf("Unexpected value or err, val: %v != %v, err:  %v", state, true, err)
-	}
 	if balance, err := s.GetBalance(address1); err != nil || balance != balance1 {
 		t.Errorf("Unexpected value or err, val: %v != %v, err:  %v", balance, balance1, err)
 	}
@@ -774,9 +771,6 @@ func TestStateRead(t *testing.T) {
 	as, err := s.GetArchiveState(0)
 	if as == nil || err != nil {
 		t.Fatalf("Unable to get archive state, err: %v", err)
-	}
-	if state, err := as.Exists(address1); err != nil || state != true {
-		t.Errorf("Unexpected value or err, val: %v != %v, err:  %v", state, true, err)
 	}
 	if balance, err := as.GetBalance(address1); err != nil || balance != balance1 {
 		t.Errorf("Unexpected value or err, val: %v != %v, err:  %v", balance, balance1, err)

--- a/go/state/state_utils.go
+++ b/go/state/state_utils.go
@@ -1,3 +1,13 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
 package state
 
 import (

--- a/go/state/state_utils.go
+++ b/go/state/state_utils.go
@@ -25,9 +25,9 @@ func IsEmptyAccount(s State, addr common.Address) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	code, err := s.GetCode(addr)
+	code, err := s.GetCodeSize(addr)
 	if err != nil {
 		return false, err
 	}
-	return balance == (amount.Amount{}) && nonce == (common.Nonce{}) && len(code) == 0, nil
+	return balance == (amount.Amount{}) && nonce == (common.Nonce{}) && code == 0, nil
 }

--- a/go/state/state_utils.go
+++ b/go/state/state_utils.go
@@ -1,0 +1,23 @@
+package state
+
+import (
+	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/0xsoniclabs/carmen/go/common/amount"
+)
+
+// IsEmptyAccount checks if the account is empty in the state, i.e. if it has zero balance, zero nonce and empty code
+func IsEmptyAccount(s State, addr common.Address) (bool, error) {
+	balance, err := s.GetBalance(addr)
+	if err != nil {
+		return false, err
+	}
+	nonce, err := s.GetNonce(addr)
+	if err != nil {
+		return false, err
+	}
+	code, err := s.GetCode(addr)
+	if err != nil {
+		return false, err
+	}
+	return balance == (amount.Amount{}) && nonce == (common.Nonce{}) && len(code) == 0, nil
+}

--- a/go/state/state_utils.go
+++ b/go/state/state_utils.go
@@ -12,7 +12,6 @@ package state
 
 import (
 	"github.com/0xsoniclabs/carmen/go/common"
-	"github.com/0xsoniclabs/carmen/go/common/amount"
 )
 
 // IsEmptyAccount checks if the account is empty in the state, i.e. if it has zero balance, zero nonce and empty code
@@ -25,9 +24,9 @@ func IsEmptyAccount(s State, addr common.Address) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	code, err := s.GetCodeSize(addr)
+	codeSize, err := s.GetCodeSize(addr)
 	if err != nil {
 		return false, err
 	}
-	return balance == (amount.Amount{}) && nonce == (common.Nonce{}) && code == 0, nil
+	return balance.IsZero() && nonce == (common.Nonce{}) && codeSize == 0, nil
 }

--- a/go/state/state_utils_test.go
+++ b/go/state/state_utils_test.go
@@ -1,3 +1,13 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
 package state
 
 import (

--- a/go/state/state_utils_test.go
+++ b/go/state/state_utils_test.go
@@ -28,7 +28,7 @@ func TestIsEmptyAccount(t *testing.T) {
 			set_expectations: func(s *MockState) {
 				s.EXPECT().GetBalance(gomock.Any()).Return(amount.New(0), nil)
 				s.EXPECT().GetNonce(gomock.Any()).Return(common.Nonce{}, nil)
-				s.EXPECT().GetCode(gomock.Any()).Return([]byte{}, nil)
+				s.EXPECT().GetCodeSize(gomock.Any()).Return(0, nil)
 			},
 			expected: true,
 		},
@@ -36,7 +36,7 @@ func TestIsEmptyAccount(t *testing.T) {
 			set_expectations: func(s *MockState) {
 				s.EXPECT().GetBalance(gomock.Any()).Return(amount.New(100), nil)
 				s.EXPECT().GetNonce(gomock.Any()).Return(common.Nonce{}, nil)
-				s.EXPECT().GetCode(gomock.Any()).Return([]byte{}, nil)
+				s.EXPECT().GetCodeSize(gomock.Any()).Return(0, nil)
 			},
 			expected: false,
 		},
@@ -44,7 +44,7 @@ func TestIsEmptyAccount(t *testing.T) {
 			set_expectations: func(s *MockState) {
 				s.EXPECT().GetBalance(gomock.Any()).Return(amount.New(0), nil)
 				s.EXPECT().GetNonce(gomock.Any()).Return(common.Nonce{1}, nil)
-				s.EXPECT().GetCode(gomock.Any()).Return([]byte{}, nil)
+				s.EXPECT().GetCodeSize(gomock.Any()).Return(0, nil)
 			},
 			expected: false,
 		},
@@ -52,7 +52,7 @@ func TestIsEmptyAccount(t *testing.T) {
 			set_expectations: func(s *MockState) {
 				s.EXPECT().GetBalance(gomock.Any()).Return(amount.New(0), nil)
 				s.EXPECT().GetNonce(gomock.Any()).Return(common.Nonce{}, nil)
-				s.EXPECT().GetCode(gomock.Any()).Return([]byte{0x60, 0x00}, nil) // PUSH1 0x00
+				s.EXPECT().GetCodeSize(gomock.Any()).Return(2, nil) // PUSH1 0x00
 			},
 			expected: false,
 		},

--- a/go/state/state_utils_test.go
+++ b/go/state/state_utils_test.go
@@ -1,0 +1,65 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/0xsoniclabs/carmen/go/common/amount"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestIsEmptyAccount(t *testing.T) {
+	testCases := map[string]struct {
+		set_expectations func(s *MockState)
+		expected         bool
+	}{
+		"empty account": {
+			set_expectations: func(s *MockState) {
+				s.EXPECT().GetBalance(gomock.Any()).Return(amount.New(0), nil)
+				s.EXPECT().GetNonce(gomock.Any()).Return(common.Nonce{}, nil)
+				s.EXPECT().GetCode(gomock.Any()).Return([]byte{}, nil)
+			},
+			expected: true,
+		},
+		"non-empty balance": {
+			set_expectations: func(s *MockState) {
+				s.EXPECT().GetBalance(gomock.Any()).Return(amount.New(100), nil)
+				s.EXPECT().GetNonce(gomock.Any()).Return(common.Nonce{}, nil)
+				s.EXPECT().GetCode(gomock.Any()).Return([]byte{}, nil)
+			},
+			expected: false,
+		},
+		"non-empty nonce": {
+			set_expectations: func(s *MockState) {
+				s.EXPECT().GetBalance(gomock.Any()).Return(amount.New(0), nil)
+				s.EXPECT().GetNonce(gomock.Any()).Return(common.Nonce{1}, nil)
+				s.EXPECT().GetCode(gomock.Any()).Return([]byte{}, nil)
+			},
+			expected: false,
+		},
+		"non-empty code": {
+			set_expectations: func(s *MockState) {
+				s.EXPECT().GetBalance(gomock.Any()).Return(amount.New(0), nil)
+				s.EXPECT().GetNonce(gomock.Any()).Return(common.Nonce{}, nil)
+				s.EXPECT().GetCode(gomock.Any()).Return([]byte{0x60, 0x00}, nil) // PUSH1 0x00
+			},
+			expected: false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockState := NewMockState(ctrl)
+			tc.set_expectations(mockState)
+
+			result, err := IsEmptyAccount(mockState, common.Address{})
+			require.NoError(err)
+			require.Equal(tc.expected, result)
+		})
+	}
+}

--- a/go/state/state_utils_test.go
+++ b/go/state/state_utils_test.go
@@ -11,6 +11,7 @@
 package state
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/0xsoniclabs/carmen/go/common"
@@ -19,7 +20,7 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func TestIsEmptyAccount(t *testing.T) {
+func TestIsEmptyAccount_BehavesCorrectly(t *testing.T) {
 	testCases := map[string]struct {
 		set_expectations func(s *MockState)
 		expected         bool
@@ -70,6 +71,47 @@ func TestIsEmptyAccount(t *testing.T) {
 			result, err := IsEmptyAccount(mockState, common.Address{})
 			require.NoError(err)
 			require.Equal(tc.expected, result)
+		})
+	}
+}
+
+func TestIsEmptyAccount_PropagatesErrors(t *testing.T) {
+	errTest := errors.New("test error")
+	testCases := map[string]struct {
+		set_expectations func(s *MockState)
+	}{
+		"GetBalance error": {
+			set_expectations: func(s *MockState) {
+				s.EXPECT().GetBalance(gomock.Any()).Return(amount.New(0), errTest)
+			},
+		},
+		"GetNonce error": {
+			set_expectations: func(s *MockState) {
+				s.EXPECT().GetBalance(gomock.Any()).Return(amount.New(0), nil)
+				s.EXPECT().GetNonce(gomock.Any()).Return(common.Nonce{}, errTest)
+			},
+		},
+		"GetCodeSize error": {
+			set_expectations: func(s *MockState) {
+				s.EXPECT().GetBalance(gomock.Any()).Return(amount.New(0), nil)
+				s.EXPECT().GetNonce(gomock.Any()).Return(common.Nonce{}, nil)
+				s.EXPECT().GetCodeSize(gomock.Any()).Return(0, errTest)
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockState := NewMockState(ctrl)
+			tc.set_expectations(mockState)
+
+			result, err := IsEmptyAccount(mockState, common.Address{})
+			require.ErrorIs(err, errTest)
+			require.False(result)
 		})
 	}
 }

--- a/go/state/synced_state.go
+++ b/go/state/synced_state.go
@@ -54,12 +54,6 @@ func UnsafeUnwrapSyncedState(state State) State {
 	return state
 }
 
-func (s *syncedState) Exists(address common.Address) (bool, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.state.Exists(address)
-}
-
 func (s *syncedState) GetBalance(address common.Address) (amount.Amount, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/rust/src/database/verkle/state.rs
+++ b/rust/src/database/verkle/state.rs
@@ -126,12 +126,6 @@ impl<T: VerkleTrie> IsArchive for VerkleTrieCarmenState<T> {
 }
 
 impl<T: VerkleTrie> CarmenState for VerkleTrieCarmenState<T> {
-    fn account_exists(&self, addr: &Address) -> BTResult<bool, Error> {
-        Ok(self.get_code_hash(addr)? != Hash::default()
-            || self.get_balance(addr)? != U256::default()
-            || self.get_nonce(addr)? != Nonce::default())
-    }
-
     fn get_balance(&self, addr: &Address) -> BTResult<U256, Error> {
         let key = self.embedding.get_basic_data_key(addr);
         let value = self.trie.lookup(&key)?;
@@ -318,47 +312,6 @@ mod tests {
 
         let result = state.apply_block_update(1, Update::default());
         assert!(result.is_ok());
-    }
-
-    #[rstest_reuse::apply(all_state_impls)]
-    fn account_exists_checks_whether_account_has_non_zero_code_hash(
-        #[case] state: Box<dyn CarmenState>,
-    ) {
-        let addr = Address::default();
-        assert!(!state.account_exists(&addr).unwrap());
-        assert_eq!(state.get_code_hash(&addr).unwrap(), Hash::default());
-
-        set_code(&*state, addr, &[0x01, 0x02, 0x03], 0);
-        assert!(state.account_exists(&addr).unwrap());
-    }
-
-    #[rstest_reuse::apply(all_state_impls)]
-    fn account_exists_checks_whether_account_has_non_zero_balance(
-        #[case] state: Box<dyn CarmenState>,
-    ) {
-        let addr = Address::default();
-        assert!(!state.account_exists(&addr).unwrap());
-        assert_eq!(state.get_balance(&addr).unwrap(), U256::default());
-
-        set_balance(
-            &*state,
-            addr,
-            crypto_bigint::U256::from_u32(42).to_be_bytes(),
-            0,
-        );
-        assert!(state.account_exists(&addr).unwrap());
-    }
-
-    #[rstest_reuse::apply(all_state_impls)]
-    fn account_exists_checks_whether_account_has_non_zero_nonce(
-        #[case] state: Box<dyn CarmenState>,
-    ) {
-        let addr = Address::default();
-        assert!(!state.account_exists(&addr).unwrap());
-        assert_eq!(state.get_nonce(&addr).unwrap(), Nonce::default());
-
-        set_nonce(&*state, addr, 7u64.to_be_bytes(), 0);
-        assert!(state.account_exists(&addr).unwrap());
     }
 
     #[rstest_reuse::apply(all_state_impls)]

--- a/rust/src/ffi/exported.rs
+++ b/rust/src/ffi/exported.rs
@@ -389,58 +389,6 @@ unsafe extern "C" fn Carmen_Rust_GetArchiveBlockHeight(
     }
 }
 
-/// Checks if the given account exists.
-///
-/// # Safety
-/// - `state` must be a valid pointer to a `StateWrapper` object which holds a pointer to a `dyn
-///   CarmenState` object
-/// - `state` must be valid for reads for the duration of the call
-/// - `state` must not be mutated for the duration of the call
-/// - `state.inner` must be a valid pointer to a `dyn CarmenState`
-/// - `state.inner` must be valid for reads for the duration of the lifetime of `token`
-/// - `state.inner` must not be mutated for the duration of the lifetime of `token`
-/// - `addr` must be a valid pointer to a byte array of length 20
-/// - `addr` must be valid for reads for the duration of the call
-/// - `addr` must not be mutated for the duration of the call
-/// - `out_state` must be a valid pointer to a `u8`
-/// - `out_state` must be valid for writes for the duration of the call
-#[unsafe(no_mangle)]
-unsafe extern "C" fn Carmen_Rust_AccountExists(
-    state: *mut c_void,
-    addr: *mut c_void,
-    out_state: *mut c_void,
-) -> bindings::Result {
-    let token = LifetimeToken;
-    if state.is_null() || addr.is_null() || out_state.is_null() {
-        return bindings::Result_kResult_InvalidArguments;
-    }
-    // SAFETY:
-    // - `state` is a valid pointer to a `StateWrapper` object (precondition)
-    // - `state` is valid for reads for the duration of the call (precondition)
-    // - `state` is not mutated for the duration of the call (precondition)
-    let state = unsafe { ref_from_ptr_scoped(state as *const StateWrapper, &token) };
-    // SAFETY:
-    // - `state.inner` is a valid pointer to a `dyn CarmenState` (precondition)
-    // - `state.inner` is valid for reads for the duration of the lifetime of `token` (precondition)
-    // - `state.inner` is not mutated for the duration of the lifetime of `token`(precondition)
-    let state = unsafe { state.inner_to_ref_scoped(&token) };
-    // SAFETY:
-    // - `addr` is a valid pointer to a byte array of length 20 (precondition)
-    // - `addr` is valid for reads for the duration of the call (precondition)
-    // - `addr` is not mutated for the duration of the call (precondition)
-    let addr = unsafe { ref_from_ptr_scoped(addr as *mut Address, &token) };
-    match state.account_exists(addr) {
-        Ok(exists) => {
-            // SAFETY:
-            // - `out_state` is a valid pointer to a `u8` (precondition)
-            // - `out_state` is valid for writes for the duration of the call (precondition)
-            unsafe { std::ptr::write(out_state as *mut u8, exists as u8) };
-            bindings::Result_kResult_Success
-        }
-        Err(err) => err.into(),
-    }
-}
-
 /// Retrieves the balance of the given account.
 ///
 /// # Safety
@@ -1093,10 +1041,6 @@ const COMPILE_TIME_CHECK_THAT_SIGNATURES_MATCH_SIGNATURES_GENERATED_FROM_C_HEADE
         bindings::Carmen_Rust_ReleaseState,
     );
     assert_same_signature(
-        Carmen_Rust_AccountExists as unsafe extern "C" fn(_, _, _) -> _,
-        bindings::Carmen_Rust_AccountExists,
-    );
-    assert_same_signature(
         Carmen_Rust_GetBalance as unsafe extern "C" fn(_, _, _) -> _,
         bindings::Carmen_Rust_GetBalance,
     );
@@ -1468,91 +1412,6 @@ mod tests {
     fn carmen_rust_release_state_checks_that_arguments_are_valid() {
         let result = unsafe { Carmen_Rust_ReleaseState(std::ptr::null_mut()) };
         assert_eq!(result, bindings::Result_kResult_InvalidArguments);
-    }
-
-    #[test]
-    fn carmen_rust_account_exists_returns_value_from_carmen_db() {
-        let addr = [1; 20];
-        let expected_account_state = true;
-        create_state_then_call_fn_then_release_state(
-            move |mock_db| {
-                mock_db
-                    .expect_account_exists()
-                    .with(eq(addr))
-                    .returning(move |_| Ok(expected_account_state));
-            },
-            move |state| {
-                let mut addr = addr;
-                let mut out_state = 0u8;
-                unsafe {
-                    Carmen_Rust_AccountExists(
-                        state,
-                        &mut addr as *mut Address as *mut c_void,
-                        &mut out_state as *mut u8 as *mut c_void,
-                    );
-                }
-                assert_eq!(out_state, expected_account_state as u8);
-            },
-        );
-    }
-
-    #[test]
-    fn carmen_rust_account_exists_checks_that_arguments_are_valid() {
-        let addr = [1u8; 20];
-        let mut out_state = 0u8;
-        let result = unsafe {
-            Carmen_Rust_AccountExists(
-                std::ptr::null_mut(), // invalid
-                &addr as *const Address as *mut c_void,
-                &mut out_state as *mut u8 as *mut c_void,
-            )
-        };
-        assert_eq!(result, bindings::Result_kResult_InvalidArguments);
-
-        let result = unsafe {
-            Carmen_Rust_AccountExists(
-                &mut 0u8 as *mut u8 as *mut c_void,
-                std::ptr::null_mut(), // invalid
-                &mut out_state as *mut u8 as *mut c_void,
-            )
-        };
-        assert_eq!(result, bindings::Result_kResult_InvalidArguments);
-
-        let result = unsafe {
-            Carmen_Rust_AccountExists(
-                &mut 0u8 as *mut u8 as *mut c_void,
-                &addr as *const Address as *mut c_void,
-                std::ptr::null_mut(), // invalid
-            )
-        };
-        assert_eq!(result, bindings::Result_kResult_InvalidArguments);
-    }
-
-    #[test]
-    fn carmen_rust_account_exists_returns_error_as_int() {
-        let addr = [1; 20];
-        create_state_then_call_fn_then_release_state(
-            move |mock_db| {
-                mock_db
-                    .expect_account_exists()
-                    .with(eq(addr))
-                    .returning(|_| {
-                        Err(crate::Error::UnsupportedOperation("some error".into()).into())
-                    });
-            },
-            move |state| {
-                let mut addr = addr;
-                let mut out_state = 0u8;
-                let result = unsafe {
-                    Carmen_Rust_AccountExists(
-                        state,
-                        &mut addr as *mut Address as *mut c_void,
-                        &mut out_state as *mut u8 as *mut c_void,
-                    )
-                };
-                assert_eq!(result, bindings::Result_kResult_UnsupportedOperation);
-            },
-        );
     }
 
     #[test]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -160,9 +160,6 @@ pub trait CarmenDb: Send + Sync {
 /// This is the safe interface which gets called from the exported FFI functions.
 #[cfg_attr(test, mockall::automock, allow(clippy::disallowed_types))]
 pub trait CarmenState: Send + Sync {
-    /// Checks if the given account exists.
-    fn account_exists(&self, addr: &Address) -> BTResult<bool, Error>;
-
     /// Returns the balance of the given account.
     fn get_balance(&self, addr: &Address) -> BTResult<U256, Error>;
 
@@ -199,10 +196,6 @@ pub trait IsArchive {
 /// required so we can hand out multiple references to a single state instance
 /// on [`CarmenDb::get_live_state`].
 impl<T: CarmenState> CarmenState for Arc<T> {
-    fn account_exists(&self, addr: &Address) -> BTResult<bool, Error> {
-        self.deref().account_exists(addr)
-    }
-
     fn get_balance(&self, addr: &Address) -> BTResult<U256, Error> {
         self.deref().get_balance(addr)
     }


### PR DESCRIPTION
The existence of an account was tied to the its emptiness: every account theoretically exists, unless they are empty
Therefore, checking for the existence of an account corresponds to query it's values, e.g. balance, nonce, and code and check they are the default value

Having the `Exists` function in the `State` interface forced each implementation to implement the same logic, sometimes in different ways depending on the used data structure. Moreover, the existence of an account is a higher level concept, which belong in  the `StateDb` component.

This PR removes the `Exists` function from the `State` implementations and moves the emptiness check to the `StateDB::Exist` function. 
Importantly, this required to swap the creation of the account and the set of the nonce in `StateDB::setNonce`, as otherwise it would have incorrectly set the account as existing when setting the nonce for a non-existing account. This also aligns the `setNonce` behavior to the other set function, which creates the account first

To mark an account as already existing in tests, a mock expectation on `state.GetBalance` is used in most cases