### PR TITLE
Make flush asynchronous in `kv_cached_file.go`

### DIFF
--- a/go/backend/kv_file/kv_cached_file.go
+++ b/go/backend/kv_file/kv_cached_file.go
@@ -31,6 +31,18 @@ type KVCachedFile[K comparable, V any] struct {
 	dirty       map[K]bool
 	file        KVFileWithMemoryFootprint[K, V]
 
+	// fileMu serializes every access to file, so the background writer and a
+	// foreground operation never touch the wrapped KVFile at the same time
+	// (KVFile is not required to be safe for concurrent use). It is independent
+	// of mu: the writer performs its disk I/O holding only fileMu, so foreground
+	// operations that stay in memory (cache/buffer hits, Set) proceed under mu
+	// meanwhile, and only those that must reach the file wait on fileMu.
+	//
+	// Lock order is mu then fileMu: a foreground caller may take fileMu while
+	// holding mu, but the writer takes fileMu on its own and only re-acquires mu
+	// after releasing it, so the two never nest the other way and cannot deadlock.
+	fileMu sync.Mutex
+
 	flushBufferThreshold int
 	// maxPendingFlushes bounds the number of sealed buffers queued for the
 	// background writer, providing back-pressure that keeps memory bounded.
@@ -102,7 +114,9 @@ func (c *KVCachedFile[K, V]) Get(key K) (*V, error) {
 			return &val, nil
 		}
 	}
+	c.fileMu.Lock()
 	value, err := c.file.Get(key)
+	c.fileMu.Unlock()
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +150,10 @@ func (c *KVCachedFile[K, V]) Has(key K) (bool, error) {
 			return true, nil
 		}
 	}
-	return c.file.Has(key)
+	c.fileMu.Lock()
+	has, err := c.file.Has(key)
+	c.fileMu.Unlock()
+	return has, err
 }
 
 // Set stores a value for the given key.
@@ -179,7 +196,10 @@ func (c *KVCachedFile[K, V]) FileSize() (uint64, error) {
 	if c.writeErr != nil {
 		return 0, c.writeErr
 	}
-	return c.file.FileSize()
+	c.fileMu.Lock()
+	size, err := c.file.FileSize()
+	c.fileMu.Unlock()
+	return size, err
 }
 
 // Iterate returns an iterator over all stored key-value pairs.
@@ -195,7 +215,10 @@ func (c *KVCachedFile[K, V]) Iterate() (iter.Seq2[K, V], error) {
 
 	// After draining, every key/value pair lives on disk, so we can delegate
 	// to the underlying file's iterator.
-	return c.file.Iterate()
+	c.fileMu.Lock()
+	seq, err := c.file.Iterate()
+	c.fileMu.Unlock()
+	return seq, err
 }
 
 func (c *KVCachedFile[K, V]) Close() error {
@@ -210,13 +233,19 @@ func (c *KVCachedFile[K, V]) Close() error {
 	if err != nil {
 		return err
 	}
+	// The writer has stopped, so fileMu is uncontended here; it is still taken to
+	// keep "every file access happens under fileMu" a true invariant.
+	c.fileMu.Lock()
+	defer c.fileMu.Unlock()
 	return c.file.Close()
 }
 
 func (c *KVCachedFile[K, V]) GetMemoryFootprint() *common.MemoryFootprint {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.fileMu.Lock()
 	fileFootprint := c.file.GetMemoryFootprint()
+	c.fileMu.Unlock()
 	valueSize := func(v V) uintptr {
 		switch vv := any(v).(type) {
 		case []byte:
@@ -348,8 +377,12 @@ func (c *KVCachedFile[K, V]) flushWorker() {
 }
 
 // writeBuffer persists a single buffer to the underlying file. It is called
-// without holding c.mu so foreground operations are not blocked on disk I/O.
+// without holding c.mu so in-memory foreground operations are not blocked on
+// disk I/O; it holds fileMu instead, serializing against foreground operations
+// that reach the file (see the fileMu field).
 func (c *KVCachedFile[K, V]) writeBuffer(buf map[K]V) error {
+	c.fileMu.Lock()
+	defer c.fileMu.Unlock()
 	if err := c.file.SetBatch(buf); err != nil {
 		return err
 	}

--- a/go/backend/kv_file/kv_cached_file.go
+++ b/go/backend/kv_file/kv_cached_file.go
@@ -13,27 +13,37 @@ package kv_file
 import (
 	"fmt"
 	"iter"
+	"slices"
 	"sync"
 	"unsafe"
 
 	"github.com/0xsoniclabs/carmen/go/common"
 )
 
-// KVCachedFile wraps a KVFile and provides an in-memory cache for key-value pairs.
-// Writes to the file are buffered in memory and flushed to disk when a threshold is reached.
-//
-// The cache keeps track of which cached entries are "dirty" (i.e. have not yet
-// been persisted to the underlying file). Only dirty entries are written on
-// flush, so repeated Flush calls with no intervening Set do not rewrite the
-// same values to disk.
+// KVCachedFile wraps a KVFile with an in-memory write-back cache. Buffered
+// writes are persisted asynchronously by a background writer; Flush, Iterate
+// and Close wait for those writes to complete, while a threshold-triggered
+// write happens in the background. A background write failure is terminal and
+// is reported by the next operation.
 type KVCachedFile[K comparable, V any] struct {
 	cache       *common.LruCache[K, V]
 	flushBuffer map[K]V
 	dirty       map[K]bool
 	file        KVFileWithMemoryFootprint[K, V]
 
-	mutex                sync.Mutex
 	flushBufferThreshold int
+	// maxPendingFlushes bounds the number of sealed buffers queued for the
+	// background writer, providing back-pressure that keeps memory bounded.
+	maxPendingFlushes int
+
+	// mu guards all mutable state below and is the locker of cond.
+	mu           sync.Mutex
+	cond         *sync.Cond    // signalled whenever pending, writeErr or closed change
+	pending      []map[K]V     // sealed buffers awaiting a durable write (FIFO)
+	writeErr     error         // sticky error from the background writer
+	closed       bool          // set to stop the background writer
+	writerDone   chan struct{} // closed when the writer goroutine has exited
+	shutdownOnce sync.Once     // makes writer shutdown idempotent
 }
 
 // OpenKVCachedFile wraps the given KVFile with a cache of the specified size and a flush buffer threshold.
@@ -46,20 +56,28 @@ func OpenKVCachedFile[K comparable, V any](file KVFileWithMemoryFootprint[K, V],
 		return nil, fmt.Errorf("cacheSize and flushBufferThreshold must be greater than 0, got %d and %d", cacheSize, flushBufferThreshold)
 	}
 
-	return &KVCachedFile[K, V]{
+	c := &KVCachedFile[K, V]{
 		cache:                common.NewLruCache[K, V](cacheSize),
 		flushBuffer:          make(map[K]V),
 		dirty:                make(map[K]bool),
 		file:                 file,
 		flushBufferThreshold: flushBufferThreshold,
-	}, nil
+		maxPendingFlushes:    flushBufferThreshold + 1,
+		writerDone:           make(chan struct{}),
+	}
+	c.cond = sync.NewCond(&c.mu)
+	go c.flushWorker()
+
+	return c, nil
 }
 
-// Get retrieves a value from the cache or disk.
-// Entries found in the flushBuffer are promoted to the cache.
+// Get retrieves the value stored for a key, or nil if it does not exist.
 func (c *KVCachedFile[K, V]) Get(key K) (*V, error) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.writeErr != nil {
+		return nil, c.writeErr
+	}
 	if val, inCache := c.cache.Get(key); inCache {
 		return &val, nil
 	}
@@ -69,6 +87,20 @@ func (c *KVCachedFile[K, V]) Get(key K) (*V, error) {
 			return nil, err
 		}
 		return &val, nil
+	}
+	// Consult buffers handed to the background writer but not yet on disk,
+	// newest first. These buffers are owned by the writer and must not be
+	// mutated, but their keys were marked clean when sealed, so the value can
+	// be promoted into the cache as a clean entry: if it is later evicted it
+	// will not be re-written, and the pending buffer stays its source of truth
+	// until the writer persists it.
+	for _, v := range slices.Backward(c.pending) {
+		if val, ok := v[key]; ok {
+			if err := c.handleCacheSet(&key, &val, false); err != nil {
+				return nil, err
+			}
+			return &val, nil
+		}
 	}
 	value, err := c.file.Get(key)
 	if err != nil {
@@ -85,29 +117,45 @@ func (c *KVCachedFile[K, V]) Get(key K) (*V, error) {
 	return value, nil
 }
 
-func (c *KVCachedFile[K, V]) Set(key K, value V) error {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-	return c.handleCacheSet(&key, &value, true)
-}
-
-// Has checks if a key exists in the cache, the pending writes, or the
-// underlying file. Unlike Get, it does not load the value into the cache.
+// Has reports whether a value is stored for the given key. Unlike Get, it does
+// not load the value into the cache.
 func (c *KVCachedFile[K, V]) Has(key K) (bool, error) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.writeErr != nil {
+		return false, c.writeErr
+	}
 	if _, inCache := c.cache.Get(key); inCache {
 		return true, nil
 	}
 	if _, inFlushBuffer := c.flushBuffer[key]; inFlushBuffer {
 		return true, nil
 	}
+	for _, v := range slices.Backward(c.pending) {
+		if _, ok := v[key]; ok {
+			return true, nil
+		}
+	}
 	return c.file.Has(key)
 }
 
+// Set stores a value for the given key.
+func (c *KVCachedFile[K, V]) Set(key K, value V) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.writeErr != nil {
+		return c.writeErr
+	}
+	return c.handleCacheSet(&key, &value, true)
+}
+
+// SetBatch stores multiple key-value pairs.
 func (c *KVCachedFile[K, V]) SetBatch(entries map[K]V) error {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.writeErr != nil {
+		return c.writeErr
+	}
 
 	for key, value := range entries {
 		if err := c.handleCacheSet(&key, &value, true); err != nil {
@@ -118,48 +166,56 @@ func (c *KVCachedFile[K, V]) SetBatch(entries map[K]V) error {
 	return nil
 }
 
-// Flush writes all pending (dirty) key-value pairs to the disk.
+// Flush persists all buffered writes to disk before returning.
 func (c *KVCachedFile[K, V]) Flush() error {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-	return c.flushLocked()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.drainLocked()
 }
 
 func (c *KVCachedFile[K, V]) FileSize() (uint64, error) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.writeErr != nil {
+		return 0, c.writeErr
+	}
 	return c.file.FileSize()
 }
 
-// Iterate returns an iterator over all key-value pairs handled by the
-// KVCachedFile. Any pending writes are flushed to disk first so that the
-// underlying file iterator observes a complete, up-to-date view.
+// Iterate returns an iterator over all stored key-value pairs.
 func (c *KVCachedFile[K, V]) Iterate() (iter.Seq2[K, V], error) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-	// Flush any pending writes to ensure the underlying file is up-to-date.
-	if err := c.flushLocked(); err != nil {
+	// Flush any pending writes (and wait for in-flight ones) so the underlying
+	// file is up-to-date before iterating.
+	if err := c.drainLocked(); err != nil {
 		return nil, err
 	}
 
-	// After flushing, every key/value pair lives on disk, so we can
-	// delegate to the underlying file's iterator.
+	// After draining, every key/value pair lives on disk, so we can delegate
+	// to the underlying file's iterator.
 	return c.file.Iterate()
 }
 
 func (c *KVCachedFile[K, V]) Close() error {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-	if err := c.flushLocked(); err != nil {
+	c.mu.Lock()
+	err := c.drainLocked()
+	c.mu.Unlock()
+
+	// Stop the background writer regardless of whether the drain succeeded, so
+	// its goroutine never outlives the cached file.
+	c.shutdownWriter()
+
+	if err != nil {
 		return err
 	}
 	return c.file.Close()
 }
 
 func (c *KVCachedFile[K, V]) GetMemoryFootprint() *common.MemoryFootprint {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	fileFootprint := c.file.GetMemoryFootprint()
 	valueSize := func(v V) uintptr {
 		switch vv := any(v).(type) {
@@ -176,54 +232,144 @@ func (c *KVCachedFile[K, V]) GetMemoryFootprint() *common.MemoryFootprint {
 	for k, v := range c.flushBuffer {
 		sizeValues += unsafe.Sizeof(k) + valueSize(v)
 	}
+	for _, buf := range c.pending {
+		for k, v := range buf {
+			sizeValues += unsafe.Sizeof(k) + valueSize(v)
+		}
+	}
 	var dirtySize uintptr
 	for k := range c.dirty {
 		dirtySize += unsafe.Sizeof(k) + unsafe.Sizeof(true)
 	}
-	return common.NewMemoryFootprint(unsafe.Sizeof(*c) + sizeValues + dirtySize + mf.Total() + fileFootprint.Total())
+	var pending uintptr
+	for _, buf := range c.pending {
+		pending += unsafe.Sizeof(buf)
+	}
+	return common.NewMemoryFootprint(unsafe.Sizeof(*c) + sizeValues + dirtySize + pending + mf.Total() + fileFootprint.Total())
 }
 
-// flushLocked moves all dirty cache entries into the flush buffer and then
-// writes the buffer to the underlying file. Clean cache entries are left in
-// place so that they are not re-written to disk. This is intended to be
-// called with the mutex locked.
-func (c *KVCachedFile[K, V]) flushLocked() error {
+// drainLocked persists all buffered writes and waits for them to complete,
+// returning the sticky write error if any. The caller must hold c.mu.
+func (c *KVCachedFile[K, V]) drainLocked() error {
+	if c.writeErr != nil {
+		return c.writeErr
+	}
 	c.cache.Iterate(func(key K, value V) bool {
 		if _, isDirty := c.dirty[key]; isDirty {
 			c.flushBuffer[key] = value
 		}
 		return true
 	})
-
-	return c.flushPending()
+	c.enqueueCurrentBufferLocked()
+	for len(c.pending) > 0 && c.writeErr == nil {
+		c.cond.Wait()
+	}
+	return c.writeErr
 }
 
-// flushPending empties the flushBuffer by writing its contents to the
-// underlying file via SetBatch and then calling Flush on it. Keys that have
-// been persisted are removed from the dirty set. This is intended to be
-// called with the mutex locked.
-func (c *KVCachedFile[K, V]) flushPending() error {
-	if len(c.flushBuffer) == 0 {
-		return nil
+// waitForPendingFlushes blocks until the background writer has persisted every
+// queued buffer, returning the sticky write error if any. The caller must not
+// hold c.mu.
+func (c *KVCachedFile[K, V]) waitForPendingFlushes() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for len(c.pending) > 0 && c.writeErr == nil {
+		c.cond.Wait()
 	}
+	return c.writeErr
+}
 
-	if err := c.file.SetBatch(c.flushBuffer); err != nil {
-		return err
+// enqueueCurrentBufferLocked hands the current flush buffer to the background
+// writer and starts a fresh one. The caller must hold c.mu.
+func (c *KVCachedFile[K, V]) enqueueCurrentBufferLocked() {
+	if len(c.flushBuffer) == 0 {
+		return
 	}
-	if err := c.file.Flush(); err != nil {
-		return err
+	// Block while the queue is full to bound memory (back-pressure).
+	for len(c.pending) >= c.maxPendingFlushes && c.writeErr == nil && !c.closed {
+		c.cond.Wait()
 	}
+	if c.writeErr != nil || c.closed {
+		return
+	}
+	// The buffered values are now committed to the background writer and will
+	// be persisted, so mark them clean immediately. A subsequent Set of any of
+	// these keys re-dirties it and is tracked in a later buffer; because
+	// buffers are written in FIFO order, the newer value wins on disk and no
+	// update is lost. (Clearing after the write completes instead would let a
+	// re-Set-while-in-flight be wrongly marked clean and dropped.)
 	for k := range c.flushBuffer {
 		delete(c.dirty, k)
 	}
+	c.pending = append(c.pending, c.flushBuffer)
 	c.flushBuffer = make(map[K]V)
-	return nil
+	c.cond.Broadcast()
 }
 
-// handleCacheSet caches the given key/value pair, marking it dirty. If the
-// insertion evicts another entry from the cache, that entry is moved into the
-// flush buffer; when the buffer reaches the flush threshold the pending writes
-// are persisted to the underlying file.
+// flushWorker is the background goroutine that persists queued buffers to disk
+// in FIFO order. On a write error it records the error as terminal and parks
+// until the file is closed, retaining the unwritten buffers.
+func (c *KVCachedFile[K, V]) flushWorker() {
+	defer close(c.writerDone)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for {
+		for len(c.pending) == 0 && !c.closed {
+			c.cond.Wait()
+		}
+		if c.closed {
+			return
+		}
+		if c.writeErr != nil {
+			// Terminal error: keep the pending buffers readable and park
+			// until Close wakes us.
+			c.cond.Wait()
+			continue
+		}
+
+		// Peek the oldest buffer but leave it in the queue so concurrent
+		// readers can still find its entries while it is being written.
+		buf := c.pending[0]
+		c.mu.Unlock()
+		err := c.writeBuffer(buf)
+		c.mu.Lock()
+
+		if err != nil {
+			c.writeErr = err
+			c.cond.Broadcast()
+			continue
+		}
+		// The dirty flags for these keys were already cleared when the buffer
+		// was sealed, so the writer only needs to drop the buffer from the
+		// queue.
+		c.pending = c.pending[1:]
+		c.cond.Broadcast()
+	}
+}
+
+// writeBuffer persists a single buffer to the underlying file. It is called
+// without holding c.mu so foreground operations are not blocked on disk I/O.
+func (c *KVCachedFile[K, V]) writeBuffer(buf map[K]V) error {
+	if err := c.file.SetBatch(buf); err != nil {
+		return err
+	}
+	return c.file.Flush()
+}
+
+// shutdownWriter stops the background writer and waits for it to exit. It is
+// idempotent and performs no file I/O.
+func (c *KVCachedFile[K, V]) shutdownWriter() {
+	c.shutdownOnce.Do(func() {
+		c.mu.Lock()
+		c.closed = true
+		c.cond.Broadcast()
+		c.mu.Unlock()
+		<-c.writerDone
+	})
+}
+
+// handleCacheSet inserts a key-value pair into the cache, optionally marking it
+// dirty. The caller must hold c.mu.
 func (c *KVCachedFile[K, V]) handleCacheSet(key *K, value *V, dirty bool) error {
 	if key == nil || value == nil {
 		return nil // No-op
@@ -231,12 +377,14 @@ func (c *KVCachedFile[K, V]) handleCacheSet(key *K, value *V, dirty bool) error 
 	if dirty {
 		c.dirty[*key] = true
 	}
+	// An evicted dirty entry moves into the flush buffer; reaching the
+	// threshold seals the buffer for the background writer.
 	evictedKey, evictedValue, evicted := c.cache.Set(*key, *value)
 	if evicted {
 		if _, isDirty := c.dirty[evictedKey]; isDirty {
 			c.flushBuffer[evictedKey] = evictedValue
 			if len(c.flushBuffer) >= c.flushBufferThreshold {
-				return c.flushPending()
+				c.enqueueCurrentBufferLocked()
 			}
 		}
 	}

--- a/go/backend/kv_file/kv_cached_file.go
+++ b/go/backend/kv_file/kv_cached_file.go
@@ -256,14 +256,15 @@ func (c *KVCachedFile[K, V]) GetMemoryFootprint() *common.MemoryFootprint {
 			return uintptr(unsafe.Sizeof(v))
 		}
 	}
-	mf := c.cache.GetDynamicMemoryFootprint(valueSize)
-	var sizeValues uintptr
+	cacheFootprint := c.cache.GetDynamicMemoryFootprint(valueSize)
+	var flushBufferSize uintptr
 	for k, v := range c.flushBuffer {
-		sizeValues += unsafe.Sizeof(k) + valueSize(v)
+		flushBufferSize += unsafe.Sizeof(k) + valueSize(v)
 	}
+	var pendingSize uintptr
 	for _, buf := range c.pending {
 		for k, v := range buf {
-			sizeValues += unsafe.Sizeof(k) + valueSize(v)
+			pendingSize += unsafe.Sizeof(k) + valueSize(v)
 		}
 	}
 	var dirtySize uintptr
@@ -274,7 +275,13 @@ func (c *KVCachedFile[K, V]) GetMemoryFootprint() *common.MemoryFootprint {
 	for _, buf := range c.pending {
 		pending += unsafe.Sizeof(buf)
 	}
-	return common.NewMemoryFootprint(unsafe.Sizeof(*c) + sizeValues + dirtySize + pending + mf.Total() + fileFootprint.Total())
+	footprint := common.NewMemoryFootprint(unsafe.Sizeof(*c))
+	footprint.AddChild("file", fileFootprint)
+	footprint.AddChild("cache", cacheFootprint)
+	footprint.AddChild("flushBuffer", common.NewMemoryFootprint(flushBufferSize))
+	footprint.AddChild("pending", common.NewMemoryFootprint(pendingSize+pending))
+	footprint.AddChild("dirty", common.NewMemoryFootprint(dirtySize))
+	return footprint
 }
 
 // drainLocked persists all buffered writes and waits for them to complete,

--- a/go/backend/kv_file/kv_cached_file.go
+++ b/go/backend/kv_file/kv_cached_file.go
@@ -303,18 +303,6 @@ func (c *KVCachedFile[K, V]) drainLocked() error {
 	return c.writeErr
 }
 
-// waitForPendingFlushes blocks until the background writer has persisted every
-// queued buffer, returning the sticky write error if any. The caller must not
-// hold c.mu.
-func (c *KVCachedFile[K, V]) waitForPendingFlushes() error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	for len(c.pending) > 0 && c.writeErr == nil {
-		c.cond.Wait()
-	}
-	return c.writeErr
-}
-
 // enqueueCurrentBufferLocked hands the current flush buffer to the background
 // writer and starts a fresh one. The caller must hold c.mu.
 func (c *KVCachedFile[K, V]) enqueueCurrentBufferLocked() {

--- a/go/backend/kv_file/kv_cached_file_test.go
+++ b/go/backend/kv_file/kv_cached_file_test.go
@@ -14,7 +14,10 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"maps"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/stretchr/testify/require"
@@ -210,12 +213,12 @@ func TestKVCachedFile_Set_UpdatesCache(t *testing.T) {
 	require.Equal(value1, got)
 }
 
-func TestKVCachedFile_Set_ReturnsErrorWhenBackingFileWriteFails(t *testing.T) {
+func TestKVCachedFile_Set_SurfacesAsyncWriteErrorOnNextOperation(t *testing.T) {
 	require := require.New(t)
 	c, mock := openTestKVCachedFile(t)
 
 	// Fill enough entries so that the next Set pushes the flush buffer to the
-	// threshold and triggers a file write.
+	// threshold and triggers a background file write.
 	for i := 0; i < cacheSize+flushBufferThreshold-1; i++ {
 		require.NoError(c.Set(i, fmt.Sprintf("value%d", i)))
 	}
@@ -223,8 +226,46 @@ func TestKVCachedFile_Set_ReturnsErrorWhenBackingFileWriteFails(t *testing.T) {
 	injected := errors.New("write failed")
 	mock.EXPECT().SetBatch(gomock.Any()).Return(injected)
 
-	err := c.Set(cacheSize+flushBufferThreshold-1, "trigger")
+	// The write is asynchronous, so the triggering Set itself does not fail;
+	// the error surfaces on the next operation (here a Flush barrier).
+	require.NoError(c.Set(cacheSize+flushBufferThreshold-1, "trigger"))
+	require.ErrorIs(c.Flush(), injected)
+
+	// The error is sticky: subsequent operations keep reporting it.
+	_, err := c.Get(0)
 	require.ErrorIs(err, injected)
+}
+
+func TestKVCachedFile_Operations_ReturnStickyErrorAfterBackgroundWriteFailure(t *testing.T) {
+	injected := errors.New("background write failed")
+
+	// induce drives the cache into its terminal error state by making the
+	// background writer fail a flush.
+	induce := func(t *testing.T, c *KVCachedFile[K, V], mock *MockKVFileWithMemoryFootprint[K, V]) {
+		mock.EXPECT().SetBatch(gomock.Any()).Return(injected).AnyTimes()
+		mock.EXPECT().Flush().Return(nil).AnyTimes()
+		c.flushBuffer[999] = "boom"
+		require.ErrorIs(t, c.Flush(), injected)
+	}
+
+	tests := map[string]func(c *KVCachedFile[K, V]) error{
+		"Get":      func(c *KVCachedFile[K, V]) error { _, err := c.Get(key1); return err },
+		"Has":      func(c *KVCachedFile[K, V]) error { _, err := c.Has(key1); return err },
+		"Set":      func(c *KVCachedFile[K, V]) error { return c.Set(key1, value1) },
+		"SetBatch": func(c *KVCachedFile[K, V]) error { return c.SetBatch(map[K]V{key1: value1}) },
+		"Flush":    func(c *KVCachedFile[K, V]) error { return c.Flush() },
+		"FileSize": func(c *KVCachedFile[K, V]) error { _, err := c.FileSize(); return err },
+		"Iterate":  func(c *KVCachedFile[K, V]) error { _, err := c.Iterate(); return err },
+	}
+
+	for name, op := range tests {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			c, mock := openTestKVCachedFile(t)
+			induce(t, c, mock)
+			require.ErrorIs(op(c), injected)
+		})
+	}
 }
 
 func TestKVCachedFile_Set_ReDirtiesKeyAfterFlush(t *testing.T) {
@@ -248,6 +289,87 @@ func TestKVCachedFile_Set_ReDirtiesKeyAfterFlush(t *testing.T) {
 
 	_, isDirty = c.dirty[1]
 	require.False(isDirty)
+}
+
+func TestKVCachedFile_Get_PromotesInFlightValueIntoCacheAsClean(t *testing.T) {
+	require := require.New(t)
+	c, mock := openTestKVCachedFile(t)
+
+	// Block the background writer inside SetBatch so the sealed buffer stays
+	// in flight while we read one of its keys.
+	release := make(chan struct{})
+	writing := make(chan struct{})
+	var once sync.Once
+	mock.EXPECT().SetBatch(gomock.Any()).DoAndReturn(func(map[K]V) error {
+		once.Do(func() { close(writing) })
+		<-release
+		return nil
+	}).AnyTimes()
+	mock.EXPECT().Flush().Return(nil).AnyTimes()
+
+	// Fill the cache and seal a buffer; key 0 is evicted into the in-flight buffer.
+	for i := 0; i < cacheSize+flushBufferThreshold; i++ {
+		require.NoError(c.Set(i, fmt.Sprintf("value%d", i)))
+	}
+	<-writing // the writer is blocked with key 0 still in a pending buffer
+
+	// Reading key 0 serves it from the pending buffer and promotes it into the
+	// cache as a clean entry.
+	got, err := c.Get(0)
+	require.NoError(err)
+	require.NotNil(got)
+	require.Equal("value0", *got)
+
+	cached, found := c.cache.Get(0)
+	require.True(found)
+	require.Equal("value0", cached)
+	_, isDirty := c.dirty[0]
+	require.False(isDirty, "promoted in-flight value must be cached as clean")
+
+	close(release)
+	require.NoError(c.Flush())
+}
+
+func TestKVCachedFile_Set_ReSetWhileInFlightIsNotLost(t *testing.T) {
+	require := require.New(t)
+	c, mock := openTestKVCachedFile(t)
+
+	// Seal a buffer for the background writer and block it inside SetBatch so
+	// the buffer stays in flight while we re-Set one of its keys.
+	release := make(chan struct{})
+	firstWrite := make(chan struct{})
+	var once sync.Once
+	written := map[K]V{}
+	mock.EXPECT().SetBatch(gomock.Any()).DoAndReturn(func(entries map[K]V) error {
+		once.Do(func() { close(firstWrite) })
+		<-release
+		for k, v := range entries {
+			written[k] = v
+		}
+		return nil
+	}).AnyTimes()
+	mock.EXPECT().Flush().Return(nil).AnyTimes()
+
+	// Fill the cache and evict (threshold) entries to seal the first buffer.
+	for i := 0; i < cacheSize+flushBufferThreshold; i++ {
+		require.NoError(c.Set(i, fmt.Sprintf("value%d", i)))
+	}
+	<-firstWrite // the writer is now blocked inside SetBatch with key 0 in flight
+
+	// Re-Set key 0 with a new value while its old value is being written.
+	require.NoError(c.Set(0, "value0-new"))
+
+	// Let the in-flight write finish, then flush everything.
+	close(release)
+	require.NoError(c.Flush())
+
+	// The re-Set value must have survived and reached disk.
+	require.Equal("value0-new", written[0])
+
+	got, err := c.Get(0)
+	require.NoError(err)
+	require.NotNil(got)
+	require.Equal("value0-new", *got)
 }
 
 func TestKVCachedFile_Flush_WritesCacheAndBufferToFile(t *testing.T) {
@@ -522,6 +644,22 @@ func TestKVCachedFile_Close_ReturnsErrorOnFileCloseError(t *testing.T) {
 	require.ErrorIs(err, injected)
 }
 
+func TestKVCachedFile_Close_StopsBackgroundWriter(t *testing.T) {
+	require := require.New(t)
+	c, mock := openTestKVCachedFile(t)
+	mock.EXPECT().Close().Return(nil)
+
+	require.NoError(c.Close())
+
+	// Close waits for the writer to exit before returning, so writerDone is
+	// already closed by now.
+	select {
+	case <-c.writerDone:
+	default:
+		require.Fail("background writer still running after Close")
+	}
+}
+
 func TestKVCachedFile_GetMemoryFootprint_IsNonZero(t *testing.T) {
 	require := require.New(t)
 	c, mock := openTestKVCachedFile(t)
@@ -553,6 +691,108 @@ func TestKVCachedFile_flushPending_ClearsDirtyForFlushedKeys(t *testing.T) {
 
 	require.NoError(c.Flush())
 	require.Empty(c.dirty)
+}
+
+func TestKVCachedFile_Open_SetsMaxPendingFlushesToFlushBufferSizePlusOne(t *testing.T) {
+	tests := map[string]int{
+		"threshold 1":   1,
+		"threshold 3":   3,
+		"threshold 100": 100,
+	}
+	for name, threshold := range tests {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			mock := NewMockKVFileWithMemoryFootprint[K, V](ctrl)
+			c, err := OpenKVCachedFile[K, V](mock, cacheSize, threshold)
+			require.NoError(err)
+			t.Cleanup(c.shutdownWriter)
+			require.Equal(threshold+1, c.maxPendingFlushes)
+		})
+	}
+}
+
+func TestKVCachedFile_Set_AppliesBackPressureWhenPendingQueueIsFull(t *testing.T) {
+	require := require.New(t)
+	c, mock := openTestKVCachedFile(t)
+
+	// Block the background writer on the first buffer so the queue cannot drain.
+	release := make(chan struct{})
+	writing := make(chan struct{})
+	var once sync.Once
+	mock.EXPECT().SetBatch(gomock.Any()).DoAndReturn(func(map[K]V) error {
+		once.Do(func() { close(writing) })
+		<-release
+		return nil
+	}).AnyTimes()
+	mock.EXPECT().Flush().Return(nil).AnyTimes()
+
+	// sealOne hands a one-entry buffer to the writer.
+	sealOne := func() {
+		c.mu.Lock()
+		c.flushBuffer[0] = "v"
+		c.enqueueCurrentBufferLocked()
+		c.mu.Unlock()
+	}
+
+	// Fill the queue to capacity: the writer picks up the first buffer and
+	// blocks inside SetBatch, so nothing drains.
+	sealOne()
+	<-writing
+	for i := 1; i < c.maxPendingFlushes; i++ {
+		sealOne()
+	}
+
+	// The next seal must block until the writer drains a buffer.
+	done := make(chan struct{})
+	go func() {
+		sealOne()
+		close(done)
+	}()
+	isDone := func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}
+	require.Never(isDone, 100*time.Millisecond, 10*time.Millisecond,
+		"seal must block while the pending queue is full")
+
+	// Releasing the writer lets it drain, which unblocks the pending seal.
+	close(release)
+	require.Eventually(isDone, time.Second, 10*time.Millisecond,
+		"seal must resume once the writer drains a buffer")
+}
+
+func TestKVCachedFile_waitForPendingFlushes_ReturnsBackgroundWriteError(t *testing.T) {
+	require := require.New(t)
+	c, mock := openTestKVCachedFile(t)
+
+	injected := errors.New("background write failed")
+	mock.EXPECT().SetBatch(gomock.Any()).Return(injected).AnyTimes()
+
+	// Flush seals a buffer and waits; the background write fails, recording the
+	// terminal error, which waitForPendingFlushes then also reports.
+	c.flushBuffer[1] = "boom"
+	require.ErrorIs(c.Flush(), injected)
+	require.ErrorIs(c.waitForPendingFlushes(), injected)
+}
+
+func TestKVCachedFile_shutdownWriter_IsIdempotent(t *testing.T) {
+	require := require.New(t)
+	c, _ := openTestKVCachedFile(t)
+
+	// Repeated calls must neither panic nor block, and the writer must exit.
+	c.shutdownWriter()
+	c.shutdownWriter()
+
+	select {
+	case <-c.writerDone:
+	default:
+		require.Fail("background writer still running after shutdown")
+	}
 }
 
 func TestKVCachedFile_handleCacheSet_UpdatesCache(t *testing.T) {
@@ -611,7 +851,8 @@ func TestKVCachedFile_handleCacheSet_FlushesBufferToFileWhenThresholdReached(t *
 	mock.EXPECT().Flush().Return(nil).Times(1)
 
 	// Insert enough entries so that the cache is full and (threshold - 1)
-	// entries have been evicted into the buffer.
+	// entries have been evicted into the buffer. No flush is triggered yet, so
+	// the background writer stays parked and these unlocked calls are safe.
 	total := cacheSize + flushBufferThreshold - 1
 	for i := 0; i < total; i++ {
 		v := fmt.Sprintf("value%d", i)
@@ -619,18 +860,26 @@ func TestKVCachedFile_handleCacheSet_FlushesBufferToFileWhenThresholdReached(t *
 	}
 	require.Equal(flushBufferThreshold-1, len(c.flushBuffer))
 
-	// The next insert pushes the buffer to the threshold and triggers a flush.
+	// The next insert pushes the buffer to the threshold and seals it for the
+	// background writer. This call wakes the writer, so it must hold the lock.
 	key := total
 	value := fmt.Sprintf("value%d", key)
-	require.NoError(c.handleCacheSet(&key, &value, true))
+	c.mu.Lock()
+	err := c.handleCacheSet(&key, &value, true)
+	c.mu.Unlock()
+	require.NoError(err)
+
+	// The buffer is sealed synchronously, so it is empty immediately; the
+	// actual write completes asynchronously, so wait for it before inspecting
+	// what was written.
+	require.Equal(0, len(c.flushBuffer))
+	require.NoError(c.waitForPendingFlushes())
 
 	// The newly-inserted entry lives in the cache.
 	cached, found := c.cache.Get(key)
 	require.True(found)
 	require.Equal(value, cached)
 
-	// The buffer has been drained after being flushed to the file.
-	require.Equal(0, len(c.flushBuffer))
 	require.Equal(flushBufferThreshold, len(written))
 	for i := 0; i < flushBufferThreshold; i++ {
 		require.Equal(fmt.Sprintf("value%d", i), written[i])
@@ -705,8 +954,183 @@ func TestKVCachedFile_handleCacheSet_UpdatedEntryIsRetrievedInAllLocations(t *te
 }
 
 // ---------------------------------------------------------------------------
+// Flush-worker / Set interaction tests
+// ---------------------------------------------------------------------------
+
+// Get must serve a key from the newest buffer when it is queued in several.
+func TestKVCachedFile_Get_ReturnsNewestValueAcrossMultiplePendingBuffers(t *testing.T) {
+	require := require.New(t)
+	c, mock := openTestKVCachedFile(t)
+
+	// Block the writer inside SetBatch so a sealed buffer stays in c.pending; the
+	// writer keeps the buffer it is writing in the queue until the write returns,
+	// so both sealed buffers coexist there while we read the key.
+	release := make(chan struct{})
+	writing := make(chan struct{})
+	var once sync.Once
+	mock.EXPECT().SetBatch(gomock.Any()).DoAndReturn(func(map[K]V) error {
+		once.Do(func() { close(writing) })
+		<-release
+		return nil
+	}).AnyTimes()
+	mock.EXPECT().Flush().Return(nil).AnyTimes()
+
+	seal := func(val V) {
+		c.mu.Lock()
+		c.flushBuffer[key1] = val
+		c.enqueueCurrentBufferLocked()
+		c.mu.Unlock()
+	}
+
+	// First buffer goes in flight; the second is queued behind it, so key1 now
+	// lives in two pending buffers: {key1:"old"} then {key1:"new"}.
+	seal("old")
+	<-writing
+	seal("new")
+
+	got, err := c.Get(key1)
+	require.NoError(err)
+	require.NotNil(got)
+	require.Equal("new", *got, "Get must return the newest pending value")
+
+	close(release)
+	require.NoError(c.Flush())
+}
+
+// The background writer must persist queued buffers oldest-first so the newest
+// value of a repeated key lands on disk last and wins.
+func TestKVCachedFile_FlushWorker_PersistsBuffersInFIFOOrder(t *testing.T) {
+	require := require.New(t)
+	c, mock := openTestKVCachedFile(t)
+
+	release := make(chan struct{})
+	writing := make(chan struct{})
+	var once sync.Once
+	var writeOrder []V
+	mock.EXPECT().SetBatch(gomock.Any()).DoAndReturn(func(entries map[K]V) error {
+		once.Do(func() { close(writing) })
+		<-release
+		writeOrder = append(writeOrder, entries[key1])
+		return nil
+	}).AnyTimes()
+	mock.EXPECT().Flush().Return(nil).AnyTimes()
+
+	seal := func(val V) {
+		c.mu.Lock()
+		c.flushBuffer[key1] = val
+		c.enqueueCurrentBufferLocked()
+		c.mu.Unlock()
+	}
+
+	seal("old")
+	<-writing   // writer holds the first buffer in flight
+	seal("new") // queued behind it
+
+	close(release)
+	require.NoError(c.Flush())
+
+	require.Equal([]V{"old", "new"}, writeOrder,
+		"buffers must be written oldest-first so the newest value wins on disk")
+}
+
+// Concurrent callers and the background writer must not race. Run with -race.
+func TestKVCachedFile_SetGetHasAndFlush_AreRaceFree(t *testing.T) {
+	require := require.New(t)
+	c, err := OpenKVCachedFile[K, V](newFakeKVFile(), cacheSize, flushBufferThreshold)
+	require.NoError(err)
+	t.Cleanup(c.shutdownWriter)
+
+	const (
+		workers        = 8
+		opsPerWorker   = 300
+		keySpace     K = 32
+	)
+	var wg sync.WaitGroup
+	for w := range workers {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := range opsPerWorker {
+				k := K(i) % keySpace
+				switch i % 4 {
+				case 0:
+					_ = c.Set(k, fmt.Sprintf("w%d-i%d", w, i))
+				case 1:
+					_, _ = c.Get(k)
+				case 2:
+					_, _ = c.Has(k)
+				case 3:
+					_ = c.Flush()
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	require.NoError(c.Flush())
+	require.NoError(c.Close())
+}
+
+// ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
+
+// fakeKVFile is a minimal thread-safe in-memory KVFile for concurrency tests,
+// where a gomock mock's expectation bookkeeping would itself serialize calls.
+type fakeKVFile struct {
+	mu   sync.Mutex
+	data map[K]V
+}
+
+func newFakeKVFile() *fakeKVFile {
+	return &fakeKVFile{data: make(map[K]V)}
+}
+
+func (f *fakeKVFile) Get(key K) (*V, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if v, ok := f.data[key]; ok {
+		return &v, nil
+	}
+	return nil, nil
+}
+
+func (f *fakeKVFile) Has(key K) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.data[key]
+	return ok, nil
+}
+
+func (f *fakeKVFile) Set(key K, value V) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.data[key] = value
+	return nil
+}
+
+func (f *fakeKVFile) SetBatch(entries map[K]V) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	maps.Copy(f.data, entries)
+	return nil
+}
+
+func (f *fakeKVFile) Flush() error { return nil }
+
+func (f *fakeKVFile) FileSize() (uint64, error) { return 0, nil }
+
+func (f *fakeKVFile) Iterate() (iter.Seq2[K, V], error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return mockIterateSeq(maps.Clone(f.data)), nil
+}
+
+func (f *fakeKVFile) Close() error { return nil }
+
+func (f *fakeKVFile) GetMemoryFootprint() *common.MemoryFootprint {
+	return common.NewMemoryFootprint(0)
+}
 
 func openTestKVCachedFile(t *testing.T) (*KVCachedFile[K, V], *MockKVFileWithMemoryFootprint[K, V]) {
 	t.Helper()
@@ -714,6 +1138,11 @@ func openTestKVCachedFile(t *testing.T) (*KVCachedFile[K, V], *MockKVFileWithMem
 	mock := NewMockKVFileWithMemoryFootprint[K, V](ctrl)
 	file, err := OpenKVCachedFile[K, V](mock, cacheSize, flushBufferThreshold)
 	require.NoError(t, err)
+	// Stop the background writer when the test ends so its goroutine never
+	// outlives the test. This performs no file I/O and is idempotent, so it
+	// is harmless for tests that already call Close. It runs before the
+	// gomock controller's own cleanup verifies expectations.
+	t.Cleanup(file.shutdownWriter)
 	return file, mock
 }
 

--- a/go/backend/kv_file/kv_cached_file_test.go
+++ b/go/backend/kv_file/kv_cached_file_test.go
@@ -17,7 +17,6 @@ import (
 	"maps"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/stretchr/testify/require"
@@ -35,11 +34,46 @@ const (
 type K = int
 type V = string
 
-func TestKVCachedFile_Open_ReturnsErrorOnNilFile(t *testing.T) {
-	require := require.New(t)
+func TestKVCachedFile_Open_ReturnsErrorOnInvalidArguments(t *testing.T) {
+	mock := NewMockKVFileWithMemoryFootprint[K, V](gomock.NewController(t))
+	tests := map[string]struct {
+		file                 KVFileWithMemoryFootprint[K, V]
+		cacheSize            int
+		flushBufferThreshold int
+	}{
+		"nil file":            {file: nil, cacheSize: cacheSize, flushBufferThreshold: flushBufferThreshold},
+		"zero cache size":     {file: mock, cacheSize: 0, flushBufferThreshold: flushBufferThreshold},
+		"negative cache size": {file: mock, cacheSize: -1, flushBufferThreshold: flushBufferThreshold},
+		"zero threshold":      {file: mock, cacheSize: cacheSize, flushBufferThreshold: 0},
+		"negative threshold":  {file: mock, cacheSize: cacheSize, flushBufferThreshold: -1},
+	}
 
-	_, err := OpenKVCachedFile[K, V](nil, cacheSize, flushBufferThreshold)
-	require.Error(err)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			_, err := OpenKVCachedFile[K, V](test.file, test.cacheSize, test.flushBufferThreshold)
+			require.Error(err)
+		})
+	}
+}
+
+func TestKVCachedFile_Open_SetsMaxPendingFlushesToThresholdPlusOne(t *testing.T) {
+	tests := map[string]int{
+		"threshold 1":   1,
+		"threshold 3":   3,
+		"threshold 100": 100,
+	}
+	for name, threshold := range tests {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			mock := NewMockKVFileWithMemoryFootprint[K, V](ctrl)
+			c, err := OpenKVCachedFile[K, V](mock, cacheSize, threshold)
+			require.NoError(err)
+			t.Cleanup(c.shutdownWriter)
+			require.Equal(threshold+1, c.maxPendingFlushes)
+		})
+	}
 }
 
 func TestKVCachedFile_Get_ReturnsValueCorrectly(t *testing.T) {
@@ -81,6 +115,114 @@ func TestKVCachedFile_Get_ReturnsValueCorrectly(t *testing.T) {
 			require.Equal(want, *got)
 		})
 	}
+}
+
+func TestKVCachedFile_Get_ReturnsNilOnUnknownKey(t *testing.T) {
+	require := require.New(t)
+	c, mock := openTestKVCachedFile(t)
+
+	mock.EXPECT().Get(999).Return(nil, nil)
+
+	got, err := c.Get(999)
+	require.NoError(err)
+	require.Nil(got)
+	_, inCache := c.cache.Get(999)
+	require.False(inCache)
+}
+
+func TestKVCachedFile_Get_ReturnsErrorOnFileReadError(t *testing.T) {
+	require := require.New(t)
+	c, mock := openTestKVCachedFile(t)
+
+	injected := errors.New("read failed")
+	mock.EXPECT().Get(key1).Return(nil, injected)
+
+	got, err := c.Get(key1)
+	require.ErrorIs(err, injected)
+	require.Nil(got)
+}
+
+func TestKVCachedFile_Get_PromotesValuesInFlushBufferIntoCacheAsDirty(t *testing.T) {
+	require := require.New(t)
+	// No file interactions expected: the buffer never reaches the flush
+	// threshold before the value is promoted back into the cache.
+	c, _ := openTestKVCachedFile(t)
+
+	for i := 0; i < cacheSize+1; i++ {
+		require.NoError(c.Set(i, fmt.Sprintf("value%d", i)))
+	}
+	_, inBuffer := c.flushBuffer[0]
+	require.True(inBuffer)
+
+	got, err := c.Get(0)
+	require.NoError(err)
+	require.NotNil(got)
+	require.Equal("value0", *got)
+
+	_, inBuffer = c.flushBuffer[0]
+	require.False(inBuffer)
+	cached, found := c.cache.Get(0)
+	require.True(found)
+	require.Equal("value0", cached)
+	// The value was removed from the buffer without being written, so it must
+	// stay dirty: a clean promotion would drop it on eviction and lose the write.
+	_, isDirty := c.dirty[0]
+	require.True(isDirty, "value promoted from the flush buffer must be cached as dirty")
+}
+
+func TestKVCachedFile_Get_PromotesInFlightValueIntoCacheAsClean(t *testing.T) {
+	require := require.New(t)
+	c, mock := openTestKVCachedFile(t)
+
+	// Block the background writer inside SetBatch so the sealed buffer stays
+	// in flight while we read one of its keys.
+	writing, unblockWriter := blockWriter(t, mock, nil)
+
+	// Fill the cache and seal a buffer; key 0 is evicted into the in-flight buffer.
+	for i := 0; i < cacheSize+flushBufferThreshold; i++ {
+		require.NoError(c.Set(i, fmt.Sprintf("value%d", i)))
+	}
+	<-writing // the writer is blocked with key 0 still in a pending buffer
+
+	// Reading key 0 serves it from the pending buffer and promotes it into the
+	// cache as a clean entry.
+	got, err := c.Get(0)
+	require.NoError(err)
+	require.NotNil(got)
+	require.Equal("value0", *got)
+
+	cached, found := c.cache.Get(0)
+	require.True(found)
+	require.Equal("value0", cached)
+	_, isDirty := c.dirty[0]
+	require.False(isDirty, "promoted in-flight value must be cached as clean")
+
+	unblockWriter()
+	require.NoError(c.Flush())
+}
+
+func TestKVCachedFile_Get_ReturnsNewestValueAcrossMultiplePendingBuffers(t *testing.T) {
+	require := require.New(t)
+	c, mock := openTestKVCachedFile(t)
+
+	// Block the writer inside SetBatch so a sealed buffer stays in c.pending; the
+	// writer keeps the buffer it is writing in the queue until the write returns,
+	// so both sealed buffers coexist there while we read the key.
+	writing, unblockWriter := blockWriter(t, mock, nil)
+
+	// First buffer goes in flight; the second is queued behind it, so key1 now
+	// lives in two pending buffers: {key1:"old"} then {key1:"new"}.
+	sealBuffer(c, key1, "old")
+	<-writing
+	sealBuffer(c, key1, "new")
+
+	got, err := c.Get(key1)
+	require.NoError(err)
+	require.NotNil(got)
+	require.Equal("new", *got, "Get must return the newest pending value")
+
+	unblockWriter()
+	require.NoError(c.Flush())
 }
 
 func TestKVCachedFile_Has_ChecksCacheBufferAndFile(t *testing.T) {
@@ -126,6 +268,24 @@ func TestKVCachedFile_Has_ChecksCacheBufferAndFile(t *testing.T) {
 	}
 }
 
+func TestKVCachedFile_Has_FindsKeyInPendingBuffers(t *testing.T) {
+	require := require.New(t)
+	c, mock := openTestKVCachedFile(t)
+
+	// Block the writer inside SetBatch so the sealed buffer holding key1 stays
+	// in the pending queue while it is looked up.
+	writing, unblockWriter := blockWriter(t, mock, nil)
+	sealBuffer(c, key1, value1)
+	<-writing
+
+	has, err := c.Has(key1)
+	require.NoError(err)
+	require.True(has, "Has must find keys awaiting a background write")
+
+	unblockWriter()
+	require.NoError(c.Flush())
+}
+
 func TestKVCachedFile_Has_DoesNotLoadValueIntoCache(t *testing.T) {
 	require := require.New(t)
 	c, mock := openTestKVCachedFile(t)
@@ -149,32 +309,6 @@ func TestKVCachedFile_Has_PropagatesFileError(t *testing.T) {
 
 	_, err := c.Has(key1)
 	require.ErrorIs(err, injected)
-}
-
-func TestKVCachedFile_Get_ReturnsNilOnUnknownKey(t *testing.T) {
-	require := require.New(t)
-	c, mock := openTestKVCachedFile(t)
-
-	mock.EXPECT().Get(999).Return(nil, nil)
-
-	got, err := c.Get(999)
-	require.NoError(err)
-	require.Nil(got)
-	// The cache must not contain the key after a Get that returns nil.
-	_, inCache := c.cache.Get(999)
-	require.False(inCache)
-}
-
-func TestKVCachedFile_Get_ReturnsErrorOnFileReadError(t *testing.T) {
-	require := require.New(t)
-	c, mock := openTestKVCachedFile(t)
-
-	injected := errors.New("read failed")
-	mock.EXPECT().Get(key1).Return(nil, injected)
-
-	got, err := c.Get(key1)
-	require.ErrorIs(err, injected)
-	require.Nil(got)
 }
 
 func TestKVCachedFile_Get_PromotesValuesInFlushBufferIntoCache(t *testing.T) {
@@ -213,61 +347,6 @@ func TestKVCachedFile_Set_UpdatesCache(t *testing.T) {
 	require.Equal(value1, got)
 }
 
-func TestKVCachedFile_Set_SurfacesAsyncWriteErrorOnNextOperation(t *testing.T) {
-	require := require.New(t)
-	c, mock := openTestKVCachedFile(t)
-
-	// Fill enough entries so that the next Set pushes the flush buffer to the
-	// threshold and triggers a background file write.
-	for i := 0; i < cacheSize+flushBufferThreshold-1; i++ {
-		require.NoError(c.Set(i, fmt.Sprintf("value%d", i)))
-	}
-
-	injected := errors.New("write failed")
-	mock.EXPECT().SetBatch(gomock.Any()).Return(injected)
-
-	// The write is asynchronous, so the triggering Set itself does not fail;
-	// the error surfaces on the next operation (here a Flush barrier).
-	require.NoError(c.Set(cacheSize+flushBufferThreshold-1, "trigger"))
-	require.ErrorIs(c.Flush(), injected)
-
-	// The error is sticky: subsequent operations keep reporting it.
-	_, err := c.Get(0)
-	require.ErrorIs(err, injected)
-}
-
-func TestKVCachedFile_Operations_ReturnStickyErrorAfterBackgroundWriteFailure(t *testing.T) {
-	injected := errors.New("background write failed")
-
-	// induce drives the cache into its terminal error state by making the
-	// background writer fail a flush.
-	induce := func(t *testing.T, c *KVCachedFile[K, V], mock *MockKVFileWithMemoryFootprint[K, V]) {
-		mock.EXPECT().SetBatch(gomock.Any()).Return(injected).AnyTimes()
-		mock.EXPECT().Flush().Return(nil).AnyTimes()
-		c.flushBuffer[999] = "boom"
-		require.ErrorIs(t, c.Flush(), injected)
-	}
-
-	tests := map[string]func(c *KVCachedFile[K, V]) error{
-		"Get":      func(c *KVCachedFile[K, V]) error { _, err := c.Get(key1); return err },
-		"Has":      func(c *KVCachedFile[K, V]) error { _, err := c.Has(key1); return err },
-		"Set":      func(c *KVCachedFile[K, V]) error { return c.Set(key1, value1) },
-		"SetBatch": func(c *KVCachedFile[K, V]) error { return c.SetBatch(map[K]V{key1: value1}) },
-		"Flush":    func(c *KVCachedFile[K, V]) error { return c.Flush() },
-		"FileSize": func(c *KVCachedFile[K, V]) error { _, err := c.FileSize(); return err },
-		"Iterate":  func(c *KVCachedFile[K, V]) error { _, err := c.Iterate(); return err },
-	}
-
-	for name, op := range tests {
-		t.Run(name, func(t *testing.T) {
-			require := require.New(t)
-			c, mock := openTestKVCachedFile(t)
-			induce(t, c, mock)
-			require.ErrorIs(op(c), injected)
-		})
-	}
-}
-
 func TestKVCachedFile_Set_ReDirtiesKeyAfterFlush(t *testing.T) {
 	require := require.New(t)
 	c, mock := openTestKVCachedFile(t)
@@ -291,64 +370,16 @@ func TestKVCachedFile_Set_ReDirtiesKeyAfterFlush(t *testing.T) {
 	require.False(isDirty)
 }
 
-func TestKVCachedFile_Get_PromotesInFlightValueIntoCacheAsClean(t *testing.T) {
-	require := require.New(t)
-	c, mock := openTestKVCachedFile(t)
-
-	// Block the background writer inside SetBatch so the sealed buffer stays
-	// in flight while we read one of its keys.
-	release, unblockWriter := newWriterRelease(t)
-	writing := make(chan struct{})
-	var once sync.Once
-	mock.EXPECT().SetBatch(gomock.Any()).DoAndReturn(func(map[K]V) error {
-		once.Do(func() { close(writing) })
-		<-release
-		return nil
-	}).AnyTimes()
-	mock.EXPECT().Flush().Return(nil).AnyTimes()
-
-	// Fill the cache and seal a buffer; key 0 is evicted into the in-flight buffer.
-	for i := 0; i < cacheSize+flushBufferThreshold; i++ {
-		require.NoError(c.Set(i, fmt.Sprintf("value%d", i)))
-	}
-	<-writing // the writer is blocked with key 0 still in a pending buffer
-
-	// Reading key 0 serves it from the pending buffer and promotes it into the
-	// cache as a clean entry.
-	got, err := c.Get(0)
-	require.NoError(err)
-	require.NotNil(got)
-	require.Equal("value0", *got)
-
-	cached, found := c.cache.Get(0)
-	require.True(found)
-	require.Equal("value0", cached)
-	_, isDirty := c.dirty[0]
-	require.False(isDirty, "promoted in-flight value must be cached as clean")
-
-	unblockWriter()
-	require.NoError(c.Flush())
-}
-
 func TestKVCachedFile_Set_ReSetWhileInFlightIsNotLost(t *testing.T) {
 	require := require.New(t)
 	c, mock := openTestKVCachedFile(t)
 
 	// Seal a buffer for the background writer and block it inside SetBatch so
 	// the buffer stays in flight while we re-Set one of its keys.
-	release, unblockWriter := newWriterRelease(t)
-	firstWrite := make(chan struct{})
-	var once sync.Once
 	written := map[K]V{}
-	mock.EXPECT().SetBatch(gomock.Any()).DoAndReturn(func(entries map[K]V) error {
-		once.Do(func() { close(firstWrite) })
-		<-release
-		for k, v := range entries {
-			written[k] = v
-		}
-		return nil
-	}).AnyTimes()
-	mock.EXPECT().Flush().Return(nil).AnyTimes()
+	firstWrite, unblockWriter := blockWriter(t, mock, func(entries map[K]V) {
+		maps.Copy(written, entries)
+	})
 
 	// Fill the cache and evict (threshold) entries to seal the first buffer.
 	for i := 0; i < cacheSize+flushBufferThreshold; i++ {
@@ -372,6 +403,45 @@ func TestKVCachedFile_Set_ReSetWhileInFlightIsNotLost(t *testing.T) {
 	require.Equal("value0-new", *got)
 }
 
+func TestKVCachedFile_Set_SurfacesAsyncWriteErrorOnNextOperation(t *testing.T) {
+	require := require.New(t)
+	c, mock := openTestKVCachedFile(t)
+
+	// Fill enough entries so that the next Set pushes the flush buffer to the
+	// threshold and triggers a background file write.
+	for i := 0; i < cacheSize+flushBufferThreshold-1; i++ {
+		require.NoError(c.Set(i, fmt.Sprintf("value%d", i)))
+	}
+
+	injected := errors.New("write failed")
+	mock.EXPECT().SetBatch(gomock.Any()).Return(injected)
+
+	// The write is asynchronous, so the triggering Set itself does not fail;
+	// the error surfaces on the next operation (here a Flush barrier).
+	require.NoError(c.Set(cacheSize+flushBufferThreshold-1, "trigger"))
+	require.ErrorIs(c.Flush(), injected)
+
+	// The error is sticky: subsequent operations keep reporting it.
+	_, err := c.Get(0)
+	require.ErrorIs(err, injected)
+}
+
+func TestKVCachedFile_SetBatch_StoresAllEntries(t *testing.T) {
+	require := require.New(t)
+	// No file interactions expected: the entries fit in the cache.
+	c, _ := openTestKVCachedFile(t)
+
+	entries := map[K]V{1: "value-1", 2: "value-2", 3: "value-3"}
+	require.NoError(c.SetBatch(entries))
+
+	for key, want := range entries {
+		got, err := c.Get(key)
+		require.NoError(err)
+		require.NotNil(got)
+		require.Equal(want, *got)
+	}
+}
+
 func TestKVCachedFile_Flush_WritesCacheAndBufferToFile(t *testing.T) {
 	require := require.New(t)
 	c, mock := openTestKVCachedFile(t)
@@ -383,19 +453,14 @@ func TestKVCachedFile_Flush_WritesCacheAndBufferToFile(t *testing.T) {
 
 	written := map[K]V{}
 	mock.EXPECT().SetBatch(gomock.Any()).DoAndReturn(func(entries map[K]V) error {
-		for k, v := range entries {
-			written[k] = v
-		}
+		maps.Copy(written, entries)
 		return nil
 	}).Times(1)
 	mock.EXPECT().Flush().Return(nil).Times(1)
 
 	require.NoError(c.Flush())
 
-	require.Equal("cache-1", written[1])
-	require.Equal("cache-2", written[2])
-	require.Equal("buffer-3", written[3])
-	require.Equal("buffer-4", written[4])
+	require.Equal(map[K]V{1: "cache-1", 2: "cache-2", 3: "buffer-3", 4: "buffer-4"}, written)
 }
 
 func TestKVCachedFile_Flush_ClearsFlushBuffer(t *testing.T) {
@@ -412,29 +477,43 @@ func TestKVCachedFile_Flush_ClearsFlushBuffer(t *testing.T) {
 	require.Equal(0, len(c.flushBuffer))
 }
 
-func TestKVCachedFile_Flush_ReturnsErrorOnFileWriteError(t *testing.T) {
+func TestKVCachedFile_Flush_ClearsDirtyForFlushedKeys(t *testing.T) {
 	require := require.New(t)
 	c, mock := openTestKVCachedFile(t)
 
-	c.flushBuffer[1] = "value"
-	injected := errors.New("write failed")
-	mock.EXPECT().SetBatch(gomock.Any()).Return(injected)
+	require.NoError(c.Set(1, "value-1"))
+	require.NoError(c.Set(2, "value-2"))
+	require.Len(c.dirty, 2)
 
-	err := c.Flush()
-	require.ErrorIs(err, injected)
+	mock.EXPECT().SetBatch(gomock.Any()).Return(nil)
+	mock.EXPECT().Flush().Return(nil)
+
+	require.NoError(c.Flush())
+	require.Empty(c.dirty)
 }
 
-func TestKVCachedFile_Flush_ReturnsErrorOnFileFlushError(t *testing.T) {
-	require := require.New(t)
-	c, mock := openTestKVCachedFile(t)
+func TestKVCachedFile_Flush_ReturnsErrorOnFileError(t *testing.T) {
+	injected := errors.New("injected")
+	tests := map[string]func(mock *MockKVFileWithMemoryFootprint[K, V]){
+		"batch write fails": func(mock *MockKVFileWithMemoryFootprint[K, V]) {
+			mock.EXPECT().SetBatch(gomock.Any()).Return(injected)
+		},
+		"file flush fails": func(mock *MockKVFileWithMemoryFootprint[K, V]) {
+			mock.EXPECT().SetBatch(gomock.Any()).Return(nil)
+			mock.EXPECT().Flush().Return(injected)
+		},
+	}
 
-	c.flushBuffer[1] = "value"
-	injected := errors.New("flush failed")
-	mock.EXPECT().SetBatch(gomock.Any()).Return(nil)
-	mock.EXPECT().Flush().Return(injected)
+	for name, setup := range tests {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			c, mock := openTestKVCachedFile(t)
+			setup(mock)
 
-	err := c.Flush()
-	require.ErrorIs(err, injected)
+			c.flushBuffer[1] = "value"
+			require.ErrorIs(c.Flush(), injected)
+		})
+	}
 }
 
 func TestKVCachedFile_Flush_IsNoopWhenNothingPending(t *testing.T) {
@@ -484,9 +563,7 @@ func TestKVCachedFile_Flush_OnlyWritesDirtyEntriesAfterPartialUpdate(t *testing.
 
 	written := map[K]V{}
 	mock.EXPECT().SetBatch(gomock.Any()).DoAndReturn(func(entries map[K]V) error {
-		for k, v := range entries {
-			written[k] = v
-		}
+		maps.Copy(written, entries)
 		return nil
 	}).Times(1)
 	mock.EXPECT().Flush().Return(nil).Times(1)
@@ -521,7 +598,7 @@ func TestKVCachedFile_Iterate_YieldsFileContents(t *testing.T) {
 	require := require.New(t)
 	c, mock := openTestKVCachedFile(t)
 
-	// No pending writes: flushLocked is a no-op, Iterate delegates directly
+	// No pending writes: draining is a no-op, Iterate delegates directly
 	// to the underlying file.
 	fileContents := map[K]V{0: "value0", 1: "value1", 2: "value2"}
 	mock.EXPECT().Iterate().Return(mockIterateSeq(fileContents), nil)
@@ -547,9 +624,7 @@ func TestKVCachedFile_Iterate_FlushesDirtyEntriesBeforeIterating(t *testing.T) {
 	written := map[K]V{}
 	gomock.InOrder(
 		mock.EXPECT().SetBatch(gomock.Any()).DoAndReturn(func(entries map[K]V) error {
-			for k, v := range entries {
-				written[k] = v
-			}
+			maps.Copy(written, entries)
 			return nil
 		}),
 		mock.EXPECT().Flush().Return(nil),
@@ -604,9 +679,7 @@ func TestKVCachedFile_Close_FlushesAndClosesUnderlyingFile(t *testing.T) {
 	written := map[K]V{}
 	gomock.InOrder(
 		mock.EXPECT().SetBatch(gomock.Any()).DoAndReturn(func(entries map[K]V) error {
-			for k, v := range entries {
-				written[k] = v
-			}
+			maps.Copy(written, entries)
 			return nil
 		}),
 		mock.EXPECT().Flush().Return(nil),
@@ -636,7 +709,7 @@ func TestKVCachedFile_Close_ReturnsErrorOnFileCloseError(t *testing.T) {
 	c, mock := openTestKVCachedFile(t)
 
 	injected := errors.New("close failed")
-	// No cache / buffer entries: flushLocked is a no-op and we go straight
+	// No cache / buffer entries: draining is a no-op and we go straight
 	// to file.Close().
 	mock.EXPECT().Close().Return(injected)
 
@@ -674,110 +747,94 @@ func TestKVCachedFile_GetMemoryFootprint_IsNonZero(t *testing.T) {
 	require.Greater(mf.Total(), uintptr(0))
 }
 
-// ---------------------------------------------------------------------------
-// Private helper tests
-// ---------------------------------------------------------------------------
+func TestKVCachedFile_Operations_ReturnStickyErrorAfterBackgroundWriteFailure(t *testing.T) {
+	injected := errors.New("background write failed")
 
-func TestKVCachedFile_flushPending_ClearsDirtyForFlushedKeys(t *testing.T) {
-	require := require.New(t)
-	c, mock := openTestKVCachedFile(t)
-
-	require.NoError(c.Set(1, "value-1"))
-	require.NoError(c.Set(2, "value-2"))
-	require.Len(c.dirty, 2)
-
-	mock.EXPECT().SetBatch(gomock.Any()).Return(nil)
-	mock.EXPECT().Flush().Return(nil)
-
-	require.NoError(c.Flush())
-	require.Empty(c.dirty)
-}
-
-func TestKVCachedFile_Open_SetsMaxPendingFlushesToFlushBufferSizePlusOne(t *testing.T) {
-	tests := map[string]int{
-		"threshold 1":   1,
-		"threshold 3":   3,
-		"threshold 100": 100,
+	// induce drives the cache into its terminal error state by making the
+	// background writer fail a flush.
+	induce := func(t *testing.T, c *KVCachedFile[K, V], mock *MockKVFileWithMemoryFootprint[K, V]) {
+		mock.EXPECT().SetBatch(gomock.Any()).Return(injected).AnyTimes()
+		mock.EXPECT().Flush().Return(nil).AnyTimes()
+		c.flushBuffer[999] = "boom"
+		require.ErrorIs(t, c.Flush(), injected)
 	}
-	for name, threshold := range tests {
+
+	tests := map[string]func(c *KVCachedFile[K, V]) error{
+		"Get":      func(c *KVCachedFile[K, V]) error { _, err := c.Get(key1); return err },
+		"Has":      func(c *KVCachedFile[K, V]) error { _, err := c.Has(key1); return err },
+		"Set":      func(c *KVCachedFile[K, V]) error { return c.Set(key1, value1) },
+		"SetBatch": func(c *KVCachedFile[K, V]) error { return c.SetBatch(map[K]V{key1: value1}) },
+		"Flush":    func(c *KVCachedFile[K, V]) error { return c.Flush() },
+		"FileSize": func(c *KVCachedFile[K, V]) error { _, err := c.FileSize(); return err },
+		"Iterate":  func(c *KVCachedFile[K, V]) error { _, err := c.Iterate(); return err },
+	}
+
+	for name, op := range tests {
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
-			ctrl := gomock.NewController(t)
-			mock := NewMockKVFileWithMemoryFootprint[K, V](ctrl)
-			c, err := OpenKVCachedFile[K, V](mock, cacheSize, threshold)
-			require.NoError(err)
-			t.Cleanup(c.shutdownWriter)
-			require.Equal(threshold+1, c.maxPendingFlushes)
+			c, mock := openTestKVCachedFile(t)
+			induce(t, c, mock)
+			require.ErrorIs(op(c), injected)
 		})
 	}
 }
 
-func TestKVCachedFile_Set_AppliesBackPressureWhenPendingQueueIsFull(t *testing.T) {
+// Concurrent callers and the background writer must not race. The fake file is
+// deliberately NOT synchronized (see fakeKVFile), so this doubles as a guard on
+// KVCachedFile's own serialization of file access: if that serialization (fileMu)
+// were dropped, the writer and a foreground reader would touch the fake's map at
+// once, which -race reports and Go's runtime turns into a fatal "concurrent map"
+// panic. Run with -race for the hard signal. Get/Has target the same keys as
+// Set, so reads exercise every layer -- cache, flush buffer, pending queue, and
+// the underlying file once entries have been evicted and written.
+func TestKVCachedFile_SetGetHasAndFlush_AreRaceFree(t *testing.T) {
 	require := require.New(t)
-	c, mock := openTestKVCachedFile(t)
+	c, err := OpenKVCachedFile[K, V](newFakeKVFile(), cacheSize, flushBufferThreshold)
+	require.NoError(err)
+	t.Cleanup(c.shutdownWriter)
 
-	// Block the background writer on the first buffer so the queue cannot drain.
-	release, unblockWriter := newWriterRelease(t)
-	writing := make(chan struct{})
-	var once sync.Once
-	mock.EXPECT().SetBatch(gomock.Any()).DoAndReturn(func(map[K]V) error {
-		once.Do(func() { close(writing) })
-		<-release
-		return nil
-	}).AnyTimes()
-	mock.EXPECT().Flush().Return(nil).AnyTimes()
-
-	// sealOne hands a one-entry buffer to the writer.
-	sealOne := func() {
-		c.mu.Lock()
-		c.flushBuffer[0] = "v"
-		c.enqueueCurrentBufferLocked()
-		c.mu.Unlock()
+	const (
+		workers      = 8
+		opsPerWorker = 100000
+	)
+	var wg sync.WaitGroup
+	for w := range workers {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := range opsPerWorker {
+				key := w*opsPerWorker + i
+				switch i % 4 {
+				case 0:
+					require.NoError(c.Set(key, fmt.Sprintf("w%d-i%d", w, i)))
+				case 1:
+					_, err := c.Get(key)
+					require.NoError(err)
+				case 2:
+					_, err := c.Has(key)
+					require.NoError(err)
+				case 3:
+					require.NoError(c.Flush())
+				}
+			}
+		}(w)
 	}
+	wg.Wait()
 
-	// Fill the queue to capacity: the writer picks up the first buffer and
-	// blocks inside SetBatch, so nothing drains.
-	sealOne()
-	<-writing
-	for i := 1; i < c.maxPendingFlushes; i++ {
-		sealOne()
-	}
-
-	// The next seal must block until the writer drains a buffer.
-	done := make(chan struct{})
-	go func() {
-		sealOne()
-		close(done)
-	}()
-	isDone := func() bool {
-		select {
-		case <-done:
-			return true
-		default:
-			return false
-		}
-	}
-	require.Never(isDone, 100*time.Millisecond, 10*time.Millisecond,
-		"seal must block while the pending queue is full")
-
-	// Releasing the writer lets it drain, which unblocks the pending seal.
-	unblockWriter()
-	require.Eventually(isDone, time.Second, 10*time.Millisecond,
-		"seal must resume once the writer drains a buffer")
+	require.NoError(c.Flush())
+	require.NoError(c.Close())
 }
 
-func TestKVCachedFile_waitForPendingFlushes_ReturnsBackgroundWriteError(t *testing.T) {
+func TestKVCachedFile_enqueueCurrentBufferLocked_IsNoopWhenBufferIsEmpty(t *testing.T) {
 	require := require.New(t)
-	c, mock := openTestKVCachedFile(t)
+	// No file interactions expected: an empty buffer is never handed to the writer.
+	c, _ := openTestKVCachedFile(t)
 
-	injected := errors.New("background write failed")
-	mock.EXPECT().SetBatch(gomock.Any()).Return(injected).AnyTimes()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.enqueueCurrentBufferLocked()
 
-	// Flush seals a buffer and waits; the background write fails, recording the
-	// terminal error, which waitForPendingFlushes then also reports.
-	c.flushBuffer[1] = "boom"
-	require.ErrorIs(c.Flush(), injected)
-	require.ErrorIs(c.waitForPendingFlushes(), injected)
+	require.Empty(c.pending)
 }
 
 func TestKVCachedFile_enqueueCurrentBufferLocked_AppendsBufferAndClearsDirtyEntries(t *testing.T) {
@@ -786,12 +843,7 @@ func TestKVCachedFile_enqueueCurrentBufferLocked_AppendsBufferAndClearsDirtyEntr
 
 	// Block the writer so the sealed buffer stays visible in c.pending for
 	// inspection instead of being consumed immediately.
-	release, unblockWriter := newWriterRelease(t)
-	mock.EXPECT().SetBatch(gomock.Any()).DoAndReturn(func(map[K]V) error {
-		<-release
-		return nil
-	}).AnyTimes()
-	mock.EXPECT().Flush().Return(nil).AnyTimes()
+	_, unblockWriter := blockWriter(t, mock, nil)
 
 	c.mu.Lock()
 	c.flushBuffer[1] = "a"
@@ -815,6 +867,86 @@ func TestKVCachedFile_enqueueCurrentBufferLocked_AppendsBufferAndClearsDirtyEntr
 
 	unblockWriter()
 	require.NoError(c.Flush())
+}
+
+func TestKVCachedFile_enqueueCurrentBufferLocked_RetainsBufferAfterWriteErrorOrClose(t *testing.T) {
+	tests := map[string]func(c *KVCachedFile[K, V]){
+		"after write error": func(c *KVCachedFile[K, V]) { c.writeErr = errors.New("terminal") },
+		"after close":       func(c *KVCachedFile[K, V]) { c.closed = true },
+	}
+
+	for name, induce := range tests {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			// No file interactions expected: a stopped writer receives no buffers.
+			c, _ := openTestKVCachedFile(t)
+
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			induce(c)
+			c.flushBuffer[key1] = value1
+
+			c.enqueueCurrentBufferLocked()
+
+			require.Empty(c.pending, "no buffer must be handed to a stopped writer")
+			require.Len(c.flushBuffer, 1, "unwritten entries must be retained")
+		})
+	}
+}
+
+// The background writer must persist queued buffers oldest-first so the newest
+// value of a repeated key lands on disk last and wins.
+func TestKVCachedFile_flushWorker_PersistsBuffersInFIFOOrder(t *testing.T) {
+	require := require.New(t)
+	c, mock := openTestKVCachedFile(t)
+
+	var writeOrder []V
+	writing, unblockWriter := blockWriter(t, mock, func(entries map[K]V) {
+		writeOrder = append(writeOrder, entries[key1])
+	})
+
+	sealBuffer(c, key1, "old")
+	<-writing                  // writer holds the first buffer in flight
+	sealBuffer(c, key1, "new") // queued behind it
+
+	unblockWriter()
+	require.NoError(c.Flush())
+
+	require.Equal([]V{"old", "new"}, writeOrder,
+		"buffers must be written oldest-first so the newest value wins on disk")
+}
+
+func TestKVCachedFile_writeBuffer_WritesBatchThenFlushesFile(t *testing.T) {
+	injected := errors.New("injected")
+	tests := map[string]struct {
+		setBatchErr error
+		flushErr    error
+	}{
+		"success":           {},
+		"batch write fails": {setBatchErr: injected},
+		"file flush fails":  {flushErr: injected},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			c, mock := openTestKVCachedFile(t)
+
+			entries := map[K]V{key1: value1}
+			mock.EXPECT().SetBatch(entries).Return(test.setBatchErr)
+			if test.setBatchErr == nil {
+				// The file is only flushed when the batch write succeeded.
+				mock.EXPECT().Flush().Return(test.flushErr)
+			}
+
+			err := c.writeBuffer(entries)
+			if test.setBatchErr != nil || test.flushErr != nil {
+				require.ErrorIs(err, injected)
+			} else {
+				require.NoError(err)
+			}
+		})
+	}
 }
 
 func TestKVCachedFile_shutdownWriter_IsIdempotent(t *testing.T) {
@@ -880,9 +1012,7 @@ func TestKVCachedFile_handleCacheSet_FlushesBufferToFileWhenThresholdReached(t *
 
 	written := map[K]V{}
 	mock.EXPECT().SetBatch(gomock.Any()).DoAndReturn(func(entries map[K]V) error {
-		for k, v := range entries {
-			written[k] = v
-		}
+		maps.Copy(written, entries)
 		return nil
 	}).Times(1)
 	mock.EXPECT().Flush().Return(nil).Times(1)
@@ -990,136 +1120,6 @@ func TestKVCachedFile_handleCacheSet_UpdatedEntryIsRetrievedInAllLocations(t *te
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Flush-worker / Set interaction tests
-// ---------------------------------------------------------------------------
-
-// Get must serve a key from the newest buffer when it is queued in several.
-func TestKVCachedFile_Get_ReturnsNewestValueAcrossMultiplePendingBuffers(t *testing.T) {
-	require := require.New(t)
-	c, mock := openTestKVCachedFile(t)
-
-	// Block the writer inside SetBatch so a sealed buffer stays in c.pending; the
-	// writer keeps the buffer it is writing in the queue until the write returns,
-	// so both sealed buffers coexist there while we read the key.
-	release, unblockWriter := newWriterRelease(t)
-	writing := make(chan struct{})
-	var once sync.Once
-	mock.EXPECT().SetBatch(gomock.Any()).DoAndReturn(func(map[K]V) error {
-		once.Do(func() { close(writing) })
-		<-release
-		return nil
-	}).AnyTimes()
-	mock.EXPECT().Flush().Return(nil).AnyTimes()
-
-	seal := func(val V) {
-		c.mu.Lock()
-		c.flushBuffer[key1] = val
-		c.enqueueCurrentBufferLocked()
-		c.mu.Unlock()
-	}
-
-	// First buffer goes in flight; the second is queued behind it, so key1 now
-	// lives in two pending buffers: {key1:"old"} then {key1:"new"}.
-	seal("old")
-	<-writing
-	seal("new")
-
-	got, err := c.Get(key1)
-	require.NoError(err)
-	require.NotNil(got)
-	require.Equal("new", *got, "Get must return the newest pending value")
-
-	unblockWriter()
-	require.NoError(c.Flush())
-}
-
-// The background writer must persist queued buffers oldest-first so the newest
-// value of a repeated key lands on disk last and wins.
-func TestKVCachedFile_FlushWorker_PersistsBuffersInFIFOOrder(t *testing.T) {
-	require := require.New(t)
-	c, mock := openTestKVCachedFile(t)
-
-	release, unblockWriter := newWriterRelease(t)
-	writing := make(chan struct{})
-	var once sync.Once
-	var writeOrder []V
-	mock.EXPECT().SetBatch(gomock.Any()).DoAndReturn(func(entries map[K]V) error {
-		once.Do(func() { close(writing) })
-		<-release
-		writeOrder = append(writeOrder, entries[key1])
-		return nil
-	}).AnyTimes()
-	mock.EXPECT().Flush().Return(nil).AnyTimes()
-
-	seal := func(val V) {
-		c.mu.Lock()
-		c.flushBuffer[key1] = val
-		c.enqueueCurrentBufferLocked()
-		c.mu.Unlock()
-	}
-
-	seal("old")
-	<-writing   // writer holds the first buffer in flight
-	seal("new") // queued behind it
-
-	unblockWriter()
-	require.NoError(c.Flush())
-
-	require.Equal([]V{"old", "new"}, writeOrder,
-		"buffers must be written oldest-first so the newest value wins on disk")
-}
-
-// Concurrent callers and the background writer must not race. The fake file is
-// deliberately NOT synchronized (see fakeKVFile), so this doubles as a guard on
-// KVCachedFile's own serialization of file access: if that serialization (fileMu)
-// were dropped, the writer and a foreground reader would touch the fake's map at
-// once, which -race reports and Go's runtime turns into a fatal "concurrent map"
-// panic. Run with -race for the hard signal. Get/Has target the same keys as
-// Set, so reads exercise every layer -- cache, flush buffer, pending queue, and
-// the underlying file once entries have been evicted and written.
-func TestKVCachedFile_SetGetHasAndFlush_AreRaceFree(t *testing.T) {
-	require := require.New(t)
-	c, err := OpenKVCachedFile[K, V](newFakeKVFile(), cacheSize, flushBufferThreshold)
-	require.NoError(err)
-	t.Cleanup(c.shutdownWriter)
-
-	const (
-		workers      = 8
-		opsPerWorker = 100000
-	)
-	var wg sync.WaitGroup
-	for w := range workers {
-		wg.Add(1)
-		go func(w int) {
-			defer wg.Done()
-			for i := range opsPerWorker {
-				key := w*opsPerWorker + i
-				switch i % 4 {
-				case 0:
-					require.NoError(c.Set(key, fmt.Sprintf("w%d-i%d", w, i)))
-				case 1:
-					_, err := c.Get(key)
-					require.NoError(err)
-				case 2:
-					_, err := c.Has(key)
-					require.NoError(err)
-				case 3:
-					require.NoError(c.Flush())
-				}
-			}
-		}(w)
-	}
-	wg.Wait()
-
-	require.NoError(c.Flush())
-	require.NoError(c.Close())
-}
-
-// ---------------------------------------------------------------------------
-// Test helpers
-// ---------------------------------------------------------------------------
-
 // fakeKVFile is a minimal in-memory KVFile for concurrency tests. It is
 // deliberately NOT synchronized: KVCachedFile must serialize all access to the
 // wrapped file itself (KVFile is not required to be safe for concurrent use), so
@@ -1183,6 +1183,42 @@ func openTestKVCachedFile(t *testing.T) (*KVCachedFile[K, V], *MockKVFileWithMem
 	return file, mock
 }
 
+// waitForPendingFlushes blocks until the background writer has persisted every
+// queued buffer, returning the sticky write error if any. It is a test-only
+// synchronization aid; production callers use Flush, which also seals the
+// current buffer.
+func (c *KVCachedFile[K, V]) waitForPendingFlushes() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for len(c.pending) > 0 && c.writeErr == nil {
+		c.cond.Wait()
+	}
+	return c.writeErr
+}
+
+// blockWriter makes the mocked file park the background writer inside SetBatch
+// until the returned unblock function is called. The returned channel is closed
+// when the writer first enters SetBatch, and onWrite (if not nil) observes every
+// batch once the writer is released; results it records are safe to read after a
+// Flush. Unblock is also invoked during test cleanup so a failed assertion
+// cannot leave the writer parked (see newWriterRelease).
+func blockWriter(t *testing.T, mock *MockKVFileWithMemoryFootprint[K, V], onWrite func(entries map[K]V)) (writing <-chan struct{}, unblock func()) {
+	t.Helper()
+	release, unblock := newWriterRelease(t)
+	writingCh := make(chan struct{})
+	var once sync.Once
+	mock.EXPECT().SetBatch(gomock.Any()).DoAndReturn(func(entries map[K]V) error {
+		once.Do(func() { close(writingCh) })
+		<-release
+		if onWrite != nil {
+			onWrite(entries)
+		}
+		return nil
+	}).AnyTimes()
+	mock.EXPECT().Flush().Return(nil).AnyTimes()
+	return writingCh, unblock
+}
+
 // newWriterRelease returns a channel used to unblock a mocked background writer
 // that parks inside SetBatch, together with a function that closes it. The
 // channel is also closed during test cleanup if the test has not closed it
@@ -1196,6 +1232,15 @@ func newWriterRelease(t *testing.T) (release chan struct{}, unblock func()) {
 	unblock = sync.OnceFunc(func() { close(release) })
 	t.Cleanup(unblock)
 	return release, unblock
+}
+
+// sealBuffer places a single entry into the flush buffer and hands the buffer
+// over to the background writer.
+func sealBuffer(c *KVCachedFile[K, V], key K, value V) {
+	c.mu.Lock()
+	c.flushBuffer[key] = value
+	c.enqueueCurrentBufferLocked()
+	c.mu.Unlock()
 }
 
 // mockIterateSeq returns an iter.Seq2 mock return value that yields the

--- a/go/backend/kv_file/kv_cached_file_test.go
+++ b/go/backend/kv_file/kv_cached_file_test.go
@@ -297,7 +297,7 @@ func TestKVCachedFile_Get_PromotesInFlightValueIntoCacheAsClean(t *testing.T) {
 
 	// Block the background writer inside SetBatch so the sealed buffer stays
 	// in flight while we read one of its keys.
-	release := make(chan struct{})
+	release, unblockWriter := newWriterRelease(t)
 	writing := make(chan struct{})
 	var once sync.Once
 	mock.EXPECT().SetBatch(gomock.Any()).DoAndReturn(func(map[K]V) error {
@@ -326,7 +326,7 @@ func TestKVCachedFile_Get_PromotesInFlightValueIntoCacheAsClean(t *testing.T) {
 	_, isDirty := c.dirty[0]
 	require.False(isDirty, "promoted in-flight value must be cached as clean")
 
-	close(release)
+	unblockWriter()
 	require.NoError(c.Flush())
 }
 
@@ -336,7 +336,7 @@ func TestKVCachedFile_Set_ReSetWhileInFlightIsNotLost(t *testing.T) {
 
 	// Seal a buffer for the background writer and block it inside SetBatch so
 	// the buffer stays in flight while we re-Set one of its keys.
-	release := make(chan struct{})
+	release, unblockWriter := newWriterRelease(t)
 	firstWrite := make(chan struct{})
 	var once sync.Once
 	written := map[K]V{}
@@ -360,7 +360,7 @@ func TestKVCachedFile_Set_ReSetWhileInFlightIsNotLost(t *testing.T) {
 	require.NoError(c.Set(0, "value0-new"))
 
 	// Let the in-flight write finish, then flush everything.
-	close(release)
+	unblockWriter()
 	require.NoError(c.Flush())
 
 	// The re-Set value must have survived and reached disk.
@@ -717,7 +717,7 @@ func TestKVCachedFile_Set_AppliesBackPressureWhenPendingQueueIsFull(t *testing.T
 	c, mock := openTestKVCachedFile(t)
 
 	// Block the background writer on the first buffer so the queue cannot drain.
-	release := make(chan struct{})
+	release, unblockWriter := newWriterRelease(t)
 	writing := make(chan struct{})
 	var once sync.Once
 	mock.EXPECT().SetBatch(gomock.Any()).DoAndReturn(func(map[K]V) error {
@@ -761,7 +761,7 @@ func TestKVCachedFile_Set_AppliesBackPressureWhenPendingQueueIsFull(t *testing.T
 		"seal must block while the pending queue is full")
 
 	// Releasing the writer lets it drain, which unblocks the pending seal.
-	close(release)
+	unblockWriter()
 	require.Eventually(isDone, time.Second, 10*time.Millisecond,
 		"seal must resume once the writer drains a buffer")
 }
@@ -965,7 +965,7 @@ func TestKVCachedFile_Get_ReturnsNewestValueAcrossMultiplePendingBuffers(t *test
 	// Block the writer inside SetBatch so a sealed buffer stays in c.pending; the
 	// writer keeps the buffer it is writing in the queue until the write returns,
 	// so both sealed buffers coexist there while we read the key.
-	release := make(chan struct{})
+	release, unblockWriter := newWriterRelease(t)
 	writing := make(chan struct{})
 	var once sync.Once
 	mock.EXPECT().SetBatch(gomock.Any()).DoAndReturn(func(map[K]V) error {
@@ -993,7 +993,7 @@ func TestKVCachedFile_Get_ReturnsNewestValueAcrossMultiplePendingBuffers(t *test
 	require.NotNil(got)
 	require.Equal("new", *got, "Get must return the newest pending value")
 
-	close(release)
+	unblockWriter()
 	require.NoError(c.Flush())
 }
 
@@ -1003,7 +1003,7 @@ func TestKVCachedFile_FlushWorker_PersistsBuffersInFIFOOrder(t *testing.T) {
 	require := require.New(t)
 	c, mock := openTestKVCachedFile(t)
 
-	release := make(chan struct{})
+	release, unblockWriter := newWriterRelease(t)
 	writing := make(chan struct{})
 	var once sync.Once
 	var writeOrder []V
@@ -1026,14 +1026,20 @@ func TestKVCachedFile_FlushWorker_PersistsBuffersInFIFOOrder(t *testing.T) {
 	<-writing   // writer holds the first buffer in flight
 	seal("new") // queued behind it
 
-	close(release)
+	unblockWriter()
 	require.NoError(c.Flush())
 
 	require.Equal([]V{"old", "new"}, writeOrder,
 		"buffers must be written oldest-first so the newest value wins on disk")
 }
 
-// Concurrent callers and the background writer must not race. Run with -race.
+// Concurrent callers and the background writer must not race. The fake file is
+// deliberately NOT synchronized (see fakeKVFile), so this doubles as a guard on
+// KVCachedFile's own serialization of file access: if that serialization (fileMu)
+// were dropped, the writer and a foreground reader would touch the fake's map at
+// once, which -race reports and Go's runtime turns into a fatal "concurrent map"
+// panic. Run with -race for the hard signal. Get/Has target never-written keys so
+// they miss the cache and actually reach the file.
 func TestKVCachedFile_SetGetHasAndFlush_AreRaceFree(t *testing.T) {
 	require := require.New(t)
 	c, err := OpenKVCachedFile[K, V](newFakeKVFile(), cacheSize, flushBufferThreshold)
@@ -1041,9 +1047,8 @@ func TestKVCachedFile_SetGetHasAndFlush_AreRaceFree(t *testing.T) {
 	t.Cleanup(c.shutdownWriter)
 
 	const (
-		workers        = 8
-		opsPerWorker   = 300
-		keySpace     K = 32
+		workers      = 8
+		opsPerWorker = 300
 	)
 	var wg sync.WaitGroup
 	for w := range workers {
@@ -1051,14 +1056,18 @@ func TestKVCachedFile_SetGetHasAndFlush_AreRaceFree(t *testing.T) {
 		go func(w int) {
 			defer wg.Done()
 			for i := range opsPerWorker {
-				k := K(i) % keySpace
+				key := w*opsPerWorker + i
 				switch i % 4 {
 				case 0:
-					_ = c.Set(k, fmt.Sprintf("w%d-i%d", w, i))
+					// Distinct keys keep evicting dirty entries, which keeps the
+					// background writer flushing buffers to the file.
+					_ = c.Set(key, fmt.Sprintf("w%d-i%d", w, i))
 				case 1:
-					_, _ = c.Get(k)
+					// Negative keys are never written, so they miss the cache,
+					// buffer and pending, forcing a read of the underlying file.
+					_, _ = c.Get(-key)
 				case 2:
-					_, _ = c.Has(k)
+					_, _ = c.Has(-key)
 				case 3:
 					_ = c.Flush()
 				}
@@ -1075,10 +1084,12 @@ func TestKVCachedFile_SetGetHasAndFlush_AreRaceFree(t *testing.T) {
 // Test helpers
 // ---------------------------------------------------------------------------
 
-// fakeKVFile is a minimal thread-safe in-memory KVFile for concurrency tests,
-// where a gomock mock's expectation bookkeeping would itself serialize calls.
+// fakeKVFile is a minimal in-memory KVFile for concurrency tests. It is
+// deliberately NOT synchronized: KVCachedFile must serialize all access to the
+// wrapped file itself (KVFile is not required to be safe for concurrent use), so
+// a lock here would hide a regression in that serialization instead of exposing
+// it. Do not add a mutex.
 type fakeKVFile struct {
-	mu   sync.Mutex
 	data map[K]V
 }
 
@@ -1087,8 +1098,6 @@ func newFakeKVFile() *fakeKVFile {
 }
 
 func (f *fakeKVFile) Get(key K) (*V, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
 	if v, ok := f.data[key]; ok {
 		return &v, nil
 	}
@@ -1096,22 +1105,16 @@ func (f *fakeKVFile) Get(key K) (*V, error) {
 }
 
 func (f *fakeKVFile) Has(key K) (bool, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
 	_, ok := f.data[key]
 	return ok, nil
 }
 
 func (f *fakeKVFile) Set(key K, value V) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
 	f.data[key] = value
 	return nil
 }
 
 func (f *fakeKVFile) SetBatch(entries map[K]V) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
 	maps.Copy(f.data, entries)
 	return nil
 }
@@ -1121,8 +1124,6 @@ func (f *fakeKVFile) Flush() error { return nil }
 func (f *fakeKVFile) FileSize() (uint64, error) { return 0, nil }
 
 func (f *fakeKVFile) Iterate() (iter.Seq2[K, V], error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
 	return mockIterateSeq(maps.Clone(f.data)), nil
 }
 
@@ -1144,6 +1145,21 @@ func openTestKVCachedFile(t *testing.T) (*KVCachedFile[K, V], *MockKVFileWithMem
 	// gomock controller's own cleanup verifies expectations.
 	t.Cleanup(file.shutdownWriter)
 	return file, mock
+}
+
+// newWriterRelease returns a channel used to unblock a mocked background writer
+// that parks inside SetBatch, together with a function that closes it. The
+// channel is also closed during test cleanup if the test has not closed it
+// itself: without this, a failed assertion would skip the test's own close and
+// leave the writer parked, so the shutdownWriter cleanup registered by
+// openTestKVCachedFile would deadlock waiting for the writer to exit. Because it
+// is registered after that cleanup, LIFO ordering runs it first.
+func newWriterRelease(t *testing.T) (release chan struct{}, unblock func()) {
+	t.Helper()
+	release = make(chan struct{})
+	unblock = sync.OnceFunc(func() { close(release) })
+	t.Cleanup(unblock)
+	return release, unblock
 }
 
 // mockIterateSeq returns an iter.Seq2 mock return value that yields the

--- a/go/backend/kv_file/kv_cached_file_test.go
+++ b/go/backend/kv_file/kv_cached_file_test.go
@@ -780,6 +780,43 @@ func TestKVCachedFile_waitForPendingFlushes_ReturnsBackgroundWriteError(t *testi
 	require.ErrorIs(c.waitForPendingFlushes(), injected)
 }
 
+func TestKVCachedFile_enqueueCurrentBufferLocked_AppendsBufferAndClearsDirtyEntries(t *testing.T) {
+	require := require.New(t)
+	c, mock := openTestKVCachedFile(t)
+
+	// Block the writer so the sealed buffer stays visible in c.pending for
+	// inspection instead of being consumed immediately.
+	release, unblockWriter := newWriterRelease(t)
+	mock.EXPECT().SetBatch(gomock.Any()).DoAndReturn(func(map[K]V) error {
+		<-release
+		return nil
+	}).AnyTimes()
+	mock.EXPECT().Flush().Return(nil).AnyTimes()
+
+	c.mu.Lock()
+	c.flushBuffer[1] = "a"
+	c.flushBuffer[2] = "b"
+	c.dirty[1] = true
+	c.dirty[2] = true
+	// Dirty entry that is not in the flush buffer must survive the seal.
+	c.dirty[3] = true
+	sealed := maps.Clone(c.flushBuffer)
+
+	c.enqueueCurrentBufferLocked()
+
+	require.Empty(c.flushBuffer, "flushBuffer must be reset after enqueue")
+	require.Len(c.pending, 1, "sealed buffer must be appended to pending")
+	require.Equal(sealed, c.pending[0], "pending buffer must equal the sealed flushBuffer")
+
+	require.NotContains(c.dirty, K(1), "dirty entries in the sealed buffer must be cleared")
+	require.NotContains(c.dirty, K(2), "dirty entries in the sealed buffer must be cleared")
+	require.Contains(c.dirty, K(3), "dirty entries not in the sealed buffer must be retained")
+	c.mu.Unlock()
+
+	unblockWriter()
+	require.NoError(c.Flush())
+}
+
 func TestKVCachedFile_shutdownWriter_IsIdempotent(t *testing.T) {
 	require := require.New(t)
 	c, _ := openTestKVCachedFile(t)
@@ -1038,8 +1075,9 @@ func TestKVCachedFile_FlushWorker_PersistsBuffersInFIFOOrder(t *testing.T) {
 // KVCachedFile's own serialization of file access: if that serialization (fileMu)
 // were dropped, the writer and a foreground reader would touch the fake's map at
 // once, which -race reports and Go's runtime turns into a fatal "concurrent map"
-// panic. Run with -race for the hard signal. Get/Has target never-written keys so
-// they miss the cache and actually reach the file.
+// panic. Run with -race for the hard signal. Get/Has target the same keys as
+// Set, so reads exercise every layer -- cache, flush buffer, pending queue, and
+// the underlying file once entries have been evicted and written.
 func TestKVCachedFile_SetGetHasAndFlush_AreRaceFree(t *testing.T) {
 	require := require.New(t)
 	c, err := OpenKVCachedFile[K, V](newFakeKVFile(), cacheSize, flushBufferThreshold)
@@ -1048,7 +1086,7 @@ func TestKVCachedFile_SetGetHasAndFlush_AreRaceFree(t *testing.T) {
 
 	const (
 		workers      = 8
-		opsPerWorker = 300
+		opsPerWorker = 100000
 	)
 	var wg sync.WaitGroup
 	for w := range workers {
@@ -1059,17 +1097,15 @@ func TestKVCachedFile_SetGetHasAndFlush_AreRaceFree(t *testing.T) {
 				key := w*opsPerWorker + i
 				switch i % 4 {
 				case 0:
-					// Distinct keys keep evicting dirty entries, which keeps the
-					// background writer flushing buffers to the file.
-					_ = c.Set(key, fmt.Sprintf("w%d-i%d", w, i))
+					require.NoError(c.Set(key, fmt.Sprintf("w%d-i%d", w, i)))
 				case 1:
-					// Negative keys are never written, so they miss the cache,
-					// buffer and pending, forcing a read of the underlying file.
-					_, _ = c.Get(-key)
+					_, err := c.Get(key)
+					require.NoError(err)
 				case 2:
-					_, _ = c.Has(-key)
+					_, err := c.Has(key)
+					require.NoError(err)
 				case 3:
-					_ = c.Flush()
+					require.NoError(c.Flush())
 				}
 			}
 		}(w)


### PR DESCRIPTION
`KVCachedFile` currently hangs when the flushing threshold is reached, waiting for all the values to be written down to disk. This is expensive, especially if used for components active during block processing.
This PR makes the flush asynchronous, unblocking the user immediately after setting an element (conditionally).

The `maxPendingFlushes` threshold poses a limit to the memory pressure of the asynchronous updates, and adding a new element will wait until the number of elements to flush is lower than the upper bound.
It is set to `flushBufferThreshold + 1` in order to allow at least one completely asynchronous flush of the flush buffer