### PR TITLE
Avoid pushing null values into `KVCachedFile` cache

### DIFF
--- a/go/backend/kv_file/kv_cached_file.go
+++ b/go/backend/kv_file/kv_cached_file.go
@@ -74,6 +74,9 @@ func (c *KVCachedFile[K, V]) Get(key K) (*V, error) {
 	if err != nil {
 		return nil, err
 	}
+	if value == nil {
+		return nil, nil
+	}
 	err = c.handleCacheSet(&key, value, false)
 	if err != nil {
 		return nil, err

--- a/go/backend/kv_file/kv_cached_file_test.go
+++ b/go/backend/kv_file/kv_cached_file_test.go
@@ -157,6 +157,9 @@ func TestKVCachedFile_Get_ReturnsNilOnUnknownKey(t *testing.T) {
 	got, err := c.Get(999)
 	require.NoError(err)
 	require.Nil(got)
+	// The cache must not contain the key after a Get that returns nil.
+	_, inCache := c.cache.Get(999)
+	require.False(inCache)
 }
 
 func TestKVCachedFile_Get_ReturnsErrorOnFileReadError(t *testing.T) {


### PR DESCRIPTION
Currently, querying a value from the file in the kv_cached_file could result into pushing a null value into the cache if it was not present on the file.
This PR fixes it and adds a test for it