### PR TITLE
Fix race condition in flat.go

### DIFF
--- a/go/database/flat/flat.go
+++ b/go/database/flat/flat.go
@@ -279,6 +279,7 @@ func processCommands(
 		if command.update != nil {
 			zone := tracy.ZoneBegin("State.Update")
 			backendChan, err := backend.Apply(command.update.block, command.update.data)
+			issues.HandleIssue(err)
 			if command.update.done != nil {
 				// Do no block the command processing loop while waiting for the
 				// backend asynchronous update to complete.
@@ -294,7 +295,6 @@ func processCommands(
 					close(command.update.done)
 				}(err)
 			}
-			issues.HandleIssue(err)
 			zone.End()
 		} else if command.commit != nil {
 			zone := tracy.ZoneBegin("State.Commit")


### PR DESCRIPTION
In `flat.go`, the `processCommand` function registers the error from the `Apply` function in the `IssueCollector` and returns it in the optional synchronization channel. 
However, currently it could write the error to the channel before the issue collector, causing a weird behavior where an error is returned but it's not yet registered. This is also what a user would usually do: wait on the channel, and if an error is returned, do something on the state implementation.

This is a very rare behavior (the goroutine needs to be instantiated and terminate right after it's defined), before the call to the issue collector is made. 
This was found by `TestState_Apply_BackendApplyReturnsError_IsForwarded`, running with `-race`

This PR prevents this behavior by first registering the error in the Issue collector and then running the logic to update the channel.