### PR TITLE
Cache RootLists with KVCachedFile

### DIFF
--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -738,10 +738,11 @@ func loadRoots(archiveDirectory string) (_ *rootList, retErr error) {
 		)
 	}
 
-	size, err := kvFile.Size()
+	size, err := kvFile.FileSize()
 	if err != nil {
 		return nil, errors.Join(err, kvFile.Close())
 	}
+	size /= entrySize
 	if int(size) < checkpointData.NumRoots {
 		return nil, errors.Join(
 			fmt.Errorf("root list file is corrupted: expected at least %d roots, but found only %d", checkpointData.NumRoots, size),

--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -91,19 +91,19 @@ func OpenArchiveTrie(
 	forestConfig := ForestConfig{Mode: Immutable, NodeCacheConfig: cacheConfig}
 	forest, err := OpenFileForest(directory, config, forestConfig)
 	if err != nil {
-		return nil, err
+		return nil, errors.Join(err, roots.Close())
 	}
 
 	head, err := makeTrie(directory, forest)
 	if err != nil {
-		return nil, errors.Join(err, forest.Close())
+		return nil, errors.Join(err, roots.Close(), forest.Close())
 	}
 
 	root := NewNodeReference(EmptyId())
 	if roots.length() > 0 {
 		rootValue, err := roots.get(uint64(roots.length() - 1))
 		if err != nil {
-			return nil, err
+			return nil, errors.Join(err, roots.Close(), head.Close())
 		}
 		root = rootValue.NodeRef
 	}
@@ -111,7 +111,7 @@ func OpenArchiveTrie(
 
 	state, err := newMptState(directory, lock, head)
 	if err != nil {
-		return nil, errors.Join(err, head.Close())
+		return nil, errors.Join(err, roots.Close(), head.Close())
 	}
 
 	checkpointDir := filepath.Join(directory, fileNameArchiveCheckpointDirectory)
@@ -125,7 +125,7 @@ func OpenArchiveTrie(
 		roots,
 	)
 	if err != nil {
-		return nil, errors.Join(err, head.Close())
+		return nil, errors.Join(err, roots.Close(), head.Close())
 	}
 
 	// Load the checkpointing configuration and set
@@ -165,10 +165,15 @@ func VerifyArchiveTrie(ctx context.Context, directory string, config MptConfig, 
 		return err
 	}
 	if roots.length() == 0 {
-		return nil
+		return roots.Close()
 	}
 	rootsList, err := roots.GetAll()
 	if err != nil {
+		return errors.Join(err, roots.Close())
+	}
+	// The roots are fully loaded into memory; release the file before the
+	// verification starts.
+	if err := roots.Close(); err != nil {
 		return err
 	}
 	return VerifyMptState(ctx, directory, config, rootsList, observer)
@@ -652,8 +657,13 @@ type rootList struct {
 	filename  string                              // < the file storing the list of roots
 	directory string                              // < the directory for checkpoint data
 
-	numRoots       int // < total number of roots
-	numRootsInFile int // < number of roots stored in the file
+	numRoots int // < total number of roots
+
+	// numRootsInFile is a lower bound on the number of roots persisted in the
+	// file: it is only synchronised by storeRoots, while the underlying cache
+	// may flush entries to disk on its own at any time. It must therefore only
+	// be consumed after a storeRoots call, as done by Prepare.
+	numRootsInFile int
 
 	checkpoint checkpoint.Checkpoint
 }
@@ -802,7 +812,7 @@ func (l *rootList) GetAll() ([]Root, error) {
 	return allRoots, nil
 }
 
-func StoreRoots(filename string, rootsToWrite []Root) error {
+func StoreRoots(filename string, rootsToWrite []Root) (err error) {
 	// loadRoots derives the roots file path from the directory and the
 	// canonical filename. Reject inputs that would otherwise cause writes to
 	// silently target a different path than the caller requested.

--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -824,9 +824,9 @@ func (l *rootList) storeRoots() error {
 	return nil
 }
 
-func (r *rootList) GetMemoryFootprint() *common.MemoryFootprint {
-	mf := common.NewMemoryFootprint(unsafe.Sizeof(*r))
-	mf.AddChild("roots", r.roots.GetMemoryFootprint())
+func (l *rootList) GetMemoryFootprint() *common.MemoryFootprint {
+	mf := common.NewMemoryFootprint(unsafe.Sizeof(*l))
+	mf.AddChild("roots", l.roots.GetMemoryFootprint())
 	return mf
 }
 

--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -451,7 +451,7 @@ func (a *ArchiveTrie) GetMemoryFootprint() *common.MemoryFootprint {
 	mf := common.NewMemoryFootprint(unsafe.Sizeof(*a))
 	mf.AddChild("head", a.head.GetMemoryFootprint())
 	a.rootsMutex.Lock()
-	mf.AddChild("roots", common.NewMemoryFootprint(uintptr(a.roots.length())*unsafe.Sizeof(NodeId(0))))
+	mf.AddChild("roots", a.roots.GetMemoryFootprint())
 	a.rootsMutex.Unlock()
 	return mf
 }
@@ -650,9 +650,9 @@ func (a *ArchiveTrie) GetConfig() MptConfig {
 // rootList is a utility type managing an in-memory copy of the list of roots
 // of an archive and its synchronization with an on-disk file copy.
 type rootList struct {
-	roots     *kv_file.KVCachedFile[uint64, Root] // < the in-memory copy of the roots list
-	filename  string                              // < the file storing the list of roots
-	directory string                              // < the directory for checkpoint data
+	roots     kv_file.KVFileWithMemoryFootprint[uint64, Root] // < the in-memory copy of the roots list
+	filename  string                                          // < the file storing the list of roots
+	directory string                                          // < the directory for checkpoint data
 
 	numRoots int // < total number of roots
 
@@ -724,18 +724,6 @@ func loadRoots(archiveDirectory string) (_ *rootList, retErr error) {
 	kvFile, err := kv_file.OpenKVCachedFile[uint64, Root](roots, 10000, 1000)
 	if err != nil {
 		return nil, errors.Join(err, roots.Close())
-	}
-
-	// Verify that the on-disk file is a whole number of root entries.
-	fileSize, err := kvFile.FileSize()
-	if err != nil {
-		return nil, errors.Join(err, kvFile.Close())
-	}
-	if fileSize%entrySize != 0 {
-		return nil, errors.Join(
-			fmt.Errorf("invalid root file format: size %d is not a multiple of entry size %d", fileSize, entrySize),
-			kvFile.Close(),
-		)
 	}
 
 	size, err := kvFile.FileSize()
@@ -834,6 +822,12 @@ func (l *rootList) storeRoots() error {
 	}
 	l.numRootsInFile = l.numRoots
 	return nil
+}
+
+func (r *rootList) GetMemoryFootprint() *common.MemoryFootprint {
+	mf := common.NewMemoryFootprint(unsafe.Sizeof(*r))
+	mf.AddChild("roots", r.roots.GetMemoryFootprint())
+	return mf
 }
 
 func (l *rootList) GuaranteeCheckpoint(checkpoint checkpoint.Checkpoint) error {

--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -504,7 +504,9 @@ func (a *ArchiveTrie) VisitAccountStorage(
 func (a *ArchiveTrie) Close() error {
 	return errors.Join(
 		a.CheckErrors(),
-		a.head.closeWithError(a.Flush()))
+		a.head.closeWithError(a.Flush()),
+		a.roots.Close(),
+	)
 }
 
 func (a *ArchiveTrie) createCheckpoint() error {
@@ -826,6 +828,9 @@ func StoreRoots(filename string, rootsToWrite []Root) error {
 }
 
 func (l *rootList) storeRoots() error {
+	if l.roots == nil {
+		return nil
+	}
 	if err := l.roots.Flush(); err != nil {
 		return err
 	}

--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -11,7 +11,6 @@
 package mpt
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -24,6 +23,7 @@ import (
 	"unsafe"
 
 	"github.com/0xsoniclabs/carmen/go/backend/archive"
+	"github.com/0xsoniclabs/carmen/go/backend/kv_file"
 	"github.com/0xsoniclabs/carmen/go/backend/stock/file"
 	"github.com/0xsoniclabs/carmen/go/backend/utils"
 	"github.com/0xsoniclabs/carmen/go/backend/utils/checkpoint"
@@ -101,7 +101,11 @@ func OpenArchiveTrie(
 
 	root := NewNodeReference(EmptyId())
 	if roots.length() > 0 {
-		root = roots.get(uint64(roots.length() - 1)).NodeRef
+		rootValue, err := roots.get(uint64(roots.length() - 1))
+		if err != nil {
+			return nil, err
+		}
+		root = rootValue.NodeRef
 	}
 	head.root = root
 
@@ -163,7 +167,11 @@ func VerifyArchiveTrie(ctx context.Context, directory string, config MptConfig, 
 	if roots.length() == 0 {
 		return nil
 	}
-	return VerifyMptState(ctx, directory, config, roots.roots, observer)
+	rootsList, err := roots.GetAll()
+	if err != nil {
+		return err
+	}
+	return VerifyMptState(ctx, directory, config, rootsList, observer)
 }
 
 func (a *ArchiveTrie) Add(block uint64, update common.Update, hint any) error {
@@ -191,7 +199,10 @@ func (a *ArchiveTrie) Add(block uint64, update common.Update, hint any) error {
 			return a.addError(err)
 		}
 		for uint64(a.roots.length()) < block {
-			a.roots.append(Root{a.head.Root(), lastHash})
+			if err := a.roots.append(Root{a.head.Root(), lastHash}); err != nil {
+				a.rootsMutex.Unlock()
+				return a.addError(err)
+			}
 		}
 	}
 	a.rootsMutex.Unlock()
@@ -228,7 +239,10 @@ func (a *ArchiveTrie) Add(block uint64, update common.Update, hint any) error {
 
 	// Save new root node.
 	a.rootsMutex.Lock()
-	a.roots.append(Root{a.head.Root(), hash})
+	if err := a.roots.append(Root{a.head.Root(), hash}); err != nil {
+		a.rootsMutex.Unlock()
+		return a.addError(err)
+	}
 	a.rootsMutex.Unlock()
 
 	// Create a new checkpoint if we crossed an interval boundary.
@@ -254,7 +268,11 @@ func (a *ArchiveTrie) GetBlockRoot(block uint64) (NodeId, error) {
 	if block >= uint64(a.roots.length()) {
 		return EmptyId(), fmt.Errorf("block %d not present in archive", block)
 	}
-	return a.roots.get(block).NodeRef.id, nil
+	root, err := a.roots.get(block)
+	if err != nil {
+		return EmptyId(), err
+	}
+	return root.NodeRef.id, nil
 }
 
 func (a *ArchiveTrie) GetBlockHeight() (block uint64, empty bool, err error) {
@@ -352,9 +370,12 @@ func (a *ArchiveTrie) GetHash(block uint64) (hash common.Hash, err error) {
 		a.rootsMutex.Unlock()
 		return common.Hash{}, fmt.Errorf("invalid block: %d >= %d", block, length)
 	}
-	res := a.roots.get(block).Hash
+	res, err := a.roots.get(block)
 	a.rootsMutex.Unlock()
-	return res, nil
+	if err != nil {
+		return common.Hash{}, err
+	}
+	return res.Hash, nil
 }
 
 func (a *ArchiveTrie) CreateWitnessProof(block uint64, address common.Address, keys ...common.Key) (witness.Proof, error) {
@@ -390,10 +411,18 @@ func (a *ArchiveTrie) GetDiff(srcBlock, trgBlock uint64) (Diff, error) {
 		a.rootsMutex.Unlock()
 		return Diff{}, fmt.Errorf("target block %d not present in archive, highest block is %d", trgBlock, a.roots.length()-1)
 	}
-	before := a.roots.get(srcBlock).NodeRef
-	after := a.roots.get(trgBlock).NodeRef
+	before, err := a.roots.get(srcBlock)
+	if err != nil {
+		a.rootsMutex.Unlock()
+		return Diff{}, err
+	}
+	after, err := a.roots.get(trgBlock)
+	if err != nil {
+		a.rootsMutex.Unlock()
+		return Diff{}, err
+	}
 	a.rootsMutex.Unlock()
-	return GetDiff(a.forest, &before, &after)
+	return GetDiff(a.forest, &before.NodeRef, &after.NodeRef)
 }
 
 // GetDiffForBlock computes the diff introduced by the given block compared to its
@@ -405,9 +434,13 @@ func (a *ArchiveTrie) GetDiffForBlock(block uint64) (Diff, error) {
 			a.rootsMutex.Unlock()
 			return Diff{}, fmt.Errorf("archive is empty, no diff present for block 0")
 		}
-		after := a.roots.get(0).NodeRef
+		after, err := a.roots.get(0)
+		if err != nil {
+			a.rootsMutex.Unlock()
+			return Diff{}, err
+		}
 		a.rootsMutex.Unlock()
-		return GetDiff(a.forest, &emptyNodeReference, &after)
+		return GetDiff(a.forest, &emptyNodeReference, &after.NodeRef)
 	}
 	return a.GetDiff(block-1, block)
 }
@@ -424,22 +457,15 @@ func (a *ArchiveTrie) GetMemoryFootprint() *common.MemoryFootprint {
 func (a *ArchiveTrie) Check() error {
 	roots := make([]*NodeReference, a.roots.length())
 	for i := 0; i < a.roots.length(); i++ {
-		roots[i] = &a.roots.roots[i].NodeRef
+		rootm, err := a.roots.get(uint64(i))
+		if err != nil {
+			return err
+		}
+		roots[i] = &rootm.NodeRef
 	}
 	return errors.Join(
 		a.CheckErrors(),
 		a.forest.CheckAll(roots))
-}
-
-func (a *ArchiveTrie) Dump() {
-	a.rootsMutex.Lock()
-	defer a.rootsMutex.Unlock()
-	for i, root := range a.roots.roots {
-		fmt.Printf("\nBlock %d: %x\n", i, root.Hash)
-		view := getTrieView(root.NodeRef, a.forest)
-		view.Dump()
-		fmt.Printf("\n")
-	}
 }
 
 func (a *ArchiveTrie) Flush() error {
@@ -576,9 +602,13 @@ func (a *ArchiveTrie) getView(block uint64) (*LiveTrie, error) {
 		a.rootsMutex.Unlock()
 		return nil, fmt.Errorf("invalid block: %d >= %d", block, length)
 	}
-	rootRef := a.roots.roots[block].NodeRef
+	root, err := a.roots.get(block)
+	if err != nil {
+		a.rootsMutex.Unlock()
+		return nil, err
+	}
 	a.rootsMutex.Unlock()
-	return getTrieView(rootRef, a.forest), nil
+	return getTrieView(root.NodeRef, a.forest), nil
 }
 
 // CheckErrors returns a non-nil error should any error
@@ -616,24 +646,48 @@ func (a *ArchiveTrie) GetConfig() MptConfig {
 // rootList is a utility type managing an in-memory copy of the list of roots
 // of an archive and its synchronization with an on-disk file copy.
 type rootList struct {
-	roots          []Root
-	filename       string // < the file storing the list of roots
-	directory      string // < the directory for checkpoint data
-	numRootsInFile int
+	roots     *kv_file.KVCachedFile[uint64, Root] // < the in-memory copy of the roots list
+	filename  string                              // < the file storing the list of roots
+	directory string                              // < the directory for checkpoint data
+
+	numRoots       int // < total number of roots
+	numRootsInFile int // < number of roots stored in the file
 
 	checkpoint checkpoint.Checkpoint
 }
 
 func (l *rootList) length() int {
-	return len(l.roots)
+	return l.numRoots
 }
 
-func (l *rootList) get(block uint64) Root {
-	return l.roots[block]
+func (l *rootList) get(block uint64) (Root, error) {
+	root, err := l.roots.Get(block)
+	if err != nil {
+		return Root{}, err
+	}
+	if root == nil {
+		return Root{}, fmt.Errorf("root for block %d not found", block)
+	}
+	return *root, nil
 }
 
-func (l *rootList) append(r Root) {
-	l.roots = append(l.roots, r)
+func (l *rootList) append(r Root) error {
+	if err := l.roots.Set(uint64(l.numRoots), r); err != nil {
+		return err
+	}
+	l.numRoots++
+	return nil
+}
+
+// Close releases the resources backing the root list. After Close, the list
+// must not be used any further.
+func (l *rootList) Close() error {
+	if l.roots == nil {
+		return nil
+	}
+	err := l.roots.Close()
+	l.roots = nil
+	return err
 }
 
 func loadRoots(archiveDirectory string) (_ *rootList, retErr error) {
@@ -644,13 +698,6 @@ func loadRoots(archiveDirectory string) (_ *rootList, retErr error) {
 	if err := os.MkdirAll(directory, 0700); err != nil {
 		return nil, err
 	}
-	// If there is no file, initialize and return an empty list.
-	if _, err := os.Stat(filename); err != nil {
-		return &rootList{
-			filename:  filename,
-			directory: directory,
-		}, nil
-	}
 
 	committedCheckpointFile := filepath.Join(directory, fileNameArchiveRootsCommittedCheckpoint)
 	checkpointData, err := readRootListCheckpointData(committedCheckpointFile)
@@ -658,93 +705,131 @@ func loadRoots(archiveDirectory string) (_ *rootList, retErr error) {
 		return nil, err
 	}
 
-	f, err := os.Open(filename)
+	// OpenOrderedFile creates the underlying file if it does not yet exist,
+	// so a fresh archive directory yields an empty root list.
+	entrySize := uint64(NodeIdEncoder{}.GetEncodedSize() + 32)
+	roots, err := kv_file.OpenOrderedFile(filename, entrySize, readRoot, writeRoot)
 	if err != nil {
 		return nil, err
 	}
-	defer func() { retErr = errors.Join(retErr, f.Close()) }()
-	stat, err := f.Stat()
+	kvFile, err := kv_file.OpenKVCachedFile[uint64, Root](roots, 10000, 1000)
 	if err != nil {
-		return nil, err
+		return nil, errors.Join(err, roots.Close())
 	}
 
-	reader := bufio.NewReader(f)
-	roots, err := loadRootsFrom(reader, stat.Size())
+	// Verify that the on-disk file is a whole number of root entries.
+	fileSize, err := kvFile.FileSize()
 	if err != nil {
-		return nil, err
+		return nil, errors.Join(err, kvFile.Close())
 	}
+	if fileSize%entrySize != 0 {
+		return nil, errors.Join(
+			fmt.Errorf("invalid root file format: size %d is not a multiple of entry size %d", fileSize, entrySize),
+			kvFile.Close(),
+		)
+	}
+
+	size, err := kvFile.Size()
+	if err != nil {
+		return nil, errors.Join(err, kvFile.Close())
+	}
+	if int(size) < checkpointData.NumRoots {
+		return nil, errors.Join(
+			fmt.Errorf("root list file is corrupted: expected at least %d roots, but found only %d", checkpointData.NumRoots, size),
+			kvFile.Close(),
+		)
+	}
+
 	return &rootList{
-		roots:          roots,
+		roots:          kvFile,
 		filename:       filename,
 		directory:      directory,
-		numRootsInFile: len(roots),
+		numRoots:       int(size),
+		numRootsInFile: int(size),
 		checkpoint:     checkpointData.Checkpoint,
 	}, nil
 }
 
-func loadRootsFrom(reader io.Reader, sizeInBytes int64) ([]Root, error) {
+// readRoot reads a single root from the given reader.
+// Key is skipped, as the file it's ordered
+func readRoot(reader io.Reader) (uint64, Root, error) {
 	encoder := NodeIdEncoder{}
-	res := make([]Root, 0, sizeInBytes/int64(encoder.GetEncodedSize()+32)) // NodeID size + 32 bytes Hash size
 	buffer := make([]byte, encoder.GetEncodedSize())
 	var hash common.Hash
-	for {
-		if _, err := io.ReadFull(reader, buffer); err != nil {
-			if err == io.EOF {
-				return res, nil
-			}
-			return nil, fmt.Errorf("invalid root file format: %v", err)
-		}
-
-		if _, err := io.ReadFull(reader, hash[:]); err != nil {
-			return nil, fmt.Errorf("invalid root file format: %v", err)
-		}
-
-		var id NodeId
-		encoder.Load(buffer, &id)
-		res = append(res, Root{NewNodeReference(id), hash})
-	}
-}
-
-func StoreRoots(filename string, roots []Root) error {
-	list := rootList{roots: roots, filename: filename}
-	return list.storeRoots()
-}
-
-func (l *rootList) storeRoots() error {
-	toBeWritten := l.roots[l.numRootsInFile:]
-	if l.numRootsInFile > 0 && len(toBeWritten) == 0 {
-		return nil
+	if _, err := io.ReadFull(reader, buffer); err != nil {
+		return 0, Root{}, fmt.Errorf("invalid root file format: %v", err)
 	}
 
-	f, err := os.OpenFile(l.filename, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+	if _, err := io.ReadFull(reader, hash[:]); err != nil {
+		return 0, Root{}, fmt.Errorf("invalid root file format: %v", err)
+	}
+
+	var id NodeId
+	encoder.Load(buffer, &id)
+	return 0, Root{NewNodeReference(id), hash}, nil
+}
+
+// writeRoot writes a single root to the given writer with the format
+// [<node-id>, <state-hash>].
+func writeRoot(writer io.Writer, pos uint64, root Root) error {
+	// Format: [<node-id>, <state-hash>]*
+	encoder := NodeIdEncoder{}
+	buffer := make([]byte, encoder.GetEncodedSize())
+	encoder.Store(buffer, &root.NodeRef.id)
+	if _, err := writer.Write(buffer[:]); err != nil {
+		return err
+	}
+	if _, err := writer.Write(root.Hash[:]); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (l *rootList) GetAll() ([]Root, error) {
+	seq, err := l.roots.Iterate()
+	if err != nil {
+		return nil, err
+	}
+	allRoots := make([]Root, l.numRoots)
+	for i, root := range seq {
+		if i >= uint64(len(allRoots)) {
+			continue
+		}
+		allRoots[i] = root
+	}
+	return allRoots, nil
+}
+
+func StoreRoots(filename string, rootsToWrite []Root) error {
+	// loadRoots derives the roots file path from the directory and the
+	// canonical filename. Reject inputs that would otherwise cause writes to
+	// silently target a different path than the caller requested.
+	if base := filepath.Base(filename); base != fileNameArchiveRoots {
+		return fmt.Errorf("StoreRoots: unsupported roots filename %q, expected %q", base, fileNameArchiveRoots)
+	}
+	roots, err := loadRoots(filepath.Dir(filename))
 	if err != nil {
 		return err
 	}
-	writer := bufio.NewWriter(f)
-	res := errors.Join(
-		storeRootsTo(writer, toBeWritten),
-		writer.Flush(),
-		f.Close(),
-	)
-	if res == nil {
-		l.numRootsInFile = len(l.roots)
+	defer func() {
+		err = errors.Join(err, roots.Close())
+	}()
+	for _, root := range rootsToWrite {
+		if err = roots.append(root); err != nil {
+			return err
+		}
 	}
-	return res
+	if err = roots.storeRoots(); err != nil {
+		return err
+	}
+	return nil
 }
 
-func storeRootsTo(writer io.Writer, roots []Root) error {
-	// Simple file format: [<node-id><state-hash>]*
-	encoder := NodeIdEncoder{}
-	buffer := make([]byte, encoder.GetEncodedSize())
-	for _, root := range roots {
-		encoder.Store(buffer, &root.NodeRef.id)
-		if _, err := writer.Write(buffer[:]); err != nil {
-			return err
-		}
-		if _, err := writer.Write(root.Hash[:]); err != nil {
-			return err
-		}
+func (l *rootList) storeRoots() error {
+	if err := l.roots.Flush(); err != nil {
+		return err
 	}
+	l.numRootsInFile = l.numRoots
 	return nil
 }
 
@@ -771,7 +856,7 @@ func (l *rootList) Prepare(checkpoint checkpoint.Checkpoint) error {
 	pendingFile := filepath.Join(l.directory, fileNameArchiveRootsPreparedCheckpoint)
 	return writeRootListCheckpointData(pendingFile, rootListCheckpointData{
 		Checkpoint: checkpoint,
-		NumRoots:   l.length(),
+		NumRoots:   l.numRootsInFile,
 	})
 }
 

--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"iter"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -159,24 +160,20 @@ func OpenArchiveTrie(
 // VerifyArchiveTrie validates file-based archive stored in the given directory.
 // If the test passes, the data stored in the respective directory
 // can be considered a valid archive database of the given configuration.
-func VerifyArchiveTrie(ctx context.Context, directory string, config MptConfig, observer VerificationObserver) error {
+func VerifyArchiveTrie(ctx context.Context, directory string, config MptConfig, observer VerificationObserver) (res error) {
 	roots, err := loadRoots(directory)
 	if err != nil {
 		return err
 	}
+	defer func() { res = errors.Join(res, roots.Close()) }()
 	if roots.length() == 0 {
-		return roots.Close()
+		return nil
 	}
-	rootsList, err := roots.GetAll()
+	rootsSeq, err := roots.Iterate()
 	if err != nil {
-		return errors.Join(err, roots.Close())
-	}
-	// The roots are fully loaded into memory; release the file before the
-	// verification starts.
-	if err := roots.Close(); err != nil {
 		return err
 	}
-	return VerifyMptState(ctx, directory, config, rootsList, observer)
+	return VerifyMptState(ctx, directory, config, rootsSeq, observer)
 }
 
 func (a *ArchiveTrie) Add(block uint64, update common.Update, hint any) error {
@@ -797,19 +794,9 @@ func writeRoot(writer io.Writer, pos uint64, root Root) error {
 	return nil
 }
 
-func (l *rootList) GetAll() ([]Root, error) {
-	seq, err := l.roots.Iterate()
-	if err != nil {
-		return nil, err
-	}
-	allRoots := make([]Root, l.numRoots)
-	for i, root := range seq {
-		if i >= uint64(len(allRoots)) {
-			continue
-		}
-		allRoots[i] = root
-	}
-	return allRoots, nil
+// Iterate returns a sequence of all (block, root) pairs in the list.
+func (l *rootList) Iterate() (iter.Seq2[uint64, Root], error) {
+	return l.roots.Iterate()
 }
 
 func StoreRoots(filename string, rootsToWrite []Root) (err error) {

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -1815,9 +1815,9 @@ func TestArchiveTrie_StoreLoadRoots(t *testing.T) {
 	}
 	for i := 0; i < 48; i++ {
 		id := NodeId(uint64(1) << i)
-		original.append(Root{NodeRef: NewNodeReference(id)})
+		require.NoError(original.append(Root{NodeRef: NewNodeReference(id)}))
 		id = NodeId((uint64(1) << (i + 1)) - 1)
-		original.append(Root{NodeRef: NewNodeReference(id)})
+		require.NoError(original.append(Root{NodeRef: NewNodeReference(id)}))
 	}
 
 	if err := original.storeRoots(); err != nil {
@@ -1873,16 +1873,16 @@ func TestArchiveTrie_RootListStoreOnlyWritesNewRoots(t *testing.T) {
 	}
 
 	// First round: 3 new roots.
-	list.append(Root{NodeRef: NewNodeReference(ValueId(1))})
-	list.append(Root{NodeRef: NewNodeReference(ValueId(2))})
-	list.append(Root{NodeRef: NewNodeReference(ValueId(3))})
+	require.NoError(t, list.append(Root{NodeRef: NewNodeReference(ValueId(1))}))
+	require.NoError(t, list.append(Root{NodeRef: NewNodeReference(ValueId(2))}))
+	require.NoError(t, list.append(Root{NodeRef: NewNodeReference(ValueId(3))}))
 	if err := list.storeRoots(); err != nil {
 		t.Fatalf("failed to store roots: %v", err)
 	}
 
 	// Second round: 2 additional new roots.
-	list.append(Root{NodeRef: NewNodeReference(ValueId(4))})
-	list.append(Root{NodeRef: NewNodeReference(ValueId(5))})
+	require.NoError(t, list.append(Root{NodeRef: NewNodeReference(ValueId(4))}))
+	require.NoError(t, list.append(Root{NodeRef: NewNodeReference(ValueId(5))}))
 	if err := list.storeRoots(); err != nil {
 		t.Fatalf("failed to store roots: %v", err)
 	}
@@ -1922,7 +1922,7 @@ func TestArchiveTrie_IncrementalRootListUpdates(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		for j := 0; j < 10; j++ {
 			id := NodeId(counter)
-			list.append(Root{NodeRef: NewNodeReference(id)})
+			require.NoError(t, list.append(Root{NodeRef: NewNodeReference(id)}))
 			counter++
 		}
 		if err := list.storeRoots(); err != nil {
@@ -1997,7 +1997,7 @@ func TestArchiveTrie_FileAccessErrorWhenStoringRootsIsDetected(t *testing.T) {
 		directory: filepath.Join(dir, fileNameArchiveRootsCheckpointDirectory),
 	}
 
-	list.append(Root{})
+	require.NoError(t, list.append(Root{}))
 	if err := list.storeRoots(); !errors.Is(err, injectedErr) {
 		t.Errorf("expected injected error when storing roots into non-accessible file, got %v", err)
 	}
@@ -2010,8 +2010,8 @@ func TestRootList_CanParticipateToCheckpointOperations(t *testing.T) {
 		t.Fatalf("failed to load roots: %v", err)
 	}
 
-	roots.append(Root{NodeRef: NewNodeReference(ValueId(1))})
-	roots.append(Root{NodeRef: NewNodeReference(ValueId(2))})
+	require.NoError(t, roots.append(Root{NodeRef: NewNodeReference(ValueId(1))}))
+	require.NoError(t, roots.append(Root{NodeRef: NewNodeReference(ValueId(2))}))
 
 	if want, got := 2, roots.length(); want != got {
 		t.Fatalf("invalid number of roots, wanted %d, got %d", want, got)
@@ -2027,7 +2027,7 @@ func TestRootList_CanParticipateToCheckpointOperations(t *testing.T) {
 		t.Fatalf("failed to create checkpoint: %v", err)
 	}
 
-	roots.append(Root{NodeRef: NewNodeReference(ValueId(3))})
+	require.NoError(t, roots.append(Root{NodeRef: NewNodeReference(ValueId(3))}))
 	if err := roots.storeRoots(); err != nil {
 		t.Fatalf("failed to store roots: %v", err)
 	}
@@ -2141,7 +2141,7 @@ func TestArchiveTrie_FailingOperation_InvalidatesOtherArchiveOperations(t *testi
 			roots, err := loadRoots(t.TempDir())
 			require.NoError(t, err)
 			archive := &ArchiveTrie{forest: db, head: live, roots: roots}
-			archive.roots.append(Root{NodeRef: NewNodeReference(ValueId(1))})
+			require.NoError(t, archive.roots.append(Root{NodeRef: NewNodeReference(ValueId(1))}))
 
 			// all operations must fail
 			for _, name := range rotate(names, i) {
@@ -2221,7 +2221,7 @@ func TestArchiveTrie_FailingLiveStateUpdate_InvalidatesArchive(t *testing.T) {
 			roots, err := loadRoots(t.TempDir())
 			require.NoError(t, err)
 			archive := &ArchiveTrie{forest: db, head: liveState, roots: roots}
-			archive.roots.append(Root{NodeRef: NewNodeReference(ValueId(1))})
+			require.NoError(t, archive.roots.append(Root{NodeRef: NewNodeReference(ValueId(1))}))
 			defer func() {
 				if err := archive.Close(); !errors.Is(err, injectedErr) {
 					t.Errorf("expected error does not match: %v != %v", err, injectedErr)
@@ -3026,7 +3026,7 @@ func TestRootList_LoadRoots_ForwardsIoIssues(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to load roots: %v", err)
 			}
-			roots.append(Root{NodeRef: NewNodeReference(ValueId(1))})
+			require.NoError(t, roots.append(Root{NodeRef: NewNodeReference(ValueId(1))}))
 
 			cp := checkpoint.Checkpoint(1)
 			err = errors.Join(
@@ -3147,8 +3147,8 @@ func TestRootList_Prepare_FlushesRootsToDisk(t *testing.T) {
 		t.Fatalf("failed to load roots: %v", err)
 	}
 
-	roots.append(Root{NodeRef: NewNodeReference(ValueId(1))})
-	roots.append(Root{NodeRef: NewNodeReference(ValueId(2))})
+	require.NoError(t, roots.append(Root{NodeRef: NewNodeReference(ValueId(1))}))
+	require.NoError(t, roots.append(Root{NodeRef: NewNodeReference(ValueId(2))}))
 
 	if want, got := 0, roots.numRootsInFile; want != got {
 		t.Fatalf("unexpected number of roots in file, wanted %d, got %d", want, got)
@@ -3202,7 +3202,7 @@ func TestRootList_Prepare_DetectsFlushIssue(t *testing.T) {
 		filename:  filepath.Join(dir, fileNameArchiveRoots),
 		directory: checkpointDir,
 	}
-	roots.append(Root{NodeRef: NewNodeReference(ValueId(1))})
+	require.NoError(t, roots.append(Root{NodeRef: NewNodeReference(ValueId(1))}))
 
 	cp := checkpoint.Checkpoint(1)
 	if err := roots.Prepare(cp); !errors.Is(err, injectedErr) {
@@ -3318,8 +3318,8 @@ func TestRootList_Restore_CanRecoverCorruptedRoots(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to load roots: %v", err)
 			}
-			roots.append(Root{NodeRef: NewNodeReference(ValueId(123))})
-			roots.append(Root{NodeRef: NewNodeReference(ValueId(123))})
+			require.NoError(t, roots.append(Root{NodeRef: NewNodeReference(ValueId(123))}))
+			require.NoError(t, roots.append(Root{NodeRef: NewNodeReference(ValueId(123))}))
 
 			cp := checkpoint.Checkpoint(1)
 			if err := roots.Prepare(cp); err != nil {
@@ -3435,8 +3435,8 @@ func TestRootList_getNumRootsInCheckpoint_RetrievesRootHeightFromCommittedOrPend
 	if err != nil {
 		t.Fatalf("failed to load roots: %v", err)
 	}
-	roots.append(Root{NodeRef: NewNodeReference(ValueId(1))})
-	roots.append(Root{NodeRef: NewNodeReference(ValueId(2))})
+	require.NoError(t, roots.append(Root{NodeRef: NewNodeReference(ValueId(1))}))
+	require.NoError(t, roots.append(Root{NodeRef: NewNodeReference(ValueId(2))}))
 
 	err = errors.Join(
 		roots.Prepare(1),
@@ -3446,7 +3446,7 @@ func TestRootList_getNumRootsInCheckpoint_RetrievesRootHeightFromCommittedOrPend
 		t.Fatalf("failed to create checkpoint: %v", err)
 	}
 
-	roots.append(Root{NodeRef: NewNodeReference(ValueId(3))})
+	require.NoError(t, roots.append(Root{NodeRef: NewNodeReference(ValueId(3))}))
 	if err := roots.Prepare(2); err != nil {
 		t.Fatalf("failed to prepare checkpoint: %v", err)
 	}
@@ -3485,9 +3485,9 @@ func TestRootList_truncate_ShortensTheRootFileAndUpdatesTheLastCheckpoint(t *tes
 		t.Fatalf("failed to load roots: %v", err)
 	}
 
-	roots.append(Root{NodeRef: NewNodeReference(ValueId(1))})
-	roots.append(Root{NodeRef: NewNodeReference(ValueId(2))})
-	roots.append(Root{NodeRef: NewNodeReference(ValueId(3))})
+	require.NoError(t, roots.append(Root{NodeRef: NewNodeReference(ValueId(1))}))
+	require.NoError(t, roots.append(Root{NodeRef: NewNodeReference(ValueId(2))}))
+	require.NoError(t, roots.append(Root{NodeRef: NewNodeReference(ValueId(3))}))
 
 	if err := roots.storeRoots(); err != nil {
 		t.Fatalf("failed to store roots: %v", err)
@@ -3545,9 +3545,9 @@ func TestRootList_truncate_FailsIfCurrentListIsTooShort(t *testing.T) {
 		t.Fatalf("failed to load roots: %v", err)
 	}
 
-	roots.append(Root{NodeRef: NewNodeReference(ValueId(1))})
-	roots.append(Root{NodeRef: NewNodeReference(ValueId(2))})
-	roots.append(Root{NodeRef: NewNodeReference(ValueId(3))})
+	require.NoError(t, roots.append(Root{NodeRef: NewNodeReference(ValueId(1))}))
+	require.NoError(t, roots.append(Root{NodeRef: NewNodeReference(ValueId(2))}))
+	require.NoError(t, roots.append(Root{NodeRef: NewNodeReference(ValueId(3))}))
 
 	if err := roots.storeRoots(); err != nil {
 		t.Fatalf("failed to store roots: %v", err)

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -1978,11 +1978,11 @@ func TestArchiveTrie_IncrementalRootListUpdates(t *testing.T) {
 			t.Fatalf("failed to reload roots: %v", err)
 		}
 
-		wantRoots, err := list.GetAll()
+		wantRoots, err := collectRoots(list)
 		if err != nil {
 			t.Fatalf("failed to fetch stored roots: %v", err)
 		}
-		gotRoots, err := restored.GetAll()
+		gotRoots, err := collectRoots(restored)
 		if err != nil {
 			t.Fatalf("failed to fetch restored roots: %v", err)
 		}
@@ -2011,7 +2011,7 @@ func TestArchiveTrie_DirectlyStoredRootsCanBeRestored(t *testing.T) {
 		t.Fatalf("failed to load roots: %v", err)
 	}
 
-	got, err := restored.GetAll()
+	got, err := collectRoots(restored)
 	if err != nil {
 		t.Fatalf("failed to fetch restored roots: %v", err)
 	}
@@ -2044,6 +2044,79 @@ func TestArchiveTrie_FileAccessErrorWhenStoringRootsIsDetected(t *testing.T) {
 	require.NoError(t, list.append(Root{}))
 	if err := list.storeRoots(); !errors.Is(err, injectedErr) {
 		t.Errorf("expected injected error when storing roots into non-accessible file, got %v", err)
+	}
+}
+
+func TestRootList_Iterate_YieldsAllAppendedRoots(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	list, err := loadRoots(dir)
+	require.NoError(err)
+
+	want := []Root{
+		{NodeRef: NewNodeReference(ValueId(1)), Hash: common.Hash{1}},
+		{NodeRef: NewNodeReference(ValueId(2)), Hash: common.Hash{2}},
+		{NodeRef: NewNodeReference(ValueId(3)), Hash: common.Hash{3}},
+	}
+	for _, r := range want {
+		require.NoError(list.append(r))
+	}
+
+	seq, err := list.Iterate()
+	require.NoError(err)
+
+	got := map[uint64]Root{}
+	for block, r := range seq {
+		got[block] = r
+	}
+	require.Len(got, len(want))
+	for i, r := range want {
+		require.Equal(r, got[uint64(i)])
+	}
+}
+
+func TestRootList_Iterate_EmptyListYieldsNothing(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	list, err := loadRoots(dir)
+	require.NoError(err)
+
+	seq, err := list.Iterate()
+	require.NoError(err)
+
+	count := 0
+	for range seq {
+		count++
+	}
+	require.Zero(count)
+}
+
+func TestRootList_Iterate_CanBeInvokedMultipleTimes(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	list, err := loadRoots(dir)
+	require.NoError(err)
+
+	want := []Root{
+		{NodeRef: NewNodeReference(ValueId(7)), Hash: common.Hash{7}},
+		{NodeRef: NewNodeReference(ValueId(8)), Hash: common.Hash{8}},
+	}
+	for _, r := range want {
+		require.NoError(list.append(r))
+	}
+
+	seq, err := list.Iterate()
+	require.NoError(err)
+
+	for pass := 0; pass < 2; pass++ {
+		got := map[uint64]Root{}
+		for block, r := range seq {
+			got[block] = r
+		}
+		require.Len(got, len(want), "pass %d", pass)
+		for i, r := range want {
+			require.Equal(r, got[uint64(i)], "pass %d", pass)
+		}
 	}
 }
 
@@ -3623,6 +3696,22 @@ func TestRootList_truncateRootsFile_FailsForNonExistingFile(t *testing.T) {
 	if err := truncateRootsFile(file, 4); err == nil {
 		t.Fatalf("expected error when truncating non-existing file")
 	}
+}
+
+// collectRoots returns all roots stored in the given list as a slice.
+func collectRoots(l *rootList) ([]Root, error) {
+	seq, err := l.Iterate()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Root, l.length())
+	for i, r := range seq {
+		if i >= uint64(len(out)) {
+			continue
+		}
+		out[i] = r
+	}
+	return out, nil
 }
 
 func BenchmarkArchiveFlush_Roots(b *testing.B) {

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -85,6 +85,50 @@ func TestArchiveTrie_CanBeReOpened(t *testing.T) {
 	}
 }
 
+func TestArchiveTrie_Reopen_PreservesAllBlockRootHashes(t *testing.T) {
+	for _, config := range allMptConfigs {
+		t.Run(config.Name, func(t *testing.T) {
+			require := require.New(t)
+			dir := t.TempDir()
+
+			const blocks = 10
+			hashes := make([]common.Hash, blocks)
+
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
+			require.NoError(err)
+
+			for i := 0; i < blocks; i++ {
+				update := common.Update{
+					Balances: []common.BalanceUpdate{
+						{Account: common.Address{byte(i + 1)}, Balance: amount.New(uint64(i + 1))},
+					},
+				}
+				require.NoError(archive.Add(uint64(i), update, nil))
+				hash, err := archive.GetHash(uint64(i))
+				require.NoError(err)
+				hashes[i] = hash
+			}
+
+			require.NoError(archive.Close())
+
+			archive, err = OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
+			require.NoError(err)
+			defer func() { require.NoError(archive.Close()) }()
+
+			height, empty, err := archive.GetBlockHeight()
+			require.NoError(err)
+			require.False(empty)
+			require.Equal(uint64(blocks-1), height)
+
+			for i := 0; i < blocks; i++ {
+				got, err := archive.GetHash(uint64(i))
+				require.NoError(err)
+				require.Equal(hashes[i], got, "hash mismatch for block %d", i)
+			}
+		})
+	}
+}
+
 func TestArchiveTrie_Open_LastCheckpointTimeIsSelectedRandomly(t *testing.T) {
 
 	config := ArchiveConfig{

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -11,7 +11,6 @@
 package mpt
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -28,6 +27,7 @@ import (
 	"time"
 
 	"github.com/0xsoniclabs/carmen/go/backend/archive"
+	"github.com/0xsoniclabs/carmen/go/backend/kv_file"
 	"github.com/0xsoniclabs/carmen/go/backend/utils"
 	"github.com/0xsoniclabs/carmen/go/backend/utils/checkpoint"
 	"github.com/0xsoniclabs/carmen/go/common"
@@ -853,7 +853,13 @@ func TestArchiveTrie_Add_UpdateFailsHashing(t *testing.T) {
 	live.EXPECT().Flush()
 	live.EXPECT().closeWithError(gomock.Any())
 
-	archive := &ArchiveTrie{head: live, forest: db, roots: &rootList{}}
+	// A real (temp-file backed) root list is required because filling the
+	// skipped blocks appends to the paged array.
+	roots, err := loadRoots(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to load roots: %v", err)
+	}
+	archive := &ArchiveTrie{head: live, forest: db, roots: roots}
 	defer func() {
 		if err := archive.Close(); !errors.Is(err, injectedError) {
 			t.Errorf("closing should fail, got %v, want: %v", err, injectedError)
@@ -1069,42 +1075,6 @@ func TestArchiveTrie_Add_FailingToCreateCheckpointsIsDetected(t *testing.T) {
 	}
 }
 
-func TestArchiveTrie_RootsGrowSubLinearly(t *testing.T) {
-	dir := t.TempDir()
-	roots, err := loadRoots(dir)
-	if err != nil {
-		t.Fatalf("failed to create empty root list: %v", err)
-	}
-
-	// Golang slices grow by the factor of 2 when they are small,
-	// while they grow slower when they become huge.
-	// The slice 'archive.roots' contains millions of elements
-	// stored as GiBs in memory.
-	// This test verifies that the slices grow slower for huge arrays
-	// to ensure that memory consumption is not doubled every time
-	// the slice grows.
-	// This feature cannot be customized, i.e., this test verifies
-	// that the described assumption will hold in future versions
-	// of golang and/or runtime configurations.
-
-	const size = 100_000
-	const threshold = 10_000
-	const factor = 1.3
-
-	var prevCap int
-	for i := 0; i < size; i++ {
-		roots.append(Root{})
-
-		if i > threshold {
-			if got, want := cap(roots.roots), int(factor*float64(prevCap)); got >= want {
-				t.Fatalf("array grows too fast: %d >= %d", got, want)
-			}
-		}
-
-		prevCap = cap(roots.roots)
-	}
-}
-
 func TestArchiveTrie_Add_LiveStateFailsHashing(t *testing.T) {
 	// inject a failing hasher
 	var injectedError = errors.New("injectedError")
@@ -1114,7 +1084,11 @@ func TestArchiveTrie_Add_LiveStateFailsHashing(t *testing.T) {
 	live.EXPECT().Flush()
 	live.EXPECT().closeWithError(gomock.Any())
 
-	archive := &ArchiveTrie{head: live, roots: &rootList{}}
+	roots, err := loadRoots(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to load roots: %v", err)
+	}
+	archive := &ArchiveTrie{head: live, roots: roots}
 	defer func() {
 		if err := archive.Close(); !errors.Is(err, injectedError) {
 			t.Errorf("closing should fail, got %v, want: %v", err, injectedError)
@@ -1140,7 +1114,11 @@ func TestArchiveTrie_Add_LiveStateFailsCreateAccount(t *testing.T) {
 	live.EXPECT().Flush()
 	live.EXPECT().closeWithError(gomock.Any())
 
-	archive := &ArchiveTrie{head: live, roots: &rootList{}}
+	roots, err := loadRoots(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to load roots: %v", err)
+	}
+	archive := &ArchiveTrie{head: live, roots: roots}
 	defer func() {
 		if err := archive.Close(); !errors.Is(err, injectedError) {
 			t.Errorf("closing should fail, got %v, want: %v", err, injectedError)
@@ -1168,7 +1146,11 @@ func TestArchiveTrie_Add_FreezingFails(t *testing.T) {
 	live.EXPECT().Flush()
 	live.EXPECT().closeWithError(gomock.Any())
 
-	archive := &ArchiveTrie{head: live, forest: db, roots: &rootList{}}
+	roots, err := loadRoots(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to load roots: %v", err)
+	}
+	archive := &ArchiveTrie{head: live, forest: db, roots: roots}
 	defer func() {
 		if err := archive.Close(); !errors.Is(err, injectedErr) {
 			t.Errorf("closing should fail, got %v, want: %v", err, injectedErr)
@@ -1736,31 +1718,6 @@ func TestArchiveTrie_GetMemoryFootprint(t *testing.T) {
 	}
 }
 
-func TestArchiveTrie_Dump(t *testing.T) {
-	for _, config := range allMptConfigs {
-		t.Run(config.Name, func(t *testing.T) {
-			dir := t.TempDir()
-			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
-			if err != nil {
-				t.Fatalf("failed to create empty archive, err %v", err)
-			}
-			defer func() {
-				if err := archive.Close(); err != nil {
-					t.Errorf("failed to close archive: %v", err)
-				}
-			}()
-
-			if err = archive.Add(0, common.Update{
-				Balances: []common.BalanceUpdate{{Account: common.Address{1}, Balance: amount.New(1)}},
-			}, nil); err != nil {
-				t.Fatalf("cannot apply update: %s", err)
-			}
-
-			archive.Dump()
-		})
-	}
-}
-
 func TestArchiveTrie_VerificationOfArchiveWithMissingFileFails(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
@@ -1846,49 +1803,8 @@ func TestArchiveTrie_VerificationOfArchiveWithCorruptedFileFails(t *testing.T) {
 	}
 }
 
-func TestArchiveTrie_CanLoadRootsFromJunkySource(t *testing.T) {
-
-	roots := []Root{
-		{NewNodeReference(ValueId(12)), common.Hash{12}},
-		{NewNodeReference(ValueId(14)), common.Hash{14}},
-	}
-
-	var b bytes.Buffer
-	writer := bufio.NewWriter(&b)
-	require.NoError(t, storeRootsTo(writer, roots))
-	require.NoError(t, writer.Flush())
-
-	for _, size := range []int{1, 2, 4, 1024} {
-		reader := utils.NewChunkReader(b.Bytes(), size)
-		res, err := loadRootsFrom(reader, int64(b.Len()))
-		if err != nil {
-			t.Fatalf("error loading roots: %v", err)
-		}
-		if !reflect.DeepEqual(roots, res) {
-			t.Errorf("failed to restore roots, wanted %v, got %v", roots, res)
-		}
-	}
-}
-
-func TestArchiveTrie_LoadRootsCapacityIsCorrect(t *testing.T) {
-	for _, size := range []int64{1, 2, 3, 5, 10, 20, 30, 50, 100, 200, 300, 500, 1000, 2000, 3000, 5000, 10000} {
-		reader := bytes.NewReader([]byte{})
-		res, err := loadRootsFrom(reader, size)
-		if err != nil {
-			t.Fatalf("error loading roots: %v", err)
-		}
-		if len(res) != 0 {
-			t.Errorf("unexpected len, wanted 0, got %d", len(res))
-		}
-
-		expected := size / int64(NodeIdEncoder{}.GetEncodedSize()+32)
-		if got, want := cap(res), int(expected); got > want {
-			t.Errorf("unexpected capacity, wanted %d, got %d", want, got)
-		}
-	}
-}
-
 func TestArchiveTrie_StoreLoadRoots(t *testing.T) {
+	require := require.New(t)
 	dir := t.TempDir()
 	original, err := loadRoots(dir)
 	if err != nil {
@@ -1917,9 +1833,11 @@ func TestArchiveTrie_StoreLoadRoots(t *testing.T) {
 	}
 
 	for i := 0; i < original.length(); i++ {
-		want := original.roots[i].NodeRef.Id()
-		got := restored.roots[i].NodeRef.Id()
-		if want != got {
+		want, err := original.get(uint64(i))
+		require.NoError(err)
+		got, err := restored.get(uint64(i))
+		require.NoError(err)
+		if want.NodeRef.Id() != got.NodeRef.Id() {
 			t.Errorf("invalid restored root at position %d, wanted %v, got %v", i, want, got)
 		}
 	}
@@ -1927,40 +1845,66 @@ func TestArchiveTrie_StoreLoadRoots(t *testing.T) {
 
 func TestArchiveTrie_RootListStoreOnlyWritesNewRoots(t *testing.T) {
 	dir := t.TempDir()
-	list, err := loadRoots(dir)
+
+	// Use a mock backing file to record which keys are actually written on
+	// each Flush.
+	ctrl := gomock.NewController(t)
+	file := kv_file.NewMockKVFileWithMemoryFootprint[uint64, Root](ctrl)
+
+	var writtenBatches []map[uint64]Root
+	file.EXPECT().SetBatch(gomock.Any()).DoAndReturn(func(entries map[uint64]Root) error {
+		cp := make(map[uint64]Root, len(entries))
+		for k, v := range entries {
+			cp[k] = v
+		}
+		writtenBatches = append(writtenBatches, cp)
+		return nil
+	}).AnyTimes()
+	file.EXPECT().Flush().Return(nil).AnyTimes()
+
+	cached, err := kv_file.OpenKVCachedFile[uint64, Root](file, 10000, 1000)
 	if err != nil {
-		t.Fatalf("failed to load roots: %v", err)
+		t.Fatalf("failed to open kv cached file: %v", err)
+	}
+	list := &rootList{
+		roots:     cached,
+		filename:  filepath.Join(dir, fileNameArchiveRoots),
+		directory: filepath.Join(dir, fileNameArchiveRootsCheckpointDirectory),
 	}
 
-	// The first write establishes a list of roots in the output file.
-	list.append(Root{})
-	list.append(Root{})
-	list.append(Root{})
+	// First round: 3 new roots.
+	list.append(Root{NodeRef: NewNodeReference(ValueId(1))})
+	list.append(Root{NodeRef: NewNodeReference(ValueId(2))})
+	list.append(Root{NodeRef: NewNodeReference(ValueId(3))})
 	if err := list.storeRoots(); err != nil {
 		t.Fatalf("failed to store roots: %v", err)
 	}
 
-	// We redirect the incremental update into another file to see what is written.
-	oldFile := list.filename
-	newFile := filepath.Join(dir, "new-roots.dat")
-	list.filename = newFile
-	list.append(Root{})
-	list.append(Root{})
+	// Second round: 2 additional new roots.
+	list.append(Root{NodeRef: NewNodeReference(ValueId(4))})
+	list.append(Root{NodeRef: NewNodeReference(ValueId(5))})
 	if err := list.storeRoots(); err != nil {
 		t.Fatalf("failed to store roots: %v", err)
 	}
 
-	if err := os.Rename(newFile, oldFile); err != nil {
-		t.Fatalf("failed to rename file: %v", err)
+	if got := list.length(); got != 5 {
+		t.Fatalf("unexpected number of roots, wanted 5, got %d", got)
+	}
+	if got := list.numRootsInFile; got != 5 {
+		t.Fatalf("unexpected number of roots in file, wanted 5, got %d", got)
 	}
 
-	// Loading the second file should only produce 2 roots.
-	restored, err := loadRoots(dir)
-	if err != nil {
-		t.Fatalf("failed to load roots: %v", err)
+	// storeRoots must have been observed at least once for each round and
+	// must not write more entries than the total appended so far.
+	if len(writtenBatches) < 2 {
+		t.Fatalf("expected at least 2 flushes, got %d", len(writtenBatches))
 	}
-	if want, got := 2, restored.length(); want != got {
-		t.Fatalf("invalid number of restored roots, wanted %d, got %d", want, got)
+	for i, batch := range writtenBatches {
+		for key := range batch {
+			if key >= uint64(list.length()) {
+				t.Errorf("flush %d contains unexpected key %d", i, key)
+			}
+		}
 	}
 }
 
@@ -1990,8 +1934,19 @@ func TestArchiveTrie_IncrementalRootListUpdates(t *testing.T) {
 			t.Fatalf("failed to reload roots: %v", err)
 		}
 
-		if !reflect.DeepEqual(list, restored) {
-			t.Fatalf("failed to restore roots, wanted %v, got %v", list, restored)
+		wantRoots, err := list.GetAll()
+		if err != nil {
+			t.Fatalf("failed to fetch stored roots: %v", err)
+		}
+		gotRoots, err := restored.GetAll()
+		if err != nil {
+			t.Fatalf("failed to fetch restored roots: %v", err)
+		}
+		if !reflect.DeepEqual(wantRoots, gotRoots) {
+			t.Fatalf("failed to restore roots, wanted %v, got %v", wantRoots, gotRoots)
+		}
+		if want, got := list.length(), restored.length(); want != got {
+			t.Fatalf("mismatched root list length, wanted %d, got %d", want, got)
 		}
 	}
 }
@@ -2012,29 +1967,39 @@ func TestArchiveTrie_DirectlyStoredRootsCanBeRestored(t *testing.T) {
 		t.Fatalf("failed to load roots: %v", err)
 	}
 
-	if !reflect.DeepEqual(roots, restored.roots) {
-		t.Errorf("failed to restore roots, wanted %v, got %v", roots, restored.roots)
+	got, err := restored.GetAll()
+	if err != nil {
+		t.Fatalf("failed to fetch restored roots: %v", err)
+	}
+	if !reflect.DeepEqual(roots, got) {
+		t.Errorf("failed to restore roots, wanted %v, got %v", roots, got)
 	}
 }
 
 func TestArchiveTrie_FileAccessErrorWhenStoringRootsIsDetected(t *testing.T) {
 	dir := t.TempDir()
-	list, err := loadRoots(dir)
-	if err != nil {
-		t.Fatalf("failed to load roots: %v", err)
-	}
-	if err := list.storeRoots(); err != nil {
-		t.Fatalf("failed to store empty roots file: %v", err)
-	}
 
-	// remove write access
-	if err := os.Chmod(list.filename, 0x400); err != nil {
-		t.Fatalf("cannot chmod roots file: %v", err)
+	// Use a mock backing file whose SetBatch returns an error to simulate a
+	// write failure when the pending roots are flushed to disk.
+	ctrl := gomock.NewController(t)
+	file := kv_file.NewMockKVFileWithMemoryFootprint[uint64, Root](ctrl)
+	injectedErr := errors.New("injected write failure")
+	file.EXPECT().SetBatch(gomock.Any()).Return(injectedErr).AnyTimes()
+	file.EXPECT().Flush().Return(nil).AnyTimes()
+
+	cached, err := kv_file.OpenKVCachedFile[uint64, Root](file, 10000, 1000)
+	if err != nil {
+		t.Fatalf("failed to open kv cached file: %v", err)
+	}
+	list := &rootList{
+		roots:     cached,
+		filename:  filepath.Join(dir, fileNameArchiveRoots),
+		directory: filepath.Join(dir, fileNameArchiveRootsCheckpointDirectory),
 	}
 
 	list.append(Root{})
-	if err := list.storeRoots(); err == nil {
-		t.Errorf("expected an error when storing roots into non-accessible file")
+	if err := list.storeRoots(); !errors.Is(err, injectedErr) {
+		t.Errorf("expected injected error when storing roots into non-accessible file, got %v", err)
 	}
 }
 
@@ -2133,56 +2098,6 @@ func TestArchiveTrie_QueryLoadTest(t *testing.T) {
 	}
 }
 
-func TestStoreRootsTo_WriterFailures(t *testing.T) {
-	var roots []Root
-	for i := 0; i < 48; i++ {
-		id := NodeId(uint64(1) << i)
-		roots = append(roots, Root{NodeRef: NewNodeReference(id)})
-	}
-
-	var injectedErr = errors.New("write error")
-	ctrl := gomock.NewController(t)
-	osfile := utils.NewMockOsFile(ctrl)
-	osfile.EXPECT().Write(gomock.Any()).Return(0, injectedErr)
-
-	if err := storeRootsTo(osfile, roots); !errors.Is(err, injectedErr) {
-		t.Errorf("writing roots should fail")
-	}
-}
-
-func TestStoreRootsTo_SecondWriterFailures(t *testing.T) {
-	var roots []Root
-	for i := 0; i < 48; i++ {
-		id := NodeId(uint64(1) << i)
-		roots = append(roots, Root{NodeRef: NewNodeReference(id)})
-	}
-
-	var injectedErr = errors.New("write error")
-	ctrl := gomock.NewController(t)
-	osfile := utils.NewMockOsFile(ctrl)
-	gomock.InOrder(
-		osfile.EXPECT().Write(gomock.Any()).Return(0, nil),
-		osfile.EXPECT().Write(gomock.Any()).Return(0, injectedErr),
-	)
-
-	if err := storeRootsTo(osfile, roots); !errors.Is(err, injectedErr) {
-		t.Errorf("writing roots should fail")
-	}
-}
-
-func TestStoreRoots_Cannot_Create(t *testing.T) {
-	var roots []Root
-	dir := t.TempDir()
-	file := filepath.Join(dir, fileNameArchiveRootsCheckpointDirectory)
-	if err := os.Mkdir(file, os.FileMode(0644)); err != nil {
-		t.Fatalf("cannot create dir: %s", err)
-	}
-	if err := StoreRoots(file, roots); err == nil {
-		t.Errorf("writing roots should fail")
-	}
-
-}
-
 func TestArchiveTrie_FailingOperation_InvalidatesOtherArchiveOperations(t *testing.T) {
 	injectedErr := fmt.Errorf("injectedError")
 
@@ -2223,8 +2138,10 @@ func TestArchiveTrie_FailingOperation_InvalidatesOtherArchiveOperations(t *testi
 			live.EXPECT().Flush().Return(injectedErr).AnyTimes() // flush can be repeated
 			live.EXPECT().closeWithError(gomock.Any()).AnyTimes()
 
-			archive := &ArchiveTrie{forest: db, head: live, roots: &rootList{}}
-			archive.roots.roots = append(archive.roots.roots, Root{NodeRef: NewNodeReference(ValueId(1))})
+			roots, err := loadRoots(t.TempDir())
+			require.NoError(t, err)
+			archive := &ArchiveTrie{forest: db, head: live, roots: roots}
+			archive.roots.append(Root{NodeRef: NewNodeReference(ValueId(1))})
 
 			// all operations must fail
 			for _, name := range rotate(names, i) {
@@ -2301,8 +2218,10 @@ func TestArchiveTrie_FailingLiveStateUpdate_InvalidatesArchive(t *testing.T) {
 			db.EXPECT().hashAddress(gomock.Any()).DoAndReturn(common.Keccak256ForAddress).AnyTimes()
 			db.EXPECT().getViewAccess(gomock.Any()).Return(shared.MakeShared[Node](&EmptyNode{}).GetViewHandle(), nil).AnyTimes()
 
-			archive := &ArchiveTrie{forest: db, head: liveState, roots: &rootList{}}
-			archive.roots.roots = append(archive.roots.roots, Root{NodeRef: NewNodeReference(ValueId(1))})
+			roots, err := loadRoots(t.TempDir())
+			require.NoError(t, err)
+			archive := &ArchiveTrie{forest: db, head: liveState, roots: roots}
+			archive.roots.append(Root{NodeRef: NewNodeReference(ValueId(1))})
 			defer func() {
 				if err := archive.Close(); !errors.Is(err, injectedErr) {
 					t.Errorf("expected error does not match: %v != %v", err, injectedErr)
@@ -3130,44 +3049,6 @@ func TestRootList_LoadRoots_ForwardsIoIssues(t *testing.T) {
 	}
 }
 
-func TestRootList_storeRootsTo_HandlesWriteIssues(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	writeCounter := utils.NewMockOsFile(ctrl)
-
-	roots := make([]Root, 10)
-
-	counter := 0
-	writeCounter.EXPECT().Write(gomock.Any()).DoAndReturn(func(p []byte) (int, error) {
-		counter++
-		return len(p), nil
-	}).AnyTimes()
-
-	if err := storeRootsTo(writeCounter, roots); err != nil {
-		t.Fatalf("failed to store roots: %v", err)
-	}
-
-	if counter == 0 {
-		t.Fatalf("expected write to be called")
-	}
-
-	for i := 0; i < counter; i++ {
-		t.Run(fmt.Sprintf("write_%d", i), func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			out := utils.NewMockOsFile(ctrl)
-
-			inducedError := fmt.Errorf("induced error")
-			gomock.InOrder(
-				out.EXPECT().Write(gomock.Any()).Return(0, nil).Times(i),
-				out.EXPECT().Write(gomock.Any()).Return(0, inducedError),
-			)
-
-			if err := storeRootsTo(out, roots); !errors.Is(err, inducedError) {
-				t.Fatalf("expected error when writing roots")
-			}
-		})
-	}
-}
-
 func TestRootList_GuaranteeCheckpoint_EmptyListSupportsCheckpointZero(t *testing.T) {
 	dir := t.TempDir()
 	roots, err := loadRoots(dir)
@@ -3298,23 +3179,34 @@ func TestRootList_Prepare_OnlyAcceptsIncrementalCheckpoints(t *testing.T) {
 
 func TestRootList_Prepare_DetectsFlushIssue(t *testing.T) {
 	dir := t.TempDir()
-	roots, err := loadRoots(dir)
+
+	// Create the checkpoint directory that loadRoots would otherwise set up.
+	checkpointDir := filepath.Join(dir, fileNameArchiveRootsCheckpointDirectory)
+	if err := os.MkdirAll(checkpointDir, 0700); err != nil {
+		t.Fatalf("failed to create checkpoint directory: %v", err)
+	}
+
+	// Use a mock backing file whose SetBatch returns an error so that the
+	// flush triggered inside Prepare fails.
+	ctrl := gomock.NewController(t)
+	file := kv_file.NewMockKVFileWithMemoryFootprint[uint64, Root](ctrl)
+	injectedErr := errors.New("injected flush failure")
+	file.EXPECT().SetBatch(gomock.Any()).Return(injectedErr)
+
+	cached, err := kv_file.OpenKVCachedFile[uint64, Root](file, 10000, 1000)
 	if err != nil {
-		t.Fatalf("failed to load roots: %v", err)
+		t.Fatalf("failed to open kv cached file: %v", err)
 	}
-
+	roots := &rootList{
+		roots:     cached,
+		filename:  filepath.Join(dir, fileNameArchiveRoots),
+		directory: checkpointDir,
+	}
 	roots.append(Root{NodeRef: NewNodeReference(ValueId(1))})
-	if err := roots.storeRoots(); err != nil {
-		t.Fatalf("failed to store roots: %v", err)
-	}
-	if err := os.Chmod(roots.filename, 0400); err != nil {
-		t.Fatalf("failed to make roots file read-only: %v", err)
-	}
 
-	roots.append(Root{NodeRef: NewNodeReference(ValueId(1))})
 	cp := checkpoint.Checkpoint(1)
-	if err := roots.Prepare(cp); err == nil {
-		t.Fatalf("expected error when roots could not be flushed to disk")
+	if err := roots.Prepare(cp); !errors.Is(err, injectedErr) {
+		t.Fatalf("expected error when roots could not be flushed to disk, got %v", err)
 	}
 }
 

--- a/go/database/mpt/live_trie.go
+++ b/go/database/mpt/live_trie.go
@@ -86,10 +86,10 @@ func VerifyFileLiveTrie(ctx context.Context, directory string, config MptConfig,
 	if !exists {
 		return nil
 	}
-	return verifyFileForest(ctx, directory, config, []Root{{
+	return verifyFileForest(ctx, directory, config, rootsFromSlice([]Root{{
 		NewNodeReference(metadata.RootNode),
 		metadata.RootHash,
-	}}, observer)
+	}}), observer)
 }
 
 func makeTrie(

--- a/go/database/mpt/verification.go
+++ b/go/database/mpt/verification.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"path/filepath"
 	"sort"
 
@@ -44,6 +45,18 @@ func (NilVerificationObserver) StartVerification()        {}
 func (NilVerificationObserver) Progress(msg string)       {}
 func (NilVerificationObserver) EndVerification(res error) {}
 
+// rootsFromSlice adapts a slice of roots to the iterator type expected by
+// the verification API.
+func rootsFromSlice(roots []Root) iter.Seq2[uint64, Root] {
+	return func(yield func(uint64, Root) bool) {
+		for i, r := range roots {
+			if !yield(uint64(i), r) {
+				return
+			}
+		}
+	}
+}
+
 // VerifyMptState runs validation checks on the forest and code hashes
 // stored in the given directory.
 // Forest checks:
@@ -57,7 +70,7 @@ func (NilVerificationObserver) EndVerification(res error) {}
 //     - all byte-codes within the code file matches their hashed representation in accounts
 //  2. Non-fatal checks
 //     - there are no extra Code Hashes not referenced by any account
-func VerifyMptState(ctx context.Context, directory string, config MptConfig, roots []Root, observer VerificationObserver) (res error) {
+func VerifyMptState(ctx context.Context, directory string, config MptConfig, roots iter.Seq2[uint64, Root], observer VerificationObserver) (res error) {
 	if observer == nil {
 		observer = NilVerificationObserver{}
 	}
@@ -93,7 +106,7 @@ func VerifyMptState(ctx context.Context, directory string, config MptConfig, roo
 //   - all required files are present and can be read
 //   - all referenced nodes are present
 //   - all hashes are consistent
-func verifyFileForest(ctx context.Context, directory string, config MptConfig, roots []Root, observer VerificationObserver) (res error) {
+func verifyFileForest(ctx context.Context, directory string, config MptConfig, roots iter.Seq2[uint64, Root], observer VerificationObserver) (res error) {
 	if observer == nil {
 		observer = NilVerificationObserver{}
 	}
@@ -113,7 +126,7 @@ func verifyFileForest(ctx context.Context, directory string, config MptConfig, r
 	return verifyForest(directory, config, roots, source, observer)
 }
 
-func verifyForest(directory string, config MptConfig, roots []Root, source *verificationNodeSource, observer VerificationObserver) (res error) {
+func verifyForest(directory string, config MptConfig, roots iter.Seq2[uint64, Root], source *verificationNodeSource, observer VerificationObserver) (res error) {
 	// ------------------------- Meta-Data Checks -----------------------------
 
 	observer.Progress(fmt.Sprintf("Checking forest stored in %s ...", directory))
@@ -198,7 +211,7 @@ func verifyForest(directory string, config MptConfig, roots []Root, source *veri
 	// Check roots for Archive node
 	if source.getConfig().HashStorageLocation == HashStoredWithNode {
 		// Check hashes of roots.
-		observer.Progress(fmt.Sprintf("Checking %d root hashes ...", len(roots)))
+		observer.Progress("Checking root hashes ...")
 		refIds := newNodeIds()
 		for _, root := range roots {
 			refIds.Put(root.NodeRef.id)
@@ -309,7 +322,7 @@ func verifyHashes[N any](
 	stock stock.Stock[uint64, N],
 	ids stock.IndexSet[uint64],
 	hashOfEmptyNode common.Hash,
-	roots []Root,
+	roots iter.Seq2[uint64, Root],
 	observer VerificationObserver,
 	hash func(*N) (common.Hash, error),
 	readHash func(*N) (common.Hash, bool),
@@ -535,7 +548,7 @@ func verifyHashesStoredWithParents[N any](
 	source *verificationNodeSource,
 	stock stock.Stock[uint64, N],
 	ids stock.IndexSet[uint64],
-	roots []Root,
+	roots iter.Seq2[uint64, Root],
 	observer VerificationObserver,
 	hash func(*N) (common.Hash, error),
 	isNodeType func(NodeId) bool,

--- a/go/database/mpt/verification_test.go
+++ b/go/database/mpt/verification_test.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"iter"
 	"os"
 	"path/filepath"
 	"strings"
@@ -53,7 +54,7 @@ var forestFiles = []string{
 
 func TestVerification_VerifyValidForest(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
-		if err := verifyFileForest(context.Background(), dir, config, roots, NilVerificationObserver{}); err != nil {
+		if err := verifyFileForest(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{}); err != nil {
 			t.Errorf("found unexpected error in fresh forest: %v", err)
 		}
 	})
@@ -71,7 +72,7 @@ func TestVerification_VerificationObserverIsKeptUpdatedOnEvents(t *testing.T) {
 			observer.EXPECT().EndVerification(nil),
 		)
 
-		if err := verifyFileForest(context.Background(), dir, config, roots, observer); err != nil {
+		if err := verifyFileForest(context.Background(), dir, config, rootsFromSlice(roots), observer); err != nil {
 			t.Errorf("found unexpected error in fresh forest: %v", err)
 		}
 	})
@@ -84,7 +85,7 @@ func TestVerification_MissingFileIsDetected(t *testing.T) {
 				if err := os.RemoveAll(dir + "/" + file); err != nil {
 					t.Fatalf("failed to delete file %v: %v", file, err)
 				}
-				if err := verifyFileForest(context.Background(), dir, config, roots, NilVerificationObserver{}); err == nil {
+				if err := verifyFileForest(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{}); err == nil {
 					t.Errorf("The missing file %v should have been detected", file)
 				}
 			})
@@ -118,7 +119,7 @@ func TestVerification_ModifiedFileIsDetected(t *testing.T) {
 					t.Fatalf("failed to write modified file content: %v", err)
 				}
 
-				if err := verifyFileForest(context.Background(), dir, config, roots, NilVerificationObserver{}); err == nil {
+				if err := verifyFileForest(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{}); err == nil {
 					t.Errorf("Modified file %v should have been detected", file)
 				}
 			})
@@ -167,7 +168,7 @@ func TestVerification_ModifiedRootIsDetected(t *testing.T) {
 			t.Fatalf("failed to close stock: %v", err)
 		}
 
-		if err := verifyFileForest(context.Background(), dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified root node should have been detected")
 		}
 	})
@@ -181,7 +182,7 @@ func TestVerification_AccountBalanceModificationIsDetected(t *testing.T) {
 			node.info.Balance = amount.Add(node.info.Balance, amount.New(1))
 		})
 
-		if err := verifyFileForest(context.Background(), dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -195,7 +196,7 @@ func TestVerification_AccountNonceModificationIsDetected(t *testing.T) {
 			node.info.Nonce[2]++
 		})
 
-		if err := verifyFileForest(context.Background(), dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -209,7 +210,7 @@ func TestVerification_AccountCodeHashModificationIsDetected(t *testing.T) {
 			node.info.CodeHash[2]++
 		})
 
-		if err := verifyFileForest(context.Background(), dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -223,7 +224,7 @@ func TestVerification_AccountStorageModificationIsDetected(t *testing.T) {
 			node.storage = NewNodeReference(ValueId(123456789)) // invalid in test forest
 		})
 
-		if err := verifyFileForest(context.Background(), dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -240,7 +241,7 @@ func TestVerification_AccountNodeHashModificationIsDetected(t *testing.T) {
 			node.hash[3]++
 		})
 
-		if err := verifyFileForest(context.Background(), dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -257,7 +258,7 @@ func TestVerification_AccountStorageHashModificationIsDetected(t *testing.T) {
 			node.storageHash[3]++
 		})
 
-		if err := verifyFileForest(context.Background(), dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -271,7 +272,7 @@ func TestVerification_BranchChildIdModificationIsDetected(t *testing.T) {
 			node.children[8] = NewNodeReference(ValueId(123456789)) // does not exist in test forest
 		})
 
-		if err := verifyFileForest(context.Background(), dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -288,7 +289,7 @@ func TestVerification_BranchNodeHashModificationIsDetected(t *testing.T) {
 			node.hash[4]++
 		})
 
-		if err := verifyFileForest(context.Background(), dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -311,7 +312,7 @@ func TestVerification_BranchChildHashModificationIsDetected(t *testing.T) {
 			}
 		})
 
-		if err := verifyFileForest(context.Background(), dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -325,7 +326,7 @@ func TestVerification_ExtensionPathModificationIsDetected(t *testing.T) {
 			node.path.path[0] = ^node.path.path[0]
 		})
 
-		if err := verifyFileForest(context.Background(), dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -339,7 +340,7 @@ func TestVerification_ExtensionNextModificationIsDetected(t *testing.T) {
 			node.next = NewNodeReference(BranchId(123456789))
 		})
 
-		if err := verifyFileForest(context.Background(), dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -356,7 +357,7 @@ func TestVerification_ExtensionNodeHashModificationIsDetected(t *testing.T) {
 			node.hash[24]++
 		})
 
-		if err := verifyFileForest(context.Background(), dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -373,7 +374,7 @@ func TestVerification_ExtensionNextHashModificationIsDetected(t *testing.T) {
 			node.nextHash[24]++
 		})
 
-		if err := verifyFileForest(context.Background(), dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -387,7 +388,7 @@ func TestVerification_ValueKeyModificationIsDetected(t *testing.T) {
 			node.key[5]++
 		})
 
-		if err := verifyFileForest(context.Background(), dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -401,7 +402,7 @@ func TestVerification_ValueModificationIsDetected(t *testing.T) {
 			node.value[12]++
 		})
 
-		if err := verifyFileForest(context.Background(), dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -418,7 +419,7 @@ func TestVerification_ValueNodeHashModificationIsDetected(t *testing.T) {
 			node.hash[12]++
 		})
 
-		if err := verifyFileForest(context.Background(), dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err := verifyFileForest(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{}); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -434,7 +435,7 @@ func TestVerification_MissingCodeHashInCodeFileIsDetected(t *testing.T) {
 			node.info.CodeHash = missingHash
 		})
 
-		err := VerifyMptState(context.Background(), dir, config, roots, NilVerificationObserver{})
+		err := VerifyMptState(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{})
 		if err == nil {
 			t.Errorf("missing hash in code file should have been detected")
 			return
@@ -458,7 +459,7 @@ func TestVerification_DifferentHashInCodeFileIsDetected(t *testing.T) {
 			t.Fatalf("failed to write code file")
 		}
 
-		err := VerifyMptState(context.Background(), dir, config, roots, NilVerificationObserver{})
+		err := VerifyMptState(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{})
 		if err == nil {
 			t.Errorf("different hash in code file should have been detected")
 			return
@@ -498,7 +499,7 @@ func TestVerification_ExtraCodeHashInCodeFileIsDetected(t *testing.T) {
 			t.Fatalf("failed to write code file")
 		}
 
-		if err := VerifyMptState(context.Background(), dir, config, roots, observer); err != nil {
+		if err := VerifyMptState(context.Background(), dir, config, rootsFromSlice(roots), observer); err != nil {
 			t.Errorf("found unexpected error in fresh forest: %v", err)
 		}
 
@@ -526,7 +527,7 @@ func TestVerification_UnreadableCodesReturnError(t *testing.T) {
 			t.Fatalf("failed to close codes file: %v", err)
 		}
 
-		if err = VerifyMptState(context.Background(), dir, config, roots, NilVerificationObserver{}); err == nil {
+		if err = VerifyMptState(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{}); err == nil {
 			t.Errorf("unreadable code file should have been detected")
 			return
 		}
@@ -541,13 +542,13 @@ func TestVerification_UnreadableCodesReturnError(t *testing.T) {
 
 func TestVerification_PassingNilAsObserverDoesNotFail(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
-		_ = VerifyMptState(context.Background(), dir, config, roots, nil)
+		_ = VerifyMptState(context.Background(), dir, config, rootsFromSlice(roots), nil)
 	})
 }
 
 func TestVerifyFileForest_PassingNilAsObserverDoesNotFail(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
-		if err := verifyFileForest(context.Background(), dir, config, roots, nil); err != nil {
+		if err := verifyFileForest(context.Background(), dir, config, rootsFromSlice(roots), nil); err != nil {
 			t.Errorf("found unexpected error in verification: %v", err)
 		}
 	})
@@ -563,7 +564,7 @@ func TestVerification_DifferentExtraHashInCodeFileIsDetected(t *testing.T) {
 			t.Fatalf("failed to write code file")
 		}
 
-		err := VerifyMptState(context.Background(), dir, config, roots, NilVerificationObserver{})
+		err := VerifyMptState(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{})
 		if err == nil {
 			t.Errorf("different extra hash in code file should have been detected")
 			return
@@ -625,7 +626,7 @@ func TestVerification_HashesOfEmbeddedNodesAreIgnored(t *testing.T) {
 	}
 
 	// Run the verification for the trie (which includes embedded nodes).
-	if err := verifyFileForest(context.Background(), dir, S5LiveConfig, []Root{{root, hash}}, NilVerificationObserver{}); err != nil {
+	if err := verifyFileForest(context.Background(), dir, S5LiveConfig, rootsFromSlice([]Root{{root, hash}}), NilVerificationObserver{}); err != nil {
 		t.Errorf("Unexpected verification error: %v", err)
 	}
 }
@@ -648,7 +649,7 @@ func TestVerification_ForestVerificationObserverReportsError(t *testing.T) {
 			node.info.Balance = amount.Add(node.info.Balance, amount.New(1))
 		})
 
-		if err := verifyFileForest(context.Background(), dir, config, roots, observer); err == nil {
+		if err := verifyFileForest(context.Background(), dir, config, rootsFromSlice(roots), observer); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -671,7 +672,7 @@ func TestVerification_VerificationObserverReportsError(t *testing.T) {
 			node.info.Balance = amount.Add(node.info.Balance, amount.New(1))
 		})
 
-		if err := VerifyMptState(context.Background(), dir, config, roots, observer); err == nil {
+		if err := VerifyMptState(context.Background(), dir, config, rootsFromSlice(roots), observer); err == nil {
 			t.Errorf("Modified node should have been detected")
 		}
 	})
@@ -679,26 +680,26 @@ func TestVerification_VerificationObserverReportsError(t *testing.T) {
 
 func TestVerification_VerifyValidMptState(t *testing.T) {
 	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
-		if err := VerifyMptState(context.Background(), dir, config, roots, NilVerificationObserver{}); err != nil {
+		if err := VerifyMptState(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{}); err != nil {
 			t.Errorf("found unexpected error in fresh mpt: %v", err)
 		}
 	})
 }
 
 func TestVerification_CanInterrupt(t *testing.T) {
-	type verifyFunc func(context.Context, string, MptConfig, []Root, VerificationObserver) error
+	type verifyFunc func(context.Context, string, MptConfig, iter.Seq2[uint64, Root], VerificationObserver) error
 	tests := map[string]verifyFunc{"VerifyMptState": VerifyMptState, "VerifyFileForest": verifyFileForest}
 
 	for name, verify := range tests {
 		runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
 			ctx := newCountingWhenDoneContext(context.Background(), 10_000_000)
-			if err := verify(ctx, dir, config, roots, nil); err != nil {
+			if err := verify(ctx, dir, config, rootsFromSlice(roots), nil); err != nil {
 				t.Errorf("%v: found unexpected error: %v", name, err)
 			}
 
 			for i := 0; i < ctx.count; i++ {
 				ctx := newCountingWhenDoneContext(context.Background(), i)
-				if err := verify(ctx, dir, config, roots, nil); !errors.Is(err, interrupt.ErrCanceled) {
+				if err := verify(ctx, dir, config, rootsFromSlice(roots), nil); !errors.Is(err, interrupt.ErrCanceled) {
 					t.Errorf("%v: found unexpected error: %v", name, err)
 				}
 			}


### PR DESCRIPTION
The `RootList` in the MPT archive implementation keeps all the root hashes in memory and can grow indefinitely.
Similarly to #434, this PR adds a caching layer to `RootList` by using the `KVCachedFile`. 
A new `KVFile` called `OrderedFile` is added, an array-like storage with a key-file offset mapping.

Closes https://github.com/0xsoniclabs/sonic-admin/issues/845