### PR TITLE
Add Offset File

### DIFF
--- a/go/backend/kv_file/offset_file.go
+++ b/go/backend/kv_file/offset_file.go
@@ -1,0 +1,258 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package kv_file
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"iter"
+	"maps"
+	"os"
+	"sync"
+	"unsafe"
+
+	"github.com/0xsoniclabs/carmen/go/common"
+)
+
+// OffsetFile is a KVFile backed by a single append-only file with an in-memory
+// index mapping each key to the offset of its most recent record. Updating a
+// key appends a new record and repoints the index; existing records are never
+// modified.
+type OffsetFile[K comparable, V any] struct {
+	offsets map[K]uint64
+
+	file         *os.File
+	filePath     string
+	fileSize     uint64
+	readValueFn  readValueFn[K, V]
+	writeValueFn writeValueFn[K, V]
+
+	// mutex guards offsets and fileSize. File access needs no explicit
+	// close-state tracking: os.File refcounts its descriptor internally, so
+	// any operation racing with (or following) Close fails with os.ErrClosed
+	// instead of touching a recycled descriptor.
+	mutex sync.Mutex
+}
+
+func OpenOffsetFile[K comparable, V any](path string, readValueFn readValueFn[K, V], writeValueFn writeValueFn[K, V]) (*OffsetFile[K, V], error) {
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		return nil, err
+	}
+
+	// Scan the existing content to build the in-memory offset index. The
+	// file descriptor is retained for the lifetime of the OffsetFile so
+	// that subsequent reads and writes can reuse it.
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return nil, errors.Join(err, file.Close())
+	}
+	offsets, err := parseOffsets(file, readValueFn)
+	if err != nil {
+		return nil, errors.Join(err, file.Close())
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return nil, errors.Join(err, file.Close())
+	}
+
+	return &OffsetFile[K, V]{
+		offsets:      offsets,
+		file:         file,
+		filePath:     path,
+		fileSize:     uint64(info.Size()),
+		readValueFn:  readValueFn,
+		writeValueFn: writeValueFn,
+	}, nil
+}
+
+func (o *OffsetFile[K, V]) Set(key K, value V) error {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+
+	if err := o.writeEntryLocked(key, value); err != nil {
+		return err
+	}
+	return o.updateFileSizeLocked()
+}
+
+func (o *OffsetFile[K, V]) SetBatch(pending map[K]V) error {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+
+	for key, value := range pending {
+		if err := o.writeEntryLocked(key, value); err != nil {
+			return err
+		}
+	}
+	return o.updateFileSizeLocked()
+}
+
+func (o *OffsetFile[K, V]) Get(key K) (*V, error) {
+	o.mutex.Lock()
+	offset, exists := o.offsets[key]
+	limit := o.fileSize
+	o.mutex.Unlock()
+	if !exists {
+		return nil, nil
+	}
+	// The record at the resolved offset is immutable (the file is
+	// append-only), so the read itself needs no synchronisation with
+	// concurrent writers; positioned reads do not touch the shared seek
+	// position. A concurrent Close makes the read fail with os.ErrClosed.
+	k, v, err := readFromDiskAtOffset(o.file, offset, limit, o.readValueFn)
+	if err != nil {
+		return nil, err
+	}
+	if *k != key {
+		return nil, fmt.Errorf("key mismatch: expected %v, got %v", key, *k)
+	}
+	return v, nil
+}
+
+func (o *OffsetFile[K, V]) Flush() error {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+	// No-op for OffsetFile, as writes are immediately persisted to disk.
+	return nil
+}
+
+// Close closes the underlying file descriptor. Closing is idempotent: repeated
+// calls report success without any effect. In-flight readers and iterators
+// observe the close as os.ErrClosed on their next file access; os.File
+// guarantees that a concurrent Close never lets an access touch a recycled
+// descriptor.
+func (o *OffsetFile[K, V]) Close() error {
+	if err := o.file.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+		return err
+	}
+	return nil
+}
+
+func (o *OffsetFile[K, V]) Size() (uint64, error) {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+	return uint64(len(o.offsets)), nil
+}
+
+func (o *OffsetFile[K, V]) FileSize() (uint64, error) {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+	return o.fileSize, nil
+}
+
+// writeEntryLocked appends a single (key, value) entry to the retained file
+// and updates the in-memory offset map. The caller must hold o.mutex and
+// must have verified that the file is not closed.
+func (o *OffsetFile[K, V]) writeEntryLocked(key K, value V) error {
+	curOffset, err := o.file.Seek(0, io.SeekEnd)
+	if err != nil {
+		return err
+	}
+	if err := o.writeValueFn(o.file, key, value); err != nil {
+		return err
+	}
+	o.offsets[key] = uint64(curOffset)
+	return nil
+}
+
+// updateFileSizeLocked refreshes the cached file size from the retained file.
+// The caller must hold o.mutex.
+func (o *OffsetFile[K, V]) updateFileSizeLocked() error {
+	size, err := o.file.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return err
+	}
+	o.fileSize = uint64(size)
+	return nil
+}
+
+func (o *OffsetFile[K, V]) Has(key K) (bool, error) {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+	_, exists := o.offsets[key]
+	return exists, nil
+}
+
+func (o *OffsetFile[K, V]) Iterate() (iter.Seq2[K, V], error) {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+
+	// The iterator operates on a snapshot: the offsets are cloned here and the
+	// records they point to are immutable because the file is append-only.
+	// Reads use positioned reads that do not touch the shared seek position,
+	// so the iterator does not need to hold the mutex. If the file is closed
+	// mid-iteration, the next read fails with os.ErrClosed and the iteration
+	// terminates.
+	offsets := maps.Clone(o.offsets)
+	limit := o.fileSize
+	return func(yield func(K, V) bool) {
+		for key, offset := range offsets {
+			_, value, err := readFromDiskAtOffset(o.file, offset, limit, o.readValueFn)
+			if err != nil {
+				return
+			}
+			if !yield(key, *value) {
+				return
+			}
+		}
+	}, nil
+}
+
+func (o *OffsetFile[K, V]) GetMemoryFootprint() *common.MemoryFootprint {
+	// The memory footprint of the OffsetFile is the size of the struct itself plus the size of the offsets map.
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+	sizeOffsets := uint(0)
+	for k, v := range o.offsets {
+		sizeOffsets += uint(unsafe.Sizeof(k) + unsafe.Sizeof(v))
+	}
+	return common.NewMemoryFootprint(unsafe.Sizeof(*o) + uintptr(sizeOffsets))
+}
+
+// parseOffsets scans a reader from its current position to EOF, calling
+// readValueFn to determine each record boundary, and returns a map from the
+// key of each record to its starting offset in the reader.
+func parseOffsets[K comparable, V any](reader io.ReadSeeker, readValueFn readValueFn[K, V]) (map[K]uint64, error) {
+	res := map[K]uint64{}
+	for {
+		offset, err := reader.Seek(0, io.SeekCurrent)
+		if err != nil {
+			return nil, err
+		}
+		key, _, err := readValueFn(reader)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		res[key] = uint64(offset)
+	}
+	return res, nil
+}
+
+// readFromDiskAtOffset reads a single (key, value) record starting at `offset`
+// using readValueFn. The record must end at or before `limit` (the file size at
+// the time the offset was resolved). Reads go through io.SectionReader and thus
+// use positioned reads (pread) that do not affect the file's seek position, so
+// no synchronisation with concurrent writers is required; reading from a file
+// that was closed concurrently fails with os.ErrClosed. On error the returned
+// key and value pointers are nil so that callers can distinguish a read
+// failure from a legitimate zero-valued record.
+func readFromDiskAtOffset[K comparable, V any](file io.ReaderAt, offset, limit uint64, readValueFn readValueFn[K, V]) (*K, *V, error) {
+	section := io.NewSectionReader(file, int64(offset), int64(limit-offset))
+	k, v, err := readValueFn(section)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &k, &v, nil
+}

--- a/go/backend/kv_file/offset_file_test.go
+++ b/go/backend/kv_file/offset_file_test.go
@@ -1,0 +1,509 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package kv_file
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The OffsetFile under test stores 8-byte keys followed by 8-byte values.
+const offsetEntrySize uint64 = 16
+
+func offsetReadValue(reader io.Reader) (uint64, uint64, error) {
+	var buf [16]byte
+	if _, err := io.ReadFull(reader, buf[:]); err != nil {
+		return 0, 0, err
+	}
+	key := binary.LittleEndian.Uint64(buf[0:8])
+	value := binary.LittleEndian.Uint64(buf[8:16])
+	return key, value, nil
+}
+
+func offsetWriteValue(writer io.Writer, key uint64, value uint64) error {
+	var buf [16]byte
+	binary.LittleEndian.PutUint64(buf[0:8], key)
+	binary.LittleEndian.PutUint64(buf[8:16], value)
+	_, err := writer.Write(buf[:])
+	return err
+}
+
+func openTestOffsetFile(t *testing.T) (*OffsetFile[uint64, uint64], string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "offset.dat")
+	f, err := OpenOffsetFile[uint64, uint64](path, offsetReadValue, offsetWriteValue)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+	return f, path
+}
+
+func TestOffsetFile_Open_CreatesFileWhenMissing(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "new.dat")
+
+	_, err := os.Stat(path)
+	require.True(os.IsNotExist(err))
+
+	f, err := OpenOffsetFile[uint64, uint64](path, offsetReadValue, offsetWriteValue)
+	require.NoError(err)
+	defer f.Close()
+
+	info, err := os.Stat(path)
+	require.NoError(err)
+	require.EqualValues(0, info.Size())
+}
+
+func TestOffsetFile_Open_LoadsExistingEntries(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "existing.dat")
+
+	// Two entries pre-populated: key=1, value=10 and key=2, value=20.
+	buf := make([]byte, 32)
+	binary.LittleEndian.PutUint64(buf[0:8], 1)
+	binary.LittleEndian.PutUint64(buf[8:16], 10)
+	binary.LittleEndian.PutUint64(buf[16:24], 2)
+	binary.LittleEndian.PutUint64(buf[24:32], 20)
+	require.NoError(os.WriteFile(path, buf, 0600))
+
+	f, err := OpenOffsetFile[uint64, uint64](path, offsetReadValue, offsetWriteValue)
+	require.NoError(err)
+	defer f.Close()
+
+	size, err := f.Size()
+	require.NoError(err)
+	require.EqualValues(2, size)
+
+	got1, err := f.Get(1)
+	require.NoError(err)
+	require.NotNil(got1)
+	require.EqualValues(10, *got1)
+
+	got2, err := f.Get(2)
+	require.NoError(err)
+	require.NotNil(got2)
+	require.EqualValues(20, *got2)
+}
+
+func TestOffsetFile_Open_ReturnsErrorOnInvalidFileContent(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "invalid.dat")
+	// 15 bytes: half an entry — readValueFn will fail with io.ErrUnexpectedEOF
+	// after one full entry read attempt.
+	require.NoError(os.WriteFile(path, make([]byte, 15), 0600))
+
+	_, err := OpenOffsetFile[uint64, uint64](path, offsetReadValue, offsetWriteValue)
+	require.Error(err)
+}
+
+func TestOffsetFile_Set_PersistsValue(t *testing.T) {
+	require := require.New(t)
+	f, path := openTestOffsetFile(t)
+
+	require.NoError(f.Set(1, 100))
+
+	got, err := f.Get(1)
+	require.NoError(err)
+	require.NotNil(got)
+	require.EqualValues(100, *got)
+
+	// File must have exactly one entry on disk.
+	info, err := os.Stat(path)
+	require.NoError(err)
+	require.EqualValues(offsetEntrySize, info.Size())
+}
+
+func TestOffsetFile_Set_UpdatesOffsetOnRewrite(t *testing.T) {
+	require := require.New(t)
+	f, path := openTestOffsetFile(t)
+
+	require.NoError(f.Set(7, 70))
+	require.NoError(f.Set(7, 71))
+
+	got, err := f.Get(7)
+	require.NoError(err)
+	require.NotNil(got)
+	require.EqualValues(71, *got)
+
+	// The file is append-only, so it now holds two records for key 7 but
+	// the in-memory map points to the most recent one.
+	info, err := os.Stat(path)
+	require.NoError(err)
+	require.EqualValues(2*offsetEntrySize, info.Size())
+}
+
+func TestOffsetFile_Get_ReturnsNilForUnknownKey(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOffsetFile(t)
+
+	got, err := f.Get(42)
+	require.NoError(err)
+	require.Nil(got)
+}
+
+func TestOffsetFile_Get_DetectsKeyMismatchOnDisk(t *testing.T) {
+	require := require.New(t)
+	f, path := openTestOffsetFile(t)
+
+	require.NoError(f.Set(1, 100))
+	require.NoError(f.Close())
+
+	// Corrupt the key on disk so that reading the entry at the recorded
+	// offset yields a different key than the requested one.
+	data, err := os.ReadFile(path)
+	require.NoError(err)
+	binary.LittleEndian.PutUint64(data[0:8], 999)
+	require.NoError(os.WriteFile(path, data, 0600))
+
+	f2, err := OpenOffsetFile[uint64, uint64](path, offsetReadValue, offsetWriteValue)
+	require.NoError(err)
+	defer f2.Close()
+
+	// The offsets map now records key=999. Asking for it succeeds because
+	// the stored key matches. Asking for key=1 returns nil because it was
+	// not loaded at all.
+	got, err := f2.Get(999)
+	require.NoError(err)
+	require.EqualValues(100, *got)
+
+	got, err = f2.Get(1)
+	require.NoError(err)
+	require.Nil(got)
+}
+
+func TestOffsetFile_SetBatch_PersistsAllEntries(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOffsetFile(t)
+
+	batch := map[uint64]uint64{
+		1: 10,
+		2: 20,
+		3: 30,
+	}
+	require.NoError(f.SetBatch(batch))
+
+	for k, want := range batch {
+		got, err := f.Get(k)
+		require.NoError(err)
+		require.NotNil(got)
+		require.EqualValues(want, *got, "key %d", k)
+	}
+	size, err := f.Size()
+	require.NoError(err)
+	require.EqualValues(uint64(len(batch)), size)
+}
+
+func TestOffsetFile_SetBatch_EmptyBatchIsNoop(t *testing.T) {
+	require := require.New(t)
+	f, path := openTestOffsetFile(t)
+
+	require.NoError(f.SetBatch(map[uint64]uint64{}))
+	size, err := f.Size()
+	require.NoError(err)
+	require.EqualValues(0, size)
+
+	info, err := os.Stat(path)
+	require.NoError(err)
+	require.EqualValues(0, info.Size())
+}
+
+func TestOffsetFile_Iterate_ReturnsAllEntries(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOffsetFile(t)
+
+	require.NoError(f.Set(1, 11))
+	require.NoError(f.Set(2, 22))
+	require.NoError(f.Set(3, 33))
+
+	seq, err := f.Iterate()
+	require.NoError(err)
+	all := map[uint64]uint64{}
+	for k, v := range seq {
+		all[k] = v
+	}
+	require.Equal(map[uint64]uint64{1: 11, 2: 22, 3: 33}, all)
+}
+
+func TestOffsetFile_Iterate_ReturnsLatestValueAfterOverwrite(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOffsetFile(t)
+
+	require.NoError(f.Set(1, 10))
+	require.NoError(f.Set(1, 100))
+
+	seq, err := f.Iterate()
+	require.NoError(err)
+	all := map[uint64]uint64{}
+	for k, v := range seq {
+		all[k] = v
+	}
+	require.Equal(map[uint64]uint64{1: 100}, all)
+}
+
+func TestOffsetFile_Iterate_YieldsNothingAfterClose(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOffsetFile(t)
+
+	require.NoError(f.Set(1, 1))
+	require.NoError(f.Close())
+
+	seq, err := f.Iterate()
+	require.NoError(err)
+
+	yielded := 0
+	for range seq {
+		yielded++
+	}
+	require.Equal(0, yielded)
+}
+
+func TestOffsetFile_Size_CountsUniqueKeys(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOffsetFile(t)
+
+	size, err := f.Size()
+	require.NoError(err)
+	require.EqualValues(0, size)
+
+	require.NoError(f.Set(1, 1))
+	size, err = f.Size()
+	require.NoError(err)
+	require.EqualValues(1, size)
+
+	require.NoError(f.Set(2, 2))
+	size, err = f.Size()
+	require.NoError(err)
+	require.EqualValues(2, size)
+
+	// Rewriting an existing key must not change the count.
+	require.NoError(f.Set(1, 99))
+	size, err = f.Size()
+	require.NoError(err)
+	require.EqualValues(2, size)
+}
+
+func TestOffsetFile_Flush_IsNoop(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOffsetFile(t)
+
+	require.NoError(f.Flush())
+	require.NoError(f.Flush())
+}
+
+func TestOffsetFile_Close_IsIdempotentAndRejectsWrites(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOffsetFile(t)
+
+	require.NoError(f.Set(1, 1))
+
+	require.NoError(f.Close())
+	// Close is idempotent: a second call must succeed without error.
+	require.NoError(f.Close())
+	// Subsequent writes must fail because the retained file descriptor is
+	// no longer usable.
+	require.ErrorIs(f.Set(1, 1), os.ErrClosed)
+	require.ErrorIs(f.SetBatch(map[uint64]uint64{2: 2}), os.ErrClosed)
+	// Reading an existing key touches the closed descriptor and fails.
+	_, err := f.Get(1)
+	require.ErrorIs(err, os.ErrClosed)
+	// The offset index outlives Close: a missing key reports "not found"
+	// rather than os.ErrClosed.
+	got, err := f.Get(42)
+	require.NoError(err)
+	require.Nil(got)
+}
+
+func TestOffsetFile_GetMemoryFootprint_IsNonZero(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOffsetFile(t)
+
+	require.NoError(f.Set(1, 1))
+	require.NoError(f.Set(2, 2))
+
+	mf := f.GetMemoryFootprint()
+	require.NotNil(mf)
+	require.Greater(mf.Total(), uintptr(0))
+}
+
+func TestOffsetFile_Set_PropagatesWriteError(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "err.dat")
+
+	injected := errors.New("injected write failure")
+	writeFn := func(w io.Writer, _ uint64, _ uint64) error { return injected }
+
+	f, err := OpenOffsetFile[uint64, uint64](path, offsetReadValue, writeFn)
+	require.NoError(err)
+	defer f.Close()
+
+	err = f.Set(1, 1)
+	require.ErrorIs(err, injected)
+}
+
+func TestOffsetFile_Get_PropagatesReadError(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOffsetFile(t)
+
+	// Store a real entry via the working codec, then reopen with an error
+	// injecting reader.
+	require.NoError(f.Set(1, 1))
+	require.NoError(f.Close())
+
+	injected := errors.New("injected read failure")
+
+	// The initial open uses the working reader so that the offsets are
+	// populated; a second open with a faulty reader would fail during
+	// parseOffsets. We therefore inject the failure lazily by swapping the
+	// readValueFn on a fresh instance via a closure that only fails after
+	// the initial scan.
+	var scanned bool
+	readFn := func(r io.Reader) (uint64, uint64, error) {
+		if !scanned {
+			k, v, err := offsetReadValue(r)
+			return k, v, err
+		}
+		return 0, 0, injected
+	}
+
+	path := filepath.Join(t.TempDir(), "err.dat")
+	// Copy the previously written data to the new path.
+	// (We cannot access the original path through the closed handle here,
+	// so recreate a valid one-entry file.)
+	buf := make([]byte, 16)
+	binary.LittleEndian.PutUint64(buf[0:8], 1)
+	binary.LittleEndian.PutUint64(buf[8:16], 1)
+	require.NoError(os.WriteFile(path, buf, 0600))
+
+	f2, err := OpenOffsetFile[uint64, uint64](path, readFn, offsetWriteValue)
+	require.NoError(err)
+	defer f2.Close()
+
+	scanned = true
+	_, err = f2.Get(1)
+	require.ErrorIs(err, injected)
+}
+
+// TestOffsetFile_SetBatch_ReturnsErrorAfterClose verifies that writes fail
+// once the retained file descriptor has been released via Close.
+func TestOffsetFile_SetBatch_ReturnsErrorAfterClose(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOffsetFile(t)
+
+	require.NoError(f.Close())
+	require.ErrorIs(f.SetBatch(map[uint64]uint64{1: 1}), os.ErrClosed)
+}
+
+// TestOffsetFile_Set_ReturnsErrorAfterClose mirrors the SetBatch test above
+// for the single-entry Set path.
+func TestOffsetFile_Set_ReturnsErrorAfterClose(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOffsetFile(t)
+
+	require.NoError(f.Close())
+	require.ErrorIs(f.Set(1, 1), os.ErrClosed)
+}
+
+// TestOffsetFile_ParseOffsets_HandlesChunkedReader verifies that the record
+// scanning performed at Open time still assembles entries correctly when the
+// underlying reader returns data in small chunks. This ports the concept of
+// the previous TestArchiveTrie_CanLoadRootsFromJunkySource test to the
+// OffsetFile abstraction.
+func TestOffsetFile_ParseOffsets_HandlesChunkedReader(t *testing.T) {
+	require := require.New(t)
+
+	// Serialise a few entries using the standard writer.
+	entries := []struct {
+		key, value uint64
+	}{
+		{1, 10},
+		{2, 20},
+		{3, 30},
+	}
+	var buf bytes.Buffer
+	for _, e := range entries {
+		require.NoError(offsetWriteValue(&buf, e.key, e.value))
+	}
+
+	for _, chunkSize := range []int{1, 2, 4, 7, 16, 1024} {
+		t.Run(fmt.Sprintf("chunk=%d", chunkSize), func(t *testing.T) {
+			reader := newChunkedReadSeeker(buf.Bytes(), chunkSize)
+
+			offsets, err := parseOffsets[uint64, uint64](reader, offsetReadValue)
+			require.NoError(err)
+
+			require.Len(offsets, len(entries))
+			for i, e := range entries {
+				require.EqualValues(uint64(i)*offsetEntrySize, offsets[e.key],
+					"unexpected offset for key %d", e.key)
+			}
+		})
+	}
+}
+
+// chunkedReadSeeker is an io.ReadSeeker returning data in fixed-size chunks.
+// It is used to verify that value decoders assemble records correctly even
+// when the underlying source does not deliver full records in a single Read.
+type chunkedReadSeeker struct {
+	data      []byte
+	pos       int64
+	chunkSize int
+}
+
+func newChunkedReadSeeker(data []byte, chunkSize int) *chunkedReadSeeker {
+	return &chunkedReadSeeker{data: data, chunkSize: chunkSize}
+}
+
+func (r *chunkedReadSeeker) Read(p []byte) (int, error) {
+	if r.pos >= int64(len(r.data)) {
+		return 0, io.EOF
+	}
+	remaining := int64(len(r.data)) - r.pos
+	n := int64(len(p))
+	if n > remaining {
+		n = remaining
+	}
+	if r.chunkSize > 0 && n > int64(r.chunkSize) {
+		n = int64(r.chunkSize)
+	}
+	copied := copy(p, r.data[r.pos:r.pos+n])
+	r.pos += int64(copied)
+	return copied, nil
+}
+
+func (r *chunkedReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	var newPos int64
+	switch whence {
+	case io.SeekStart:
+		newPos = offset
+	case io.SeekCurrent:
+		newPos = r.pos + offset
+	case io.SeekEnd:
+		newPos = int64(len(r.data)) + offset
+	default:
+		return 0, fmt.Errorf("invalid whence %d", whence)
+	}
+	if newPos < 0 {
+		return 0, fmt.Errorf("negative position %d", newPos)
+	}
+	r.pos = newPos
+	return newPos, nil
+}

--- a/go/backend/kv_file/offset_file_test.go
+++ b/go/backend/kv_file/offset_file_test.go
@@ -63,7 +63,7 @@ func TestOffsetFile_Open_CreatesFileWhenMissing(t *testing.T) {
 
 	f, err := OpenOffsetFile[uint64, uint64](path, offsetReadValue, offsetWriteValue)
 	require.NoError(err)
-	defer f.Close()
+	defer func() { require.NoError(f.Close()) }()
 
 	info, err := os.Stat(path)
 	require.NoError(err)
@@ -85,7 +85,7 @@ func TestOffsetFile_Open_LoadsExistingEntries(t *testing.T) {
 
 	f, err := OpenOffsetFile[uint64, uint64](path, offsetReadValue, offsetWriteValue)
 	require.NoError(err)
-	defer f.Close()
+	defer func() { require.NoError(f.Close()) }()
 
 	size, err := f.Size()
 	require.NoError(err)
@@ -175,7 +175,7 @@ func TestOffsetFile_Get_DetectsKeyMismatchOnDisk(t *testing.T) {
 
 	f2, err := OpenOffsetFile[uint64, uint64](path, offsetReadValue, offsetWriteValue)
 	require.NoError(err)
-	defer f2.Close()
+	defer func() { require.NoError(f2.Close()) }()
 
 	// The offsets map now records key=999. Asking for it succeeds because
 	// the stored key matches. Asking for key=1 returns nil because it was
@@ -353,7 +353,7 @@ func TestOffsetFile_Set_PropagatesWriteError(t *testing.T) {
 
 	f, err := OpenOffsetFile[uint64, uint64](path, offsetReadValue, writeFn)
 	require.NoError(err)
-	defer f.Close()
+	defer func() { require.NoError(f.Close()) }()
 
 	err = f.Set(1, 1)
 	require.ErrorIs(err, injected)
@@ -395,7 +395,7 @@ func TestOffsetFile_Get_PropagatesReadError(t *testing.T) {
 
 	f2, err := OpenOffsetFile[uint64, uint64](path, readFn, offsetWriteValue)
 	require.NoError(err)
-	defer f2.Close()
+	defer func() { require.NoError(f2.Close()) }()
 
 	scanned = true
 	_, err = f2.Get(1)


### PR DESCRIPTION
This PR adds the `OffsetFIle`, an append-only `KVFile` which keeps the offset of each element in memory.
Overwriting a value for a known key appends the pair at the end of the file and overwrites the offset of the previous key-value pair

This will be used to implement caching for the MPT codes