### PR TITLE
Add 'scratchDir' to the `State::Export` function

### DIFF
--- a/go/carmen/block.go
+++ b/go/carmen/block.go
@@ -163,7 +163,7 @@ func (c *archiveBlockContext) GetProof(address Address, keys ...Key) (WitnessPro
 	return witnessProof{proof}, nil
 }
 
-func (c *archiveBlockContext) Export(ctx context.Context, out io.Writer) (Hash, error) {
+func (c *archiveBlockContext) Export(ctx context.Context, out io.Writer, scratchDir string) (Hash, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -171,7 +171,7 @@ func (c *archiveBlockContext) Export(ctx context.Context, out io.Writer) (Hash, 
 		return Hash{}, fmt.Errorf("cannot export from invalid block context")
 	}
 
-	h, err := c.archiveState.Export(ctx, out)
+	h, err := c.archiveState.Export(ctx, out, scratchDir)
 	if err != nil {
 		return Hash{}, err
 	}

--- a/go/carmen/carmen.go
+++ b/go/carmen/carmen.go
@@ -204,10 +204,11 @@ type HistoricBlockContext interface {
 	// Export writes a LiveDB data dump for the given block into out.
 	// The resulting data can be used to sync a fresh
 	// LiveDB to a certain block.
+	// Temporary staging data is placed under scratchDir.
 	// Cancelling the given ctx will gracefully stop the export.
 	// Bear in mind that cancelling the context will result
 	// in returning an error interrupt.ErrCanceled.
-	Export(ctx context.Context, out io.Writer) (Hash, error)
+	Export(ctx context.Context, out io.Writer, scratchDir string) (Hash, error)
 
 	// Close releases resources held by this context. All modifications made
 	// within this context are discarded. This context is invalid after this

--- a/go/carmen/carmen_mock.go
+++ b/go/carmen/carmen_mock.go
@@ -402,18 +402,18 @@ func (mr *MockHistoricBlockContextMockRecorder) Close() *gomock.Call {
 }
 
 // Export mocks base method.
-func (m *MockHistoricBlockContext) Export(ctx context.Context, out io.Writer) (Hash, error) {
+func (m *MockHistoricBlockContext) Export(ctx context.Context, out io.Writer, scratchDir string) (Hash, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Export", ctx, out)
+	ret := m.ctrl.Call(m, "Export", ctx, out, scratchDir)
 	ret0, _ := ret[0].(Hash)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Export indicates an expected call of Export.
-func (mr *MockHistoricBlockContextMockRecorder) Export(ctx, out any) *gomock.Call {
+func (mr *MockHistoricBlockContextMockRecorder) Export(ctx, out, scratchDir any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Export", reflect.TypeOf((*MockHistoricBlockContext)(nil).Export), ctx, out)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Export", reflect.TypeOf((*MockHistoricBlockContext)(nil).Export), ctx, out, scratchDir)
 }
 
 // GetProof mocks base method.

--- a/go/carmen/database_test.go
+++ b/go/carmen/database_test.go
@@ -2348,7 +2348,7 @@ func TestDatabase_Export(t *testing.T) {
 	}
 
 	b := bytes.NewBuffer(nil)
-	rootHash, err := ctx.Export(context.Background(), b)
+	rootHash, err := ctx.Export(context.Background(), b, t.TempDir())
 	if err != nil {
 		t.Fatalf("cannot export live db: %v", err)
 	}

--- a/go/carmen/example_test.go
+++ b/go/carmen/example_test.go
@@ -552,7 +552,7 @@ func ExampleHistoricBlockContext_Export() {
 	var rootHash carmen.Hash
 	b := bytes.NewBuffer(nil)
 	if err = db.QueryBlock(uint64(1), func(ctxt carmen.HistoricBlockContext) error {
-		rootHash, err = ctxt.Export(context.Background(), b)
+		rootHash, err = ctxt.Export(context.Background(), b, dir)
 		if err != nil {
 			log.Fatalf("cannot export: %v", err)
 		}

--- a/go/database/flat/flat.go
+++ b/go/database/flat/flat.go
@@ -400,14 +400,14 @@ func (s *State) CreateWitnessProof(address common.Address, keys ...common.Key) (
 	return s.backend.CreateWitnessProof(address, keys...)
 }
 
-func (s *State) Export(ctx context.Context, out io.Writer) (common.Hash, error) {
+func (s *State) Export(ctx context.Context, out io.Writer, scratchDir string) (common.Hash, error) {
 	if err := s.sync(); err != nil {
 		return common.Hash{}, err
 	}
 	if s.backend == nil {
 		return common.Hash{}, state.ExportNotSupported
 	}
-	return s.backend.Export(ctx, out)
+	return s.backend.Export(ctx, out, scratchDir)
 }
 
 // --- Helpers ---

--- a/go/database/flat/flat_test.go
+++ b/go/database/flat/flat_test.go
@@ -833,7 +833,7 @@ func TestState_Export_SyncsAndForwardsToBackend(t *testing.T) {
 	syncs <- struct{}{}
 
 	// Expect the backend export to be called.
-	backend.EXPECT().Export(gomock.Any(), gomock.Any()).Return(common.Hash{0xAA}, nil)
+	backend.EXPECT().Export(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.Hash{0xAA}, nil)
 
 	state := &State{
 		backend:  backend,
@@ -841,7 +841,7 @@ func TestState_Export_SyncsAndForwardsToBackend(t *testing.T) {
 		syncs:    syncs,
 	}
 
-	hash, err := state.Export(t.Context(), nil)
+	hash, err := state.Export(t.Context(), nil, t.TempDir())
 	require.NoError(t, err)
 	require.Equal(t, common.Hash{0xAA}, hash)
 
@@ -864,14 +864,14 @@ func TestState_Export_IssueReportedBySyncIsForwarded(t *testing.T) {
 	}
 	state.issues.HandleIssue(issue)
 
-	_, err := state.Export(t.Context(), nil)
+	_, err := state.Export(t.Context(), nil, t.TempDir())
 	require.ErrorIs(t, err, issue)
 }
 
 func TestState_Export_NotSupportedWithoutBackend(t *testing.T) {
 	flatState := &State{}
 
-	_, err := flatState.Export(t.Context(), nil)
+	_, err := flatState.Export(t.Context(), nil, t.TempDir())
 	require.ErrorIs(t, err, state.ExportNotSupported)
 }
 

--- a/go/database/mpt/io/live.go
+++ b/go/database/mpt/io/live.go
@@ -191,6 +191,7 @@ func ExportBlockFromArchive(ctx context.Context, logger *Log, directory string, 
 // This method exports from an online archive, i.e, an archive that is being updated with new blocks.
 // To ensure the exported data is up-to-date, this method flushes the archive to disk before exporting.
 // Expected usage is, for instance, the creation of database dumps once in many blocks to backup the state.
+// Temporary staging data is placed under scratchDir.
 func ExportBlockFromOnlineArchive(ctx context.Context, logger *Log, archive *mpt.ArchiveTrie, out io.Writer, block uint64, scratchDir string) error {
 	logger.Printf("exporting block %d from online archive", block)
 	defer func() {

--- a/go/database/mpt/io/live.go
+++ b/go/database/mpt/io/live.go
@@ -191,7 +191,7 @@ func ExportBlockFromArchive(ctx context.Context, logger *Log, directory string, 
 // This method exports from an online archive, i.e, an archive that is being updated with new blocks.
 // To ensure the exported data is up-to-date, this method flushes the archive to disk before exporting.
 // Expected usage is, for instance, the creation of database dumps once in many blocks to backup the state.
-func ExportBlockFromOnlineArchive(ctx context.Context, logger *Log, archive *mpt.ArchiveTrie, out io.Writer, block uint64) error {
+func ExportBlockFromOnlineArchive(ctx context.Context, logger *Log, archive *mpt.ArchiveTrie, out io.Writer, block uint64, scratchDir string) error {
 	logger.Printf("exporting block %d from online archive", block)
 	defer func() {
 		logger.Printf("exported block %d from online archive", block)
@@ -204,12 +204,10 @@ func ExportBlockFromOnlineArchive(ctx context.Context, logger *Log, archive *mpt
 	}
 
 	logger.Printf("exporting")
-	// No export destination path is known here, so staging data falls back to
-	// the system temp directory.
 	_, err := ExportLive(ctx, logger, exportableArchiveTrie{
 		trie:  archive,
 		block: block,
-	}, out, "")
+	}, out, scratchDir)
 	return err
 }
 

--- a/go/database/mpt/io/live_test.go
+++ b/go/database/mpt/io/live_test.go
@@ -475,7 +475,7 @@ func TestIO_ExportBlockFromOnlineArchive(t *testing.T) {
 
 		// while the archive has not been explicitly flushed or closed, the data should be available when exporting
 		buffer := new(bytes.Buffer)
-		if err := ExportBlockFromOnlineArchive(context.Background(), NewLog(), archive, buffer, uint64(i)); err != nil {
+		if err := ExportBlockFromOnlineArchive(context.Background(), NewLog(), archive, buffer, uint64(i), t.TempDir()); err != nil {
 			t.Fatalf("failed to export Archive: %v", err)
 		}
 
@@ -507,6 +507,51 @@ func TestIO_ExportBlockFromOnlineArchive(t *testing.T) {
 		if err != nil {
 			t.Fatalf("cannot close database: %v", err)
 		}
+	}
+}
+
+func TestLive_Export_FailsIfScratchDirIsNotWritable(t *testing.T) {
+	type exportFunc = func(context.Context, *Log, string, io.Writer, string) error
+
+	exportLive := func(ctx context.Context, _ *Log, dir string, out io.Writer, scratchDir string) error {
+		return Export(ctx, NewLog(), dir, out, scratchDir)
+	}
+	exportArchive := func(ctx context.Context, _ *Log, dir string, out io.Writer, scratchDir string) error {
+		return ExportArchive(ctx, NewLog(), dir, out, scratchDir)
+	}
+	exportBlockFromArchive := func(ctx context.Context, _ *Log, dir string, out io.Writer, scratchDir string) error {
+		return ExportBlockFromArchive(ctx, NewLog(), dir, out, 3, scratchDir)
+	}
+
+	for name, funcs := range map[string]struct {
+		export exportFunc
+	}{
+		"live": {
+			export: exportLive,
+		},
+		"archive": {
+			export: exportArchive,
+		},
+		"live-from-archive": {
+			export: exportBlockFromArchive,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			genesis, _ := exportExampleState(t)
+
+			buffer := bytes.NewBuffer(genesis)
+			targetDir := t.TempDir()
+			genesisBlock := uint64(12)
+			require.NoError(InitializeArchive(NewLog(), targetDir, buffer, genesisBlock))
+
+			buffer = new(bytes.Buffer)
+			scratchDir := t.TempDir()
+			require.NoError(os.Chmod(scratchDir, 0500))
+
+			err := funcs.export(context.Background(), NewLog(), targetDir, buffer, scratchDir)
+			require.Error(err)
+		})
 	}
 }
 

--- a/go/database/vt/geth/state.go
+++ b/go/database/vt/geth/state.go
@@ -363,7 +363,7 @@ func (s *verkleState) CreateWitnessProof(address common.Address, keys ...common.
 	panic("not implemented")
 }
 
-func (s *verkleState) Export(ctx context.Context, out io.Writer) (common.Hash, error) {
+func (s *verkleState) Export(ctx context.Context, out io.Writer, scratchDir string) (common.Hash, error) {
 	panic("not implemented")
 }
 

--- a/go/database/vt/reference/state.go
+++ b/go/database/vt/reference/state.go
@@ -186,6 +186,6 @@ func (s *State) CreateWitnessProof(address common.Address, keys ...common.Key) (
 	return nil, fmt.Errorf("witness proof not supported yet")
 }
 
-func (s *State) Export(ctx context.Context, out io.Writer) (common.Hash, error) {
+func (s *State) Export(ctx context.Context, out io.Writer, scratchDir string) (common.Hash, error) {
 	panic("not implemented")
 }

--- a/go/database/vt/reference/state_test.go
+++ b/go/database/vt/reference/state_test.go
@@ -319,7 +319,7 @@ func TestState_Export_PanicsAsNotImplemented(t *testing.T) {
 	state := newState()
 	require.Panics(
 		func() {
-			_, err := state.Export(t.Context(), nil)
+			_, err := state.Export(t.Context(), nil, t.TempDir())
 			require.NoError(err)
 		},
 		"Export should panic as it is not implemented",

--- a/go/state/externalstate/external_state.go
+++ b/go/state/externalstate/external_state.go
@@ -357,7 +357,7 @@ func (s *ExternalState) HasEmptyStorage(addr common.Address) (bool, error) {
 	return true, nil
 }
 
-func (s *ExternalState) Export(context.Context, io.Writer) (common.Hash, error) {
+func (s *ExternalState) Export(context.Context, io.Writer, string) (common.Hash, error) {
 	return common.Hash{}, state.ExportNotSupported
 }
 

--- a/go/state/gostate/archive_state.go
+++ b/go/state/gostate/archive_state.go
@@ -163,7 +163,7 @@ func (s *ArchiveState) GetMemoryFootprint() *common.MemoryFootprint {
 	return common.NewMemoryFootprint(unsafe.Sizeof(*s))
 }
 
-func (s *ArchiveState) Export(ctx context.Context, out io.Writer) (common.Hash, error) {
+func (s *ArchiveState) Export(ctx context.Context, out io.Writer, scratchDir string) (common.Hash, error) {
 	if err := s.archiveError; err != nil {
 		return common.Hash{}, err
 	}
@@ -173,7 +173,7 @@ func (s *ArchiveState) Export(ctx context.Context, out io.Writer) (common.Hash, 
 		return common.Hash{}, state.ExportNotSupported
 	}
 
-	err := mptio.ExportBlockFromOnlineArchive(ctx, nil, trie, out, s.block)
+	err := mptio.ExportBlockFromOnlineArchive(ctx, nil, trie, out, s.block, scratchDir)
 	// trie could get corrupted during export, practically just by flushing it
 	s.archiveError = errors.Join(s.archiveError, trie.CheckErrors())
 	if err != nil || s.archiveError != nil {

--- a/go/state/gostate/archive_state_test.go
+++ b/go/state/gostate/archive_state_test.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/0xsoniclabs/carmen/go/backend/archive"
@@ -23,6 +24,7 @@ import (
 	"github.com/0xsoniclabs/carmen/go/common/interrupt"
 	"github.com/0xsoniclabs/carmen/go/database/mpt"
 	"github.com/0xsoniclabs/carmen/go/state"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -194,7 +196,7 @@ func TestArchiveState_Export_ErrorsAreCaught(t *testing.T) {
 
 			test.setup(archive)
 
-			_, err := archive.Export(context.Background(), nil)
+			_, err := archive.Export(context.Background(), nil, t.TempDir())
 			if err == nil {
 				t.Fatal("export must fail")
 			}
@@ -238,7 +240,7 @@ func TestArchiveState_Export(t *testing.T) {
 		t.Fatalf("cannot get hash: %v", err)
 	}
 
-	gotHash, err := archive.Export(context.Background(), bytes.NewBuffer(nil))
+	gotHash, err := archive.Export(context.Background(), bytes.NewBuffer(nil), t.TempDir())
 	if err != nil {
 		t.Fatalf("cannot export: %v", err)
 	}
@@ -280,7 +282,7 @@ func TestArchiveState_Export_CanBeCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err = archive.Export(ctx, bytes.NewBuffer(nil))
+	_, err = archive.Export(ctx, bytes.NewBuffer(nil), t.TempDir())
 	if err == nil {
 		t.Fatalf("export must fail")
 	}
@@ -288,4 +290,35 @@ func TestArchiveState_Export_CanBeCancelled(t *testing.T) {
 	if !errors.Is(err, interrupt.ErrCanceled) {
 		t.Errorf("unexpected err\ngot: %v\nwant: %v", err, interrupt.ErrCanceled)
 	}
+}
+
+func TestArchiveState_Export_NonWritableScratchDirFails(t *testing.T) {
+	require := require.New(t)
+
+	sourceDir := t.TempDir()
+	trie, err := mpt.OpenArchiveTrie(sourceDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{Capacity: 1024}, mpt.ArchiveConfig{})
+	require.NoError(err, "failed to create archive")
+
+	newAddr := common.AddressFromNumber(1)
+	newAmount := amount.New(1)
+
+	update := common.Update{
+		Balances: []common.BalanceUpdate{{Account: newAddr, Balance: newAmount}},
+		Nonces:   []common.NonceUpdate{{Account: newAddr, Nonce: common.ToNonce(1)}},
+		Codes:    []common.CodeUpdate{{Account: newAddr, Code: []byte{0x1}}},
+		Slots:    []common.SlotUpdate{{Account: newAddr, Key: common.Key{byte(1)}, Value: common.Value{byte(1)}}},
+	}
+
+	require.NoError(trie.Add(2, update, nil), "failed to create block in archive")
+
+	archive := &ArchiveState{
+		archive: trie,
+		block:   2,
+	}
+
+	scratchDir := t.TempDir()
+	require.NoError(os.Chmod(scratchDir, 0500))
+
+	_, err = archive.Export(context.Background(), bytes.NewBuffer(nil), scratchDir)
+	require.Error(err, "export must fail when scratch dir is not writable")
 }

--- a/go/state/gostate/archive_state_test.go
+++ b/go/state/gostate/archive_state_test.go
@@ -297,6 +297,7 @@ func TestArchiveState_Export_NonWritableScratchDirFails(t *testing.T) {
 
 	sourceDir := t.TempDir()
 	trie, err := mpt.OpenArchiveTrie(sourceDir, mpt.S5ArchiveConfig, mpt.NodeCacheConfig{Capacity: 1024}, mpt.ArchiveConfig{})
+	t.Cleanup(func() { require.NoError(trie.Close()) })
 	require.NoError(err, "failed to create archive")
 
 	newAddr := common.AddressFromNumber(1)

--- a/go/state/gostate/go_state.go
+++ b/go/state/gostate/go_state.go
@@ -374,7 +374,7 @@ func (s *GoState) Check() error {
 	return s.getStateError()
 }
 
-func (s *GoState) Export(context.Context, io.Writer) (common.Hash, error) {
+func (s *GoState) Export(context.Context, io.Writer, string) (common.Hash, error) {
 	return common.Hash{}, state.ExportNotSupported
 }
 

--- a/go/state/state.go
+++ b/go/state/state.go
@@ -99,8 +99,9 @@ type State interface {
 	CreateWitnessProof(address common.Address, keys ...common.Key) (witness.Proof, error)
 
 	// Export writes data from LiveDB into out.
+	// Temporary staging data is placed under scratchDir.
 	// If successful, expected root hash is returned.
-	Export(ctx context.Context, out io.Writer) (common.Hash, error)
+	Export(ctx context.Context, out io.Writer, scratchDir string) (common.Hash, error)
 }
 
 type LiveDB interface {

--- a/go/state/state_mock.go
+++ b/go/state/state_mock.go
@@ -110,18 +110,18 @@ func (mr *MockStateMockRecorder) CreateWitnessProof(address any, keys ...any) *g
 }
 
 // Export mocks base method.
-func (m *MockState) Export(ctx context.Context, out io.Writer) (common.Hash, error) {
+func (m *MockState) Export(ctx context.Context, out io.Writer, scratchDir string) (common.Hash, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Export", ctx, out)
+	ret := m.ctrl.Call(m, "Export", ctx, out, scratchDir)
 	ret0, _ := ret[0].(common.Hash)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Export indicates an expected call of Export.
-func (mr *MockStateMockRecorder) Export(ctx, out any) *gomock.Call {
+func (mr *MockStateMockRecorder) Export(ctx, out, scratchDir any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Export", reflect.TypeOf((*MockState)(nil).Export), ctx, out)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Export", reflect.TypeOf((*MockState)(nil).Export), ctx, out, scratchDir)
 }
 
 // Flush mocks base method.

--- a/go/state/synced_state.go
+++ b/go/state/synced_state.go
@@ -154,8 +154,8 @@ func (s *syncedState) CreateWitnessProof(address common.Address, keys ...common.
 	return s.state.CreateWitnessProof(address, keys...)
 }
 
-func (s *syncedState) Export(ctx context.Context, out io.Writer) (common.Hash, error) {
+func (s *syncedState) Export(ctx context.Context, out io.Writer, scratchDir string) (common.Hash, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.state.Export(ctx, out)
+	return s.state.Export(ctx, out, scratchDir)
 }


### PR DESCRIPTION
This PR adds the `scratchDir` parameter to the `State::Export` function, which is used by the export function to store temporary data needed for the export.