### PR TITLE
Fix lost update on re-Set of a key buffered for flushing in `KVCachedFile`

### DIFF
--- a/go/backend/kv_file/kv_cached_file.go
+++ b/go/backend/kv_file/kv_cached_file.go
@@ -404,6 +404,11 @@ func (c *KVCachedFile[K, V]) handleCacheSet(key *K, value *V, dirty bool) error 
 	}
 	if dirty {
 		c.dirty[*key] = true
+		// Drop any stale copy of the key from the un-sealed flush buffer: the
+		// cache now holds the newest value, tracked by its dirty flag. Keeping
+		// the stale entry would let a later seal clear that flag and silently
+		// drop the newer value.
+		delete(c.flushBuffer, *key)
 	}
 	// An evicted dirty entry moves into the flush buffer; reaching the
 	// threshold seals the buffer for the background writer.

--- a/go/backend/kv_file/kv_cached_file_test.go
+++ b/go/backend/kv_file/kv_cached_file_test.go
@@ -403,6 +403,35 @@ func TestKVCachedFile_Set_ReSetWhileInFlightIsNotLost(t *testing.T) {
 	require.Equal("value0-new", *got)
 }
 
+func TestKVCachedFile_Set_ReSetWhileInFlushBufferIsNotLost(t *testing.T) {
+	require := require.New(t)
+	c, mock := openTestKVCachedFile(t)
+
+	written := map[K]V{}
+	mock.EXPECT().SetBatch(gomock.Any()).DoAndReturn(func(entries map[K]V) error {
+		maps.Copy(written, entries)
+		return nil
+	}).AnyTimes()
+	mock.EXPECT().Flush().Return(nil).AnyTimes()
+
+	// Fill the cache and evict key 0 into the (un-sealed) flush buffer.
+	require.NoError(c.Set(0, "value0"))
+	for i := 1; i <= cacheSize; i++ {
+		require.NoError(c.Set(i, fmt.Sprintf("value%d", i)))
+	}
+
+	// Re-Set key 0 while its old value still sits in the flush buffer, then
+	// trigger one more eviction so the buffer reaches the threshold and is
+	// sealed for the background writer.
+	require.NoError(c.Set(0, "value0-new"))
+	require.NoError(c.Set(cacheSize+1, "trigger"))
+
+	require.NoError(c.Flush())
+
+	// The re-Set value must be the one persisted, not the stale buffered one.
+	require.Equal("value0-new", written[0])
+}
+
 func TestKVCachedFile_Set_SurfacesAsyncWriteErrorOnNextOperation(t *testing.T) {
 	require := require.New(t)
 	c, mock := openTestKVCachedFile(t)


### PR DESCRIPTION
A Set of a key whose stale value sits in the un-sealed flush buffer left that stale entry in place; sealing the buffer then cleared the key's dirty flag, so the newer cached value was never persisted.
This PR drops the stale buffer entry when the key is added again.