### PR TITLE
Mark account as empty when code hash is empty code hash

### DIFF
--- a/go/database/mpt/account.go
+++ b/go/database/mpt/account.go
@@ -27,7 +27,7 @@ type AccountInfo struct {
 // default value. All accounts not present in an MPT are implicitly empty. Also
 // no empty accounts may be explicitly stored.
 func (a *AccountInfo) IsEmpty() bool {
-	return *a == AccountInfo{}
+	return *a == AccountInfo{} || *a == AccountInfo{CodeHash: emptyCodeHash}
 }
 
 // ----------------------------------------------------------------------------

--- a/go/database/mpt/account_test.go
+++ b/go/database/mpt/account_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/common/amount"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAccountInfo_EncodingAndDecoding(t *testing.T) {
@@ -31,5 +32,31 @@ func TestAccountInfo_EncodingAndDecoding(t *testing.T) {
 		if encoder.Load(buffer[:], &restored); restored != info {
 			t.Fatalf("failed to decode info %v: got %v", info, restored)
 		}
+	}
+}
+
+func TestAccountInfo_IsEmpty(t *testing.T) {
+	testCases := map[string]struct {
+		info     AccountInfo
+		expected bool
+	}{
+		"empty": {
+			info:     AccountInfo{},
+			expected: true,
+		},
+		"non-empty": {
+			info:     AccountInfo{common.Nonce{1, 2, 3}, amount.New(456), common.Hash{7, 8, 9}},
+			expected: false,
+		},
+		"empty code hash": {
+			info:     AccountInfo{CodeHash: emptyCodeHash},
+			expected: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.info.IsEmpty())
+		})
 	}
 }


### PR DESCRIPTION
Currently, an account in the MPT is considered empty if the `AccountInfo` structure is equal to the default value, including that the code hash is a byte vector of 0s. However, resetting an account to all default values does not result in the account being marked as empty, as setting the code to an empty byte vector results in saving the empty code hash in the code hash field of the `AccountInfo`.
This issue arose after the removal of the `DeleteAccount` function in #422, which had the ability to reset the code hash to 0s. Even if an account deletion is always followed by the reset of the fields, without setting the code hash manually an account would have always been considered existing.
This was detected by the ethereum specification tests with aida.

This PR fixes it by considering an account as empty both in cases of the default value or the empty code hash for the code hash field.
This is also in line with the Ethereum behavior, where an empty code should be considered uninitialized.
The current code passes the latest ethereum specification tests (v.4.5)