### PR TITLE
Add Ordered file

### DIFF
--- a/go/backend/kv_file/ordered_file.go
+++ b/go/backend/kv_file/ordered_file.go
@@ -43,6 +43,7 @@ type OrderedFile[V any] struct {
 
 // OpenOrderedFile opens an OrderedFile at the given path, creating the file if
 // it does not exist.
+// The key passed to `readValueFn` and `writeValueFn` is ignored, as the key is implicit in the file offset.
 func OpenOrderedFile[V any](path string, itemSize uint64, readValueFn readValueFn[uint64, V], writeValueFn writeValueFn[uint64, V]) (*OrderedFile[V], error) {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		if err := os.WriteFile(path, []byte{}, 0600); err != nil {
@@ -110,15 +111,7 @@ func (o *OrderedFile[V]) Has(key uint64) (bool, error) {
 }
 
 func (o *OrderedFile[V]) Set(key uint64, value V) error {
-	o.mutex.Lock()
-	defer o.mutex.Unlock()
-
-	_, err := o.file.Seek(int64(key*o.itemSize), io.SeekStart)
-	if err != nil {
-		return err
-	}
-
-	return o.writeValueFn(o.file, key, value)
+	return o.SetBatch(map[uint64]V{key: value})
 }
 
 func (o *OrderedFile[V]) SetBatch(entries map[uint64]V) error {

--- a/go/backend/kv_file/ordered_file.go
+++ b/go/backend/kv_file/ordered_file.go
@@ -158,13 +158,6 @@ func (o *OrderedFile[V]) SetBatch(entries map[uint64]V) error {
 	return nil
 }
 
-func (o *OrderedFile[V]) Size() (uint64, error) {
-	o.mutex.Lock()
-	defer o.mutex.Unlock()
-
-	return o.sizeLocked()
-}
-
 func (o *OrderedFile[V]) FileSize() (uint64, error) {
 	o.mutex.Lock()
 	defer o.mutex.Unlock()

--- a/go/backend/kv_file/ordered_file.go
+++ b/go/backend/kv_file/ordered_file.go
@@ -12,6 +12,7 @@ package kv_file
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"iter"
 	"os"
@@ -53,6 +54,18 @@ func OpenOrderedFile[V any](path string, itemSize uint64, readValueFn readValueF
 	file, err := os.OpenFile(path, os.O_RDWR, 0600)
 	if err != nil {
 		return nil, err
+	}
+
+	// Verify that the on-disk file is a whole number of root entries.
+	fileSize, err := file.Stat()
+	if err != nil {
+		return nil, errors.Join(err, file.Close())
+	}
+	if fileSize.Size()%int64(itemSize) != 0 {
+		return nil, errors.Join(
+			fmt.Errorf("invalid root file format: size %d is not a multiple of entry size %d", fileSize.Size(), itemSize),
+			file.Close(),
+		)
 	}
 
 	return &OrderedFile[V]{

--- a/go/backend/kv_file/ordered_file.go
+++ b/go/backend/kv_file/ordered_file.go
@@ -1,0 +1,232 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package kv_file
+
+import (
+	"errors"
+	"io"
+	"iter"
+	"os"
+	"sync"
+	"unsafe"
+
+	"github.com/0xsoniclabs/carmen/go/common"
+)
+
+// OrderedFile is a KVFile that stores fixed-size values in a single file,
+// addressed by their index: the value for key k occupies the k-th slot of the
+// file. It is suited for dense, sequentially numbered data. Safe for
+// concurrent use.
+type OrderedFile[V any] struct {
+	file     *os.File
+	filepath string
+
+	itemSize     uint64 // item size in bytes
+	readValueFn  readValueFn[uint64, V]
+	writeValueFn writeValueFn[uint64, V]
+
+	// mutex guards all file access. File access needs no explicit
+	// close-state tracking: os.File refcounts its descriptor internally, so
+	// any operation racing with (or following) Close fails with os.ErrClosed
+	// instead of touching a recycled descriptor.
+	mutex sync.Mutex
+}
+
+// OpenOrderedFile opens an OrderedFile at the given path.
+// The file is created if it does not exist.
+func OpenOrderedFile[V any](path string, itemSize uint64, readValueFn readValueFn[uint64, V], writeValueFn writeValueFn[uint64, V]) (*OrderedFile[V], error) {
+	// Create the file if it does not exist.
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		if err := os.WriteFile(path, []byte{}, 0600); err != nil {
+			return nil, err
+		}
+	}
+
+	file, err := os.OpenFile(path, os.O_RDWR, 0600)
+	if err != nil {
+		return nil, err
+	}
+
+	return &OrderedFile[V]{
+		file:         file,
+		filepath:     path,
+		itemSize:     itemSize,
+		readValueFn:  readValueFn,
+		writeValueFn: writeValueFn,
+	}, nil
+}
+
+func (o *OrderedFile[V]) Get(key uint64) (*V, error) {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+
+	// Keys beyond the end of the file are treated as missing, per the KVFile
+	// contract (Get returns (nil, nil) for keys that do not exist).
+	size, err := o.sizeLocked()
+	if err != nil {
+		return nil, err
+	}
+	if key >= size {
+		return nil, nil
+	}
+
+	value, err := o.readAtLocked(key)
+	if err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+
+// readAtLocked reads the record of the given key using a positioned read
+// (pread) on the retained file descriptor, bounded to exactly one record so
+// that a decoder can never overrun into a neighbouring one. The caller must
+// hold o.mutex: records are overwritten in place, so a read racing a write to
+// the same record could observe a torn value.
+func (o *OrderedFile[V]) readAtLocked(key uint64) (V, error) {
+	section := io.NewSectionReader(o.file, int64(key*o.itemSize), int64(o.itemSize))
+	_, value, err := o.readValueFn(section)
+	return value, err
+}
+
+// Has checks if a key exists in the file. A key exists when its index is
+// within the currently allocated range of the file.
+func (o *OrderedFile[V]) Has(key uint64) (bool, error) {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+
+	size, err := o.sizeLocked()
+	if err != nil {
+		return false, err
+	}
+	return key < size, nil
+}
+
+func (o *OrderedFile[V]) Set(key uint64, value V) error {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+
+	_, err := o.file.Seek(int64(key*o.itemSize), io.SeekStart)
+	if err != nil {
+		return err
+	}
+
+	return o.writeValueFn(o.file, key, value)
+}
+
+func (o *OrderedFile[V]) Flush() error {
+	// No-op
+	return nil
+}
+
+func (o *OrderedFile[V]) SetBatch(entries map[uint64]V) error {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+
+	for key, value := range entries {
+		_, err := o.file.Seek(int64(key*o.itemSize), io.SeekStart)
+		if err != nil {
+			return err
+		}
+
+		err = o.writeValueFn(o.file, key, value)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (o *OrderedFile[V]) Size() (uint64, error) {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+
+	return o.sizeLocked()
+}
+
+func (o *OrderedFile[V]) FileSize() (uint64, error) {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+
+	info, err := o.file.Stat()
+	if err != nil {
+		return 0, err
+	}
+
+	return uint64(info.Size()), nil
+}
+
+// sizeLocked returns the number of items in the file. The caller must hold
+// o.mutex.
+func (o *OrderedFile[V]) sizeLocked() (uint64, error) {
+	info, err := o.file.Stat()
+	if err != nil {
+		return 0, err
+	}
+
+	return uint64(info.Size()) / o.itemSize, nil
+}
+
+// Iterate returns a lazy iterator over all key-value pairs stored in the
+// file, yielding them in ascending key order. The number of entries visited
+// is fixed at the time of this call (the size the file has at that moment).
+// Reads happen on demand while the iterator is being consumed; concurrent
+// mutations may therefore be observed by later reads and are not guarded
+// against by this method.
+//
+// If the file is closed while the iterator is being consumed, the iterator
+// terminates silently. The iterator never closes the underlying file itself,
+// so it cannot trigger a double close.
+func (o *OrderedFile[V]) Iterate() (iter.Seq2[uint64, V], error) {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+
+	size, err := o.sizeLocked()
+	if err != nil {
+		return nil, err
+	}
+
+	return func(yield func(uint64, V) bool) {
+		for key := range size {
+			o.mutex.Lock()
+			value, err := o.readAtLocked(key)
+			o.mutex.Unlock()
+			if err != nil {
+				// Includes os.ErrClosed when the file is closed mid-iteration.
+				return
+			}
+			if !yield(key, value) {
+				return
+			}
+		}
+	}, nil
+}
+
+// Close closes the underlying file descriptor. Closing is idempotent: repeated
+// calls report success without any effect. In-flight readers and iterators
+// observe the close as os.ErrClosed on their next file access; os.File
+// guarantees that a concurrent Close never lets an access touch a recycled
+// descriptor.
+func (o *OrderedFile[V]) Close() error {
+	if err := o.file.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+		return err
+	}
+	return nil
+}
+
+// GetMemoryFootprint returns the memory footprint of the OrderedFile.
+// It corresponds to the size of the OrderedFile struct itself.
+func (o *OrderedFile[V]) GetMemoryFootprint() *common.MemoryFootprint {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+
+	return common.NewMemoryFootprint(unsafe.Sizeof(*o))
+}

--- a/go/backend/kv_file/ordered_file.go
+++ b/go/backend/kv_file/ordered_file.go
@@ -34,17 +34,16 @@ type OrderedFile[V any] struct {
 	readValueFn  readValueFn[uint64, V]
 	writeValueFn writeValueFn[uint64, V]
 
-	// mutex guards all file access. File access needs no explicit
-	// close-state tracking: os.File refcounts its descriptor internally, so
-	// any operation racing with (or following) Close fails with os.ErrClosed
-	// instead of touching a recycled descriptor.
+	// mutex guards all file access. File access needs no explicit close-state
+	// tracking: os.File refcounts its descriptor internally, so any operation
+	// racing with (or following) Close fails with os.ErrClosed instead of
+	// touching a recycled descriptor.
 	mutex sync.Mutex
 }
 
-// OpenOrderedFile opens an OrderedFile at the given path.
-// The file is created if it does not exist.
+// OpenOrderedFile opens an OrderedFile at the given path, creating the file if
+// it does not exist.
 func OpenOrderedFile[V any](path string, itemSize uint64, readValueFn readValueFn[uint64, V], writeValueFn writeValueFn[uint64, V]) (*OrderedFile[V], error) {
-	// Create the file if it does not exist.
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		if err := os.WriteFile(path, []byte{}, 0600); err != nil {
 			return nil, err
@@ -56,7 +55,7 @@ func OpenOrderedFile[V any](path string, itemSize uint64, readValueFn readValueF
 		return nil, err
 	}
 
-	// Verify that the on-disk file is a whole number of root entries.
+	// The file must be a whole number of fixed-size records.
 	fileSize, err := file.Stat()
 	if err != nil {
 		return nil, errors.Join(err, file.Close())
@@ -98,19 +97,7 @@ func (o *OrderedFile[V]) Get(key uint64) (*V, error) {
 	return &value, nil
 }
 
-// readAtLocked reads the record of the given key using a positioned read
-// (pread) on the retained file descriptor, bounded to exactly one record so
-// that a decoder can never overrun into a neighbouring one. The caller must
-// hold o.mutex: records are overwritten in place, so a read racing a write to
-// the same record could observe a torn value.
-func (o *OrderedFile[V]) readAtLocked(key uint64) (V, error) {
-	section := io.NewSectionReader(o.file, int64(key*o.itemSize), int64(o.itemSize))
-	_, value, err := o.readValueFn(section)
-	return value, err
-}
-
-// Has checks if a key exists in the file. A key exists when its index is
-// within the currently allocated range of the file.
+// Has reports whether a value is stored for the given key.
 func (o *OrderedFile[V]) Has(key uint64) (bool, error) {
 	o.mutex.Lock()
 	defer o.mutex.Unlock()
@@ -134,11 +121,6 @@ func (o *OrderedFile[V]) Set(key uint64, value V) error {
 	return o.writeValueFn(o.file, key, value)
 }
 
-func (o *OrderedFile[V]) Flush() error {
-	// No-op
-	return nil
-}
-
 func (o *OrderedFile[V]) SetBatch(entries map[uint64]V) error {
 	o.mutex.Lock()
 	defer o.mutex.Unlock()
@@ -158,6 +140,11 @@ func (o *OrderedFile[V]) SetBatch(entries map[uint64]V) error {
 	return nil
 }
 
+func (o *OrderedFile[V]) Flush() error {
+	// No-op: writes are persisted immediately.
+	return nil
+}
+
 func (o *OrderedFile[V]) FileSize() (uint64, error) {
 	o.mutex.Lock()
 	defer o.mutex.Unlock()
@@ -170,27 +157,8 @@ func (o *OrderedFile[V]) FileSize() (uint64, error) {
 	return uint64(info.Size()), nil
 }
 
-// sizeLocked returns the number of items in the file. The caller must hold
-// o.mutex.
-func (o *OrderedFile[V]) sizeLocked() (uint64, error) {
-	info, err := o.file.Stat()
-	if err != nil {
-		return 0, err
-	}
-
-	return uint64(info.Size()) / o.itemSize, nil
-}
-
-// Iterate returns a lazy iterator over all key-value pairs stored in the
-// file, yielding them in ascending key order. The number of entries visited
-// is fixed at the time of this call (the size the file has at that moment).
-// Reads happen on demand while the iterator is being consumed; concurrent
-// mutations may therefore be observed by later reads and are not guarded
-// against by this method.
-//
-// If the file is closed while the iterator is being consumed, the iterator
-// terminates silently. The iterator never closes the underlying file itself,
-// so it cannot trigger a double close.
+// Iterate returns an iterator over all stored key-value pairs in ascending key
+// order. The set of keys visited is fixed when Iterate is called.
 func (o *OrderedFile[V]) Iterate() (iter.Seq2[uint64, V], error) {
 	o.mutex.Lock()
 	defer o.mutex.Unlock()
@@ -216,12 +184,10 @@ func (o *OrderedFile[V]) Iterate() (iter.Seq2[uint64, V], error) {
 	}, nil
 }
 
-// Close closes the underlying file descriptor. Closing is idempotent: repeated
-// calls report success without any effect. In-flight readers and iterators
-// observe the close as os.ErrClosed on their next file access; os.File
-// guarantees that a concurrent Close never lets an access touch a recycled
-// descriptor.
+// Close closes the underlying file. It is idempotent.
 func (o *OrderedFile[V]) Close() error {
+	// A concurrent close surfaces as os.ErrClosed to in-flight readers and to
+	// a repeated Close; both are reported as success.
 	if err := o.file.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
 		return err
 	}
@@ -229,10 +195,31 @@ func (o *OrderedFile[V]) Close() error {
 }
 
 // GetMemoryFootprint returns the memory footprint of the OrderedFile.
-// It corresponds to the size of the OrderedFile struct itself.
 func (o *OrderedFile[V]) GetMemoryFootprint() *common.MemoryFootprint {
 	o.mutex.Lock()
 	defer o.mutex.Unlock()
 
 	return common.NewMemoryFootprint(unsafe.Sizeof(*o))
+}
+
+// readAtLocked reads the record for the given key. The caller must hold
+// o.mutex, since records are overwritten in place and a read racing a write to
+// the same record could observe a torn value.
+func (o *OrderedFile[V]) readAtLocked(key uint64) (V, error) {
+	// A positioned read bounded to one record so a decoder cannot overrun into
+	// a neighbouring record.
+	section := io.NewSectionReader(o.file, int64(key*o.itemSize), int64(o.itemSize))
+	_, value, err := o.readValueFn(section)
+	return value, err
+}
+
+// sizeLocked returns the number of items in the file. The caller must hold
+// o.mutex.
+func (o *OrderedFile[V]) sizeLocked() (uint64, error) {
+	info, err := o.file.Stat()
+	if err != nil {
+		return 0, err
+	}
+
+	return uint64(info.Size()) / o.itemSize, nil
 }

--- a/go/backend/kv_file/ordered_file_test.go
+++ b/go/backend/kv_file/ordered_file_test.go
@@ -91,9 +91,9 @@ func TestOrderedFile_Open_OpensExistingFile(t *testing.T) {
 	require.NoError(err)
 	defer func() { require.NoError(f.Close()) }()
 
-	size, err := f.Size()
+	size, err := f.FileSize()
 	require.NoError(err)
-	require.EqualValues(2, size)
+	require.EqualValues(2*orderedItemSize, size)
 }
 
 func TestOrderedFile_Open_ReturnsErrorIfDirectoryDoesNotExist(t *testing.T) {
@@ -244,43 +244,6 @@ func TestOrderedFile_Iterate_ReturnsEmptyIteratorForEmptyFile(t *testing.T) {
 		count++
 	}
 	require.Equal(0, count)
-}
-
-func TestOrderedFile_Size_ReflectsFileSizeDividedByItemSize(t *testing.T) {
-	require := require.New(t)
-	f, _ := openTestOrderedFile(t)
-
-	size, err := f.Size()
-	require.NoError(err)
-	require.EqualValues(0, size)
-
-	require.NoError(f.Set(0, 1))
-	size, err = f.Size()
-	require.NoError(err)
-	require.EqualValues(1, size)
-
-	require.NoError(f.Set(1, 2))
-	size, err = f.Size()
-	require.NoError(err)
-	require.EqualValues(2, size)
-}
-
-func TestOrderedFile_Size_TruncatesPartiallyWrittenTrailingEntry(t *testing.T) {
-	require := require.New(t)
-	dir := t.TempDir()
-	path := filepath.Join(dir, "ordered.dat")
-
-	// One full item plus 3 spurious bytes → Size must report 1.
-	buf := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
-	require.NoError(os.WriteFile(path, buf, 0600))
-
-	f, err := OpenOrderedFile[uint64](path, orderedItemSize, orderedReadValue, orderedWriteValue)
-	require.NoError(err)
-	defer func() { require.NoError(f.Close()) }()
-
-	size, err := f.Size()
-	require.NoError(err)
-	require.EqualValues(1, size)
 }
 
 func TestOrderedFile_Flush_IsNoop(t *testing.T) {
@@ -446,8 +409,6 @@ func TestOrderedFile_OperationsFailAfterClose(t *testing.T) {
 	_, err := f.Get(0)
 	require.ErrorIs(err, os.ErrClosed)
 	_, err = f.Has(0)
-	require.ErrorIs(err, os.ErrClosed)
-	_, err = f.Size()
 	require.ErrorIs(err, os.ErrClosed)
 	_, err = f.FileSize()
 	require.ErrorIs(err, os.ErrClosed)

--- a/go/backend/kv_file/ordered_file_test.go
+++ b/go/backend/kv_file/ordered_file_test.go
@@ -25,39 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// The OrderedFile under test stores 8-byte uint64 values indexed by their
-// position. The key argument to readValueFn / writeValueFn is ignored by the
-// implementation (the position is derived from the seek offset), so the
-// helpers simply pass 0.
-
 const orderedItemSize uint64 = 8
-
-func orderedReadValue(reader io.Reader) (uint64, uint64, error) {
-	var buf [8]byte
-	if _, err := io.ReadFull(reader, buf[:]); err != nil {
-		return 0, 0, err
-	}
-	return 0, binary.LittleEndian.Uint64(buf[:]), nil
-}
-
-func orderedWriteValue(writer io.Writer, _ uint64, value uint64) error {
-	var buf [8]byte
-	binary.LittleEndian.PutUint64(buf[:], value)
-	_, err := writer.Write(buf[:])
-	return err
-}
-
-func openTestOrderedFile(t *testing.T) (*OrderedFile[uint64], string) {
-	t.Helper()
-	path := filepath.Join(t.TempDir(), "ordered.dat")
-	f, err := OpenOrderedFile[uint64](path, orderedItemSize, orderedReadValue, orderedWriteValue)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		// Best-effort close; some tests close explicitly.
-		_ = f.Close()
-	})
-	return f, path
-}
 
 func TestOrderedFile_Open_CreatesFileWhenMissing(t *testing.T) {
 	require := require.New(t)
@@ -116,6 +84,98 @@ func TestOrderedFile_Open_ReturnsErrorIfFileIsNotMultipleOfEntrySize(t *testing.
 	require.Error(err)
 }
 
+func TestOrderedFile_Get_ReadsPreviouslyWrittenValue(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOrderedFile(t)
+
+	require.NoError(f.Set(3, 12345))
+
+	got, err := f.Get(3)
+	require.NoError(err)
+	require.NotNil(got)
+	require.EqualValues(12345, *got)
+}
+
+func TestOrderedFile_Get_ReturnsNilForKeyBeyondFile(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOrderedFile(t)
+
+	// Nothing was written yet; per the KVFile contract, Get must return
+	// (nil, nil) for keys that do not exist rather than an error.
+	got, err := f.Get(0)
+	require.NoError(err)
+	require.Nil(got)
+}
+
+func TestOrderedFile_Get_PropagatesReadError(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "err.dat")
+
+	injected := errors.New("injected read failure")
+	readFn := func(r io.Reader) (uint64, uint64, error) { return 0, 0, injected }
+
+	// Write enough bytes so that Seek succeeds.
+	require.NoError(os.WriteFile(path, []byte("12345678"), 0600))
+
+	f, err := OpenOrderedFile[uint64](path, orderedItemSize, readFn, orderedWriteValue)
+	require.NoError(err)
+	defer func() { require.NoError(f.Close()) }()
+
+	_, err = f.Get(0)
+	require.ErrorIs(err, injected)
+}
+
+// TestOrderedFile_Get_ReadIsBoundedToSingleRecord verifies that a value
+// decoder cannot read beyond its own record: attempting to consume more than
+// itemSize bytes fails instead of silently returning a neighbouring record's
+// data.
+func TestOrderedFile_Get_ReadIsBoundedToSingleRecord(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ordered.dat")
+
+	// Two full records on disk.
+	require.NoError(os.WriteFile(path, []byte("1234567812345678"), 0600))
+
+	// A faulty decoder that tries to read two records worth of data.
+	greedyRead := func(r io.Reader) (uint64, uint64, error) {
+		buf := make([]byte, 2*orderedItemSize)
+		if _, err := io.ReadFull(r, buf); err != nil {
+			return 0, 0, err
+		}
+		return 0, binary.LittleEndian.Uint64(buf[:8]), nil
+	}
+
+	f, err := OpenOrderedFile[uint64](path, orderedItemSize, greedyRead, orderedWriteValue)
+	require.NoError(err)
+	defer func() { require.NoError(f.Close()) }()
+
+	_, err = f.Get(0)
+	require.ErrorIs(err, io.ErrUnexpectedEOF)
+}
+
+func TestOrderedFile_Has_ReportsKeysWithinAllocatedRange(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOrderedFile(t)
+
+	has, err := f.Has(0)
+	require.NoError(err)
+	require.False(has)
+
+	// Writing key 2 allocates slots 0..2, so all of them exist.
+	require.NoError(f.Set(2, 42))
+	for key := uint64(0); key <= 2; key++ {
+		has, err = f.Has(key)
+		require.NoError(err)
+		require.True(has, "key %d", key)
+	}
+
+	has, err = f.Has(3)
+	require.NoError(err)
+	require.False(has)
+}
+
 func TestOrderedFile_Set_WritesValueAtCorrectOffset(t *testing.T) {
 	require := require.New(t)
 	f, path := openTestOrderedFile(t)
@@ -161,27 +221,20 @@ func TestOrderedFile_Set_CanWriteSparseKeys(t *testing.T) {
 	require.EqualValues(48, info.Size())
 }
 
-func TestOrderedFile_Get_ReadsPreviouslyWrittenValue(t *testing.T) {
+func TestOrderedFile_Set_PropagatesWriteError(t *testing.T) {
 	require := require.New(t)
-	f, _ := openTestOrderedFile(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "err.dat")
 
-	require.NoError(f.Set(3, 12345))
+	injected := errors.New("injected write failure")
+	writeFn := func(w io.Writer, _ uint64, _ uint64) error { return injected }
 
-	got, err := f.Get(3)
+	f, err := OpenOrderedFile[uint64](path, orderedItemSize, orderedReadValue, writeFn)
 	require.NoError(err)
-	require.NotNil(got)
-	require.EqualValues(12345, *got)
-}
+	defer func() { require.NoError(f.Close()) }()
 
-func TestOrderedFile_Get_ReturnsNilForKeyBeyondFile(t *testing.T) {
-	require := require.New(t)
-	f, _ := openTestOrderedFile(t)
-
-	// Nothing was written yet; per the KVFile contract, Get must return
-	// (nil, nil) for keys that do not exist rather than an error.
-	got, err := f.Get(0)
-	require.NoError(err)
-	require.Nil(got)
+	err = f.Set(0, 1)
+	require.ErrorIs(err, injected)
 }
 
 func TestOrderedFile_SetBatch_WritesAllEntries(t *testing.T) {
@@ -212,6 +265,14 @@ func TestOrderedFile_SetBatch_EmptyBatchIsNoop(t *testing.T) {
 	info, err := os.Stat(path)
 	require.NoError(err)
 	require.EqualValues(0, info.Size())
+}
+
+func TestOrderedFile_Flush_IsNoop(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOrderedFile(t)
+
+	require.NoError(f.Flush())
+	require.NoError(f.Flush())
 }
 
 func TestOrderedFile_Iterate_ReturnsAllStoredValuesIndexedByPosition(t *testing.T) {
@@ -246,72 +307,6 @@ func TestOrderedFile_Iterate_ReturnsEmptyIteratorForEmptyFile(t *testing.T) {
 	require.Equal(0, count)
 }
 
-func TestOrderedFile_Flush_IsNoop(t *testing.T) {
-	require := require.New(t)
-	f, _ := openTestOrderedFile(t)
-
-	require.NoError(f.Flush())
-	require.NoError(f.Flush())
-}
-
-func TestOrderedFile_Close_ReleasesFileHandle(t *testing.T) {
-	require := require.New(t)
-	f, path := openTestOrderedFile(t)
-
-	require.NoError(f.Set(0, 7))
-	require.NoError(f.Close())
-
-	// After Close, we should still be able to read the file directly and see
-	// what was written.
-	data, err := os.ReadFile(path)
-	require.NoError(err)
-	require.EqualValues(7, binary.LittleEndian.Uint64(data))
-}
-
-func TestOrderedFile_GetMemoryFootprint_IsNonZero(t *testing.T) {
-	require := require.New(t)
-	f, _ := openTestOrderedFile(t)
-
-	mf := f.GetMemoryFootprint()
-	require.NotNil(mf)
-	require.Greater(mf.Total(), uintptr(0))
-}
-
-func TestOrderedFile_Set_PropagatesWriteError(t *testing.T) {
-	require := require.New(t)
-	dir := t.TempDir()
-	path := filepath.Join(dir, "err.dat")
-
-	injected := errors.New("injected write failure")
-	writeFn := func(w io.Writer, _ uint64, _ uint64) error { return injected }
-
-	f, err := OpenOrderedFile[uint64](path, orderedItemSize, orderedReadValue, writeFn)
-	require.NoError(err)
-	defer func() { require.NoError(f.Close()) }()
-
-	err = f.Set(0, 1)
-	require.ErrorIs(err, injected)
-}
-
-func TestOrderedFile_Get_PropagatesReadError(t *testing.T) {
-	require := require.New(t)
-	dir := t.TempDir()
-	path := filepath.Join(dir, "err.dat")
-
-	injected := errors.New("injected read failure")
-	readFn := func(r io.Reader) (uint64, uint64, error) { return 0, 0, injected }
-
-	// Write enough bytes so that Seek succeeds.
-	require.NoError(os.WriteFile(path, []byte("12345678"), 0600))
-
-	f, err := OpenOrderedFile[uint64](path, orderedItemSize, readFn, orderedWriteValue)
-	require.NoError(err)
-	defer func() { require.NoError(f.Close()) }()
-
-	_, err = f.Get(0)
-	require.ErrorIs(err, injected)
-}
-
 func TestOrderedFile_Iterate_StopsOnReadError(t *testing.T) {
 	require := require.New(t)
 	dir := t.TempDir()
@@ -340,15 +335,6 @@ func TestOrderedFile_Iterate_StopsOnReadError(t *testing.T) {
 	require.Equal(0, yielded, "read errors must abort the iterator before yielding")
 }
 
-func TestOrderedFile_Close_IsIdempotent(t *testing.T) {
-	require := require.New(t)
-	f, _ := openTestOrderedFile(t)
-
-	require.NoError(f.Close())
-	// A second Close must not attempt to close the underlying file again.
-	require.NoError(f.Close())
-}
-
 func TestOrderedFile_Iterate_TerminatesWhenFileIsClosed(t *testing.T) {
 	require := require.New(t)
 	f, _ := openTestOrderedFile(t)
@@ -373,25 +359,86 @@ func TestOrderedFile_Iterate_TerminatesWhenFileIsClosed(t *testing.T) {
 	require.False(ok)
 }
 
-func TestOrderedFile_Has_ReportsKeysWithinAllocatedRange(t *testing.T) {
+func TestOrderedFile_Iterate_HandlesChunkedReader(t *testing.T) {
+	require := require.New(t)
+
+	values := []uint64{100, 200, 300, 400}
+
+	for _, chunkSize := range []int{1, 2, 4, 7, 16, 1024} {
+		t.Run(fmt.Sprintf("chunk=%d", chunkSize), func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "ordered.dat")
+
+			// A readValueFn that first pulls the raw entry bytes from the
+			// underlying reader and then streams them through utils.NewChunkReader
+			// to simulate short reads. This exercises the pattern that value
+			// decoders should follow (use io.ReadFull to tolerate short reads).
+			chunkedRead := func(r io.Reader) (uint64, uint64, error) {
+				raw := make([]byte, orderedItemSize)
+				if _, err := io.ReadFull(r, raw); err != nil {
+					return 0, 0, err
+				}
+				chunked := utils.NewChunkReader(raw, chunkSize)
+				var buf [8]byte
+				if _, err := io.ReadFull(chunked, buf[:]); err != nil {
+					return 0, 0, err
+				}
+				return 0, binary.LittleEndian.Uint64(buf[:]), nil
+			}
+
+			f, err := OpenOrderedFile[uint64](path, orderedItemSize, chunkedRead, orderedWriteValue)
+			require.NoError(err)
+			defer func() { require.NoError(f.Close()) }()
+
+			for i, v := range values {
+				require.NoError(f.Set(uint64(i), v))
+			}
+
+			seq, err := f.Iterate()
+			require.NoError(err)
+
+			all := map[uint64]uint64{}
+			for k, v := range seq {
+				all[k] = v
+			}
+			require.Len(all, len(values))
+			for i, v := range values {
+				require.EqualValues(v, all[uint64(i)], "position %d", i)
+			}
+		})
+	}
+}
+
+func TestOrderedFile_Close_ReleasesFileHandle(t *testing.T) {
+	require := require.New(t)
+	f, path := openTestOrderedFile(t)
+
+	require.NoError(f.Set(0, 7))
+	require.NoError(f.Close())
+
+	// After Close, we should still be able to read the file directly and see
+	// what was written.
+	data, err := os.ReadFile(path)
+	require.NoError(err)
+	require.EqualValues(7, binary.LittleEndian.Uint64(data))
+}
+
+func TestOrderedFile_Close_IsIdempotent(t *testing.T) {
 	require := require.New(t)
 	f, _ := openTestOrderedFile(t)
 
-	has, err := f.Has(0)
-	require.NoError(err)
-	require.False(has)
+	require.NoError(f.Close())
+	// A second Close must not attempt to close the underlying file again.
+	require.NoError(f.Close())
+}
 
-	// Writing key 2 allocates slots 0..2, so all of them exist.
-	require.NoError(f.Set(2, 42))
-	for key := uint64(0); key <= 2; key++ {
-		has, err = f.Has(key)
-		require.NoError(err)
-		require.True(has, "key %d", key)
-	}
+func TestOrderedFile_GetMemoryFootprint_IsNonZero(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOrderedFile(t)
 
-	has, err = f.Has(3)
-	require.NoError(err)
-	require.False(has)
+	mf := f.GetMemoryFootprint()
+	require.NotNil(mf)
+	require.Greater(mf.Total(), uintptr(0))
 }
 
 // TestOrderedFile_OperationsFailAfterClose pins down that every operation
@@ -414,35 +461,6 @@ func TestOrderedFile_OperationsFailAfterClose(t *testing.T) {
 	require.ErrorIs(err, os.ErrClosed)
 	_, err = f.Iterate()
 	require.ErrorIs(err, os.ErrClosed)
-}
-
-// TestOrderedFile_Get_ReadIsBoundedToSingleRecord verifies that a value
-// decoder cannot read beyond its own record: attempting to consume more than
-// itemSize bytes fails instead of silently returning a neighbouring record's
-// data.
-func TestOrderedFile_Get_ReadIsBoundedToSingleRecord(t *testing.T) {
-	require := require.New(t)
-	dir := t.TempDir()
-	path := filepath.Join(dir, "ordered.dat")
-
-	// Two full records on disk.
-	require.NoError(os.WriteFile(path, []byte("1234567812345678"), 0600))
-
-	// A faulty decoder that tries to read two records worth of data.
-	greedyRead := func(r io.Reader) (uint64, uint64, error) {
-		buf := make([]byte, 2*orderedItemSize)
-		if _, err := io.ReadFull(r, buf); err != nil {
-			return 0, 0, err
-		}
-		return 0, binary.LittleEndian.Uint64(buf[:8]), nil
-	}
-
-	f, err := OpenOrderedFile[uint64](path, orderedItemSize, greedyRead, orderedWriteValue)
-	require.NoError(err)
-	defer func() { require.NoError(f.Close()) }()
-
-	_, err = f.Get(0)
-	require.ErrorIs(err, io.ErrUnexpectedEOF)
 }
 
 // TestOrderedFile_ConcurrentReadsAndWritesAreSafe stresses concurrent Set,
@@ -502,52 +520,38 @@ func TestOrderedFile_ConcurrentReadsAndWritesAreSafe(t *testing.T) {
 	wg.Wait()
 }
 
-func TestOrderedFile_Iterate_HandlesChunkedReader(t *testing.T) {
-	require := require.New(t)
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
 
-	values := []uint64{100, 200, 300, 400}
+// The OrderedFile under test stores 8-byte uint64 values indexed by their
+// position. The key argument to readValueFn / writeValueFn is ignored by the
+// implementation (the position is derived from the seek offset), so the
+// helpers simply pass 0.
 
-	for _, chunkSize := range []int{1, 2, 4, 7, 16, 1024} {
-		t.Run(fmt.Sprintf("chunk=%d", chunkSize), func(t *testing.T) {
-			dir := t.TempDir()
-			path := filepath.Join(dir, "ordered.dat")
-
-			// A readValueFn that first pulls the raw entry bytes from the
-			// underlying reader and then streams them through utils.NewChunkReader
-			// to simulate short reads. This exercises the pattern that value
-			// decoders should follow (use io.ReadFull to tolerate short reads).
-			chunkedRead := func(r io.Reader) (uint64, uint64, error) {
-				raw := make([]byte, orderedItemSize)
-				if _, err := io.ReadFull(r, raw); err != nil {
-					return 0, 0, err
-				}
-				chunked := utils.NewChunkReader(raw, chunkSize)
-				var buf [8]byte
-				if _, err := io.ReadFull(chunked, buf[:]); err != nil {
-					return 0, 0, err
-				}
-				return 0, binary.LittleEndian.Uint64(buf[:]), nil
-			}
-
-			f, err := OpenOrderedFile[uint64](path, orderedItemSize, chunkedRead, orderedWriteValue)
-			require.NoError(err)
-			defer func() { require.NoError(f.Close()) }()
-
-			for i, v := range values {
-				require.NoError(f.Set(uint64(i), v))
-			}
-
-			seq, err := f.Iterate()
-			require.NoError(err)
-
-			all := map[uint64]uint64{}
-			for k, v := range seq {
-				all[k] = v
-			}
-			require.Len(all, len(values))
-			for i, v := range values {
-				require.EqualValues(v, all[uint64(i)], "position %d", i)
-			}
-		})
+func orderedReadValue(reader io.Reader) (uint64, uint64, error) {
+	var buf [8]byte
+	if _, err := io.ReadFull(reader, buf[:]); err != nil {
+		return 0, 0, err
 	}
+	return 0, binary.LittleEndian.Uint64(buf[:]), nil
+}
+
+func orderedWriteValue(writer io.Writer, _ uint64, value uint64) error {
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], value)
+	_, err := writer.Write(buf[:])
+	return err
+}
+
+func openTestOrderedFile(t *testing.T) (*OrderedFile[uint64], string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ordered.dat")
+	f, err := OpenOrderedFile[uint64](path, orderedItemSize, orderedReadValue, orderedWriteValue)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// Best-effort close; some tests close explicitly.
+		_ = f.Close()
+	})
+	return f, path
 }

--- a/go/backend/kv_file/ordered_file_test.go
+++ b/go/backend/kv_file/ordered_file_test.go
@@ -69,7 +69,7 @@ func TestOrderedFile_Open_CreatesFileWhenMissing(t *testing.T) {
 
 	f, err := OpenOrderedFile[uint64](path, orderedItemSize, orderedReadValue, orderedWriteValue)
 	require.NoError(err)
-	defer f.Close()
+	defer func() { require.NoError(f.Close()) }()
 
 	info, err := os.Stat(path)
 	require.NoError(err)
@@ -89,7 +89,7 @@ func TestOrderedFile_Open_OpensExistingFile(t *testing.T) {
 
 	f, err := OpenOrderedFile[uint64](path, orderedItemSize, orderedReadValue, orderedWriteValue)
 	require.NoError(err)
-	defer f.Close()
+	defer func() { require.NoError(f.Close()) }()
 
 	size, err := f.Size()
 	require.NoError(err)
@@ -264,7 +264,7 @@ func TestOrderedFile_Size_TruncatesPartiallyWrittenTrailingEntry(t *testing.T) {
 
 	f, err := OpenOrderedFile[uint64](path, orderedItemSize, orderedReadValue, orderedWriteValue)
 	require.NoError(err)
-	defer f.Close()
+	defer func() { require.NoError(f.Close()) }()
 
 	size, err := f.Size()
 	require.NoError(err)
@@ -312,7 +312,7 @@ func TestOrderedFile_Set_PropagatesWriteError(t *testing.T) {
 
 	f, err := OpenOrderedFile[uint64](path, orderedItemSize, orderedReadValue, writeFn)
 	require.NoError(err)
-	defer f.Close()
+	defer func() { require.NoError(f.Close()) }()
 
 	err = f.Set(0, 1)
 	require.ErrorIs(err, injected)
@@ -331,7 +331,7 @@ func TestOrderedFile_Get_PropagatesReadError(t *testing.T) {
 
 	f, err := OpenOrderedFile[uint64](path, orderedItemSize, readFn, orderedWriteValue)
 	require.NoError(err)
-	defer f.Close()
+	defer func() { require.NoError(f.Close()) }()
 
 	_, err = f.Get(0)
 	require.ErrorIs(err, injected)
@@ -350,7 +350,7 @@ func TestOrderedFile_Iterate_StopsOnReadError(t *testing.T) {
 
 	f, err := OpenOrderedFile[uint64](path, orderedItemSize, readFn, orderedWriteValue)
 	require.NoError(err)
-	defer f.Close()
+	defer func() { require.NoError(f.Close()) }()
 
 	// The iterator is lazy, so Iterate itself does not read the file and
 	// therefore cannot surface the read error. Consuming the sequence
@@ -466,7 +466,7 @@ func TestOrderedFile_Get_ReadIsBoundedToSingleRecord(t *testing.T) {
 
 	f, err := OpenOrderedFile[uint64](path, orderedItemSize, greedyRead, orderedWriteValue)
 	require.NoError(err)
-	defer f.Close()
+	defer func() { require.NoError(f.Close()) }()
 
 	_, err = f.Get(0)
 	require.ErrorIs(err, io.ErrUnexpectedEOF)
@@ -558,7 +558,7 @@ func TestOrderedFile_Iterate_HandlesChunkedReader(t *testing.T) {
 
 			f, err := OpenOrderedFile[uint64](path, orderedItemSize, chunkedRead, orderedWriteValue)
 			require.NoError(err)
-			defer f.Close()
+			defer func() { require.NoError(f.Close()) }()
 
 			for i, v := range values {
 				require.NoError(f.Set(uint64(i), v))

--- a/go/backend/kv_file/ordered_file_test.go
+++ b/go/backend/kv_file/ordered_file_test.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"iter"
+	"maps"
 	"os"
 	"path/filepath"
 	"sync"
@@ -155,6 +156,20 @@ func TestOrderedFile_Get_ReadIsBoundedToSingleRecord(t *testing.T) {
 	require.ErrorIs(err, io.ErrUnexpectedEOF)
 }
 
+func TestOrderedFile_Get_ReturnsZeroForNonInitializedKeys(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOrderedFile(t)
+
+	require.NoError(f.Set(1000, 42))
+
+	for key := range uint64(1000) {
+		got, err := f.Get(key)
+		require.NoError(err)
+		require.NotNil(got)
+		require.EqualValues(0, *got, "key %d", key)
+	}
+}
+
 func TestOrderedFile_Has_ReportsKeysWithinAllocatedRange(t *testing.T) {
 	require := require.New(t)
 	f, _ := openTestOrderedFile(t)
@@ -286,10 +301,7 @@ func TestOrderedFile_Iterate_ReturnsAllStoredValuesIndexedByPosition(t *testing.
 	seq, err := f.Iterate()
 	require.NoError(err)
 
-	all := map[uint64]uint64{}
-	for k, v := range seq {
-		all[k] = v
-	}
+	all := maps.Collect(seq)
 	require.Equal(map[uint64]uint64{0: 100, 1: 101, 2: 102}, all)
 }
 
@@ -355,6 +367,7 @@ func TestOrderedFile_Iterate_TerminatesWhenFileIsClosed(t *testing.T) {
 	// Close the file before consuming the iterator.
 	require.NoError(f.Close())
 
+	// TODO: Check that the iterator terminated because the file was closed, not because it reached the end of the file.
 	_, _, ok = next()
 	require.False(ok)
 }

--- a/go/backend/kv_file/ordered_file_test.go
+++ b/go/backend/kv_file/ordered_file_test.go
@@ -104,6 +104,18 @@ func TestOrderedFile_Open_ReturnsErrorIfDirectoryDoesNotExist(t *testing.T) {
 	require.Error(err)
 }
 
+func TestOrderedFile_Open_ReturnsErrorIfFileIsNotMultipleOfEntrySize(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "invalid.dat")
+
+	// Write 10 bytes, which is not a multiple of the 8-byte entry size.
+	require.NoError(os.WriteFile(path, []byte("1234567890"), 0600))
+
+	_, err := OpenOrderedFile[uint64](path, orderedItemSize, orderedReadValue, orderedWriteValue)
+	require.Error(err)
+}
+
 func TestOrderedFile_Set_WritesValueAtCorrectOffset(t *testing.T) {
 	require := require.New(t)
 	f, path := openTestOrderedFile(t)

--- a/go/backend/kv_file/ordered_file_test.go
+++ b/go/backend/kv_file/ordered_file_test.go
@@ -1,0 +1,580 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package kv_file
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"iter"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/0xsoniclabs/carmen/go/backend/utils"
+	"github.com/stretchr/testify/require"
+)
+
+// The OrderedFile under test stores 8-byte uint64 values indexed by their
+// position. The key argument to readValueFn / writeValueFn is ignored by the
+// implementation (the position is derived from the seek offset), so the
+// helpers simply pass 0.
+
+const orderedItemSize uint64 = 8
+
+func orderedReadValue(reader io.Reader) (uint64, uint64, error) {
+	var buf [8]byte
+	if _, err := io.ReadFull(reader, buf[:]); err != nil {
+		return 0, 0, err
+	}
+	return 0, binary.LittleEndian.Uint64(buf[:]), nil
+}
+
+func orderedWriteValue(writer io.Writer, _ uint64, value uint64) error {
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], value)
+	_, err := writer.Write(buf[:])
+	return err
+}
+
+func openTestOrderedFile(t *testing.T) (*OrderedFile[uint64], string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ordered.dat")
+	f, err := OpenOrderedFile[uint64](path, orderedItemSize, orderedReadValue, orderedWriteValue)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// Best-effort close; some tests close explicitly.
+		_ = f.Close()
+	})
+	return f, path
+}
+
+func TestOrderedFile_Open_CreatesFileWhenMissing(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "new.dat")
+
+	_, err := os.Stat(path)
+	require.True(os.IsNotExist(err))
+
+	f, err := OpenOrderedFile[uint64](path, orderedItemSize, orderedReadValue, orderedWriteValue)
+	require.NoError(err)
+	defer f.Close()
+
+	info, err := os.Stat(path)
+	require.NoError(err)
+	require.EqualValues(0, info.Size())
+}
+
+func TestOrderedFile_Open_OpensExistingFile(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "existing.dat")
+
+	// Pre-populate two entries.
+	var buf [16]byte
+	binary.LittleEndian.PutUint64(buf[0:8], 111)
+	binary.LittleEndian.PutUint64(buf[8:16], 222)
+	require.NoError(os.WriteFile(path, buf[:], 0600))
+
+	f, err := OpenOrderedFile[uint64](path, orderedItemSize, orderedReadValue, orderedWriteValue)
+	require.NoError(err)
+	defer f.Close()
+
+	size, err := f.Size()
+	require.NoError(err)
+	require.EqualValues(2, size)
+}
+
+func TestOrderedFile_Open_ReturnsErrorIfDirectoryDoesNotExist(t *testing.T) {
+	require := require.New(t)
+	// A path under a non-existent directory cannot be created.
+	path := filepath.Join(t.TempDir(), "missing-dir", "file.dat")
+	_, err := OpenOrderedFile[uint64](path, orderedItemSize, orderedReadValue, orderedWriteValue)
+	require.Error(err)
+}
+
+func TestOrderedFile_Set_WritesValueAtCorrectOffset(t *testing.T) {
+	require := require.New(t)
+	f, path := openTestOrderedFile(t)
+
+	require.NoError(f.Set(0, 42))
+	require.NoError(f.Set(1, 43))
+	require.NoError(f.Set(2, 44))
+
+	require.NoError(f.Close())
+
+	data, err := os.ReadFile(path)
+	require.NoError(err)
+	require.Len(data, 24)
+	require.EqualValues(42, binary.LittleEndian.Uint64(data[0:8]))
+	require.EqualValues(43, binary.LittleEndian.Uint64(data[8:16]))
+	require.EqualValues(44, binary.LittleEndian.Uint64(data[16:24]))
+}
+
+func TestOrderedFile_Set_OverwritesExistingValue(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOrderedFile(t)
+
+	require.NoError(f.Set(0, 1))
+	require.NoError(f.Set(0, 99))
+
+	got, err := f.Get(0)
+	require.NoError(err)
+	require.NotNil(got)
+	require.EqualValues(99, *got)
+}
+
+func TestOrderedFile_Set_CanWriteSparseKeys(t *testing.T) {
+	require := require.New(t)
+	f, path := openTestOrderedFile(t)
+
+	// Writing at key 5 extends the file with an intermediate hole.
+	require.NoError(f.Set(5, 500))
+	require.NoError(f.Close())
+
+	info, err := os.Stat(path)
+	require.NoError(err)
+	// Bytes 0..40 correspond to keys 0..4 (unwritten), bytes 40..48 to key 5.
+	require.EqualValues(48, info.Size())
+}
+
+func TestOrderedFile_Get_ReadsPreviouslyWrittenValue(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOrderedFile(t)
+
+	require.NoError(f.Set(3, 12345))
+
+	got, err := f.Get(3)
+	require.NoError(err)
+	require.NotNil(got)
+	require.EqualValues(12345, *got)
+}
+
+func TestOrderedFile_Get_ReturnsNilForKeyBeyondFile(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOrderedFile(t)
+
+	// Nothing was written yet; per the KVFile contract, Get must return
+	// (nil, nil) for keys that do not exist rather than an error.
+	got, err := f.Get(0)
+	require.NoError(err)
+	require.Nil(got)
+}
+
+func TestOrderedFile_SetBatch_WritesAllEntries(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOrderedFile(t)
+
+	batch := map[uint64]uint64{
+		0: 10,
+		1: 20,
+		2: 30,
+	}
+	require.NoError(f.SetBatch(batch))
+
+	for k, want := range batch {
+		got, err := f.Get(k)
+		require.NoError(err)
+		require.NotNil(got)
+		require.EqualValues(want, *got, "key %d", k)
+	}
+}
+
+func TestOrderedFile_SetBatch_EmptyBatchIsNoop(t *testing.T) {
+	require := require.New(t)
+	f, path := openTestOrderedFile(t)
+
+	require.NoError(f.SetBatch(map[uint64]uint64{}))
+
+	info, err := os.Stat(path)
+	require.NoError(err)
+	require.EqualValues(0, info.Size())
+}
+
+func TestOrderedFile_Iterate_ReturnsAllStoredValuesIndexedByPosition(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOrderedFile(t)
+
+	require.NoError(f.Set(0, 100))
+	require.NoError(f.Set(1, 101))
+	require.NoError(f.Set(2, 102))
+
+	seq, err := f.Iterate()
+	require.NoError(err)
+
+	all := map[uint64]uint64{}
+	for k, v := range seq {
+		all[k] = v
+	}
+	require.Equal(map[uint64]uint64{0: 100, 1: 101, 2: 102}, all)
+}
+
+func TestOrderedFile_Iterate_ReturnsEmptyIteratorForEmptyFile(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOrderedFile(t)
+
+	seq, err := f.Iterate()
+	require.NoError(err)
+
+	count := 0
+	for range seq {
+		count++
+	}
+	require.Equal(0, count)
+}
+
+func TestOrderedFile_Size_ReflectsFileSizeDividedByItemSize(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOrderedFile(t)
+
+	size, err := f.Size()
+	require.NoError(err)
+	require.EqualValues(0, size)
+
+	require.NoError(f.Set(0, 1))
+	size, err = f.Size()
+	require.NoError(err)
+	require.EqualValues(1, size)
+
+	require.NoError(f.Set(1, 2))
+	size, err = f.Size()
+	require.NoError(err)
+	require.EqualValues(2, size)
+}
+
+func TestOrderedFile_Size_TruncatesPartiallyWrittenTrailingEntry(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ordered.dat")
+
+	// One full item plus 3 spurious bytes → Size must report 1.
+	buf := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
+	require.NoError(os.WriteFile(path, buf, 0600))
+
+	f, err := OpenOrderedFile[uint64](path, orderedItemSize, orderedReadValue, orderedWriteValue)
+	require.NoError(err)
+	defer f.Close()
+
+	size, err := f.Size()
+	require.NoError(err)
+	require.EqualValues(1, size)
+}
+
+func TestOrderedFile_Flush_IsNoop(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOrderedFile(t)
+
+	require.NoError(f.Flush())
+	require.NoError(f.Flush())
+}
+
+func TestOrderedFile_Close_ReleasesFileHandle(t *testing.T) {
+	require := require.New(t)
+	f, path := openTestOrderedFile(t)
+
+	require.NoError(f.Set(0, 7))
+	require.NoError(f.Close())
+
+	// After Close, we should still be able to read the file directly and see
+	// what was written.
+	data, err := os.ReadFile(path)
+	require.NoError(err)
+	require.EqualValues(7, binary.LittleEndian.Uint64(data))
+}
+
+func TestOrderedFile_GetMemoryFootprint_IsNonZero(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOrderedFile(t)
+
+	mf := f.GetMemoryFootprint()
+	require.NotNil(mf)
+	require.Greater(mf.Total(), uintptr(0))
+}
+
+func TestOrderedFile_Set_PropagatesWriteError(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "err.dat")
+
+	injected := errors.New("injected write failure")
+	writeFn := func(w io.Writer, _ uint64, _ uint64) error { return injected }
+
+	f, err := OpenOrderedFile[uint64](path, orderedItemSize, orderedReadValue, writeFn)
+	require.NoError(err)
+	defer f.Close()
+
+	err = f.Set(0, 1)
+	require.ErrorIs(err, injected)
+}
+
+func TestOrderedFile_Get_PropagatesReadError(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "err.dat")
+
+	injected := errors.New("injected read failure")
+	readFn := func(r io.Reader) (uint64, uint64, error) { return 0, 0, injected }
+
+	// Write enough bytes so that Seek succeeds.
+	require.NoError(os.WriteFile(path, []byte("12345678"), 0600))
+
+	f, err := OpenOrderedFile[uint64](path, orderedItemSize, readFn, orderedWriteValue)
+	require.NoError(err)
+	defer f.Close()
+
+	_, err = f.Get(0)
+	require.ErrorIs(err, injected)
+}
+
+func TestOrderedFile_Iterate_StopsOnReadError(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "err.dat")
+
+	// Two 8-byte entries: the iterator would visit both if reads succeeded.
+	require.NoError(os.WriteFile(path, []byte("1234567812345678"), 0600))
+
+	injected := errors.New("injected read failure")
+	readFn := func(r io.Reader) (uint64, uint64, error) { return 0, 0, injected }
+
+	f, err := OpenOrderedFile[uint64](path, orderedItemSize, readFn, orderedWriteValue)
+	require.NoError(err)
+	defer f.Close()
+
+	// The iterator is lazy, so Iterate itself does not read the file and
+	// therefore cannot surface the read error. Consuming the sequence
+	// terminates silently once the read fails.
+	seq, err := f.Iterate()
+	require.NoError(err)
+
+	yielded := 0
+	for range seq {
+		yielded++
+	}
+	require.Equal(0, yielded, "read errors must abort the iterator before yielding")
+}
+
+func TestOrderedFile_Close_IsIdempotent(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOrderedFile(t)
+
+	require.NoError(f.Close())
+	// A second Close must not attempt to close the underlying file again.
+	require.NoError(f.Close())
+}
+
+func TestOrderedFile_Iterate_TerminatesWhenFileIsClosed(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOrderedFile(t)
+
+	require.NoError(f.Set(0, 1))
+	require.NoError(f.Set(1, 2))
+	require.NoError(f.Set(2, 3))
+
+	seq, err := f.Iterate()
+	require.NoError(err)
+
+	next, _ := iter.Pull2(seq)
+	key, val, ok := next()
+	require.True(ok)
+	require.EqualValues(0, key)
+	require.EqualValues(1, val)
+
+	// Close the file before consuming the iterator.
+	require.NoError(f.Close())
+
+	_, _, ok = next()
+	require.False(ok)
+}
+
+func TestOrderedFile_Has_ReportsKeysWithinAllocatedRange(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOrderedFile(t)
+
+	has, err := f.Has(0)
+	require.NoError(err)
+	require.False(has)
+
+	// Writing key 2 allocates slots 0..2, so all of them exist.
+	require.NoError(f.Set(2, 42))
+	for key := uint64(0); key <= 2; key++ {
+		has, err = f.Has(key)
+		require.NoError(err)
+		require.True(has, "key %d", key)
+	}
+
+	has, err = f.Has(3)
+	require.NoError(err)
+	require.False(has)
+}
+
+// TestOrderedFile_OperationsFailAfterClose pins down that every operation
+// touching the file reports os.ErrClosed once the file has been closed; there
+// is no explicit close-state tracking, the guarantee comes from os.File.
+func TestOrderedFile_OperationsFailAfterClose(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOrderedFile(t)
+
+	require.NoError(f.Set(0, 1))
+	require.NoError(f.Close())
+
+	require.ErrorIs(f.Set(0, 1), os.ErrClosed)
+	require.ErrorIs(f.SetBatch(map[uint64]uint64{0: 1}), os.ErrClosed)
+	_, err := f.Get(0)
+	require.ErrorIs(err, os.ErrClosed)
+	_, err = f.Has(0)
+	require.ErrorIs(err, os.ErrClosed)
+	_, err = f.Size()
+	require.ErrorIs(err, os.ErrClosed)
+	_, err = f.FileSize()
+	require.ErrorIs(err, os.ErrClosed)
+	_, err = f.Iterate()
+	require.ErrorIs(err, os.ErrClosed)
+}
+
+// TestOrderedFile_Get_ReadIsBoundedToSingleRecord verifies that a value
+// decoder cannot read beyond its own record: attempting to consume more than
+// itemSize bytes fails instead of silently returning a neighbouring record's
+// data.
+func TestOrderedFile_Get_ReadIsBoundedToSingleRecord(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ordered.dat")
+
+	// Two full records on disk.
+	require.NoError(os.WriteFile(path, []byte("1234567812345678"), 0600))
+
+	// A faulty decoder that tries to read two records worth of data.
+	greedyRead := func(r io.Reader) (uint64, uint64, error) {
+		buf := make([]byte, 2*orderedItemSize)
+		if _, err := io.ReadFull(r, buf); err != nil {
+			return 0, 0, err
+		}
+		return 0, binary.LittleEndian.Uint64(buf[:8]), nil
+	}
+
+	f, err := OpenOrderedFile[uint64](path, orderedItemSize, greedyRead, orderedWriteValue)
+	require.NoError(err)
+	defer f.Close()
+
+	_, err = f.Get(0)
+	require.ErrorIs(err, io.ErrUnexpectedEOF)
+}
+
+// TestOrderedFile_ConcurrentReadsAndWritesAreSafe stresses concurrent Set,
+// Get, and Iterate calls. Records are overwritten in place, so without proper
+// synchronisation a reader racing a writer on the same record could observe a
+// torn value. Every written value consists of 8 identical bytes, so any
+// observed value with mixed bytes proves a torn read.
+func TestOrderedFile_ConcurrentReadsAndWritesAreSafe(t *testing.T) {
+	require := require.New(t)
+	f, _ := openTestOrderedFile(t)
+
+	const numKeys = 4
+	const rounds = 1000
+	pattern := func(b byte) uint64 { return 0x0101010101010101 * uint64(b) }
+	checkUniform := func(v uint64) {
+		var buf [8]byte
+		binary.LittleEndian.PutUint64(buf[:], v)
+		for _, b := range buf {
+			if b != buf[0] {
+				t.Errorf("torn read: observed value %016x with mixed bytes", v)
+				return
+			}
+		}
+	}
+
+	for key := range uint64(numKeys) {
+		require.NoError(f.Set(key, pattern(1)))
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() { // writer: overwrites records with uniform byte patterns
+		defer wg.Done()
+		for i := range rounds {
+			require.NoError(f.Set(uint64(i%numKeys), pattern(byte(i))))
+		}
+	}()
+	go func() { // point reader
+		defer wg.Done()
+		for i := range rounds {
+			value, err := f.Get(uint64(i % numKeys))
+			require.NoError(err)
+			require.NotNil(value)
+			checkUniform(*value)
+		}
+	}()
+	go func() { // iterating reader
+		defer wg.Done()
+		for range rounds / 100 {
+			seq, err := f.Iterate()
+			require.NoError(err)
+			for _, value := range seq {
+				checkUniform(value)
+			}
+		}
+	}()
+	wg.Wait()
+}
+
+func TestOrderedFile_Iterate_HandlesChunkedReader(t *testing.T) {
+	require := require.New(t)
+
+	values := []uint64{100, 200, 300, 400}
+
+	for _, chunkSize := range []int{1, 2, 4, 7, 16, 1024} {
+		t.Run(fmt.Sprintf("chunk=%d", chunkSize), func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "ordered.dat")
+
+			// A readValueFn that first pulls the raw entry bytes from the
+			// underlying reader and then streams them through utils.NewChunkReader
+			// to simulate short reads. This exercises the pattern that value
+			// decoders should follow (use io.ReadFull to tolerate short reads).
+			chunkedRead := func(r io.Reader) (uint64, uint64, error) {
+				raw := make([]byte, orderedItemSize)
+				if _, err := io.ReadFull(r, raw); err != nil {
+					return 0, 0, err
+				}
+				chunked := utils.NewChunkReader(raw, chunkSize)
+				var buf [8]byte
+				if _, err := io.ReadFull(chunked, buf[:]); err != nil {
+					return 0, 0, err
+				}
+				return 0, binary.LittleEndian.Uint64(buf[:]), nil
+			}
+
+			f, err := OpenOrderedFile[uint64](path, orderedItemSize, chunkedRead, orderedWriteValue)
+			require.NoError(err)
+			defer f.Close()
+
+			for i, v := range values {
+				require.NoError(f.Set(uint64(i), v))
+			}
+
+			seq, err := f.Iterate()
+			require.NoError(err)
+
+			all := map[uint64]uint64{}
+			for k, v := range seq {
+				all[k] = v
+			}
+			require.Len(all, len(values))
+			for i, v := range values {
+				require.EqualValues(v, all[uint64(i)], "position %d", i)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds the `OrderedFile`, an array-like `KVFile`. 
Values have a fixed size, and their position in the file is determined by their key (uint64) times the size of the stored value.

This will be used to implement caching for the MPT root list