### PR TITLE
Close the wrapped file in `KVCachedFile` even on error

### DIFF
--- a/go/backend/kv_file/kv_cached_file.go
+++ b/go/backend/kv_file/kv_cached_file.go
@@ -11,6 +11,7 @@
 package kv_file
 
 import (
+	"errors"
 	"fmt"
 	"iter"
 	"slices"
@@ -230,14 +231,12 @@ func (c *KVCachedFile[K, V]) Close() error {
 	// its goroutine never outlives the cached file.
 	c.shutdownWriter()
 
-	if err != nil {
-		return err
-	}
-	// The writer has stopped, so fileMu is uncontended here; it is still taken to
-	// keep "every file access happens under fileMu" a true invariant.
+	// The writer has stopped, so fileMu is  uncontended here;
+	// it is still taken to keep "every file access happens
+	// under fileMu" a true invariant.
 	c.fileMu.Lock()
 	defer c.fileMu.Unlock()
-	return c.file.Close()
+	return errors.Join(err, c.file.Close())
 }
 
 func (c *KVCachedFile[K, V]) GetMemoryFootprint() *common.MemoryFootprint {

--- a/go/backend/kv_file/kv_cached_file_test.go
+++ b/go/backend/kv_file/kv_cached_file_test.go
@@ -697,11 +697,15 @@ func TestKVCachedFile_Close_ReturnsErrorOnFlushError(t *testing.T) {
 
 	c.flushBuffer[1] = "value"
 	injected := errors.New("flush failed")
+	injectedClose := errors.New("close failed")
 	mock.EXPECT().SetBatch(gomock.Any()).Return(injected)
-	// Close on the underlying file must not be called when flush fails.
+	// The underlying file is closed even when the flush fails, so its
+	// resources are not leaked; both errors are reported.
+	mock.EXPECT().Close().Return(injectedClose)
 
 	err := c.Close()
 	require.ErrorIs(err, injected)
+	require.ErrorIs(err, injectedClose)
 }
 
 func TestKVCachedFile_Close_ReturnsErrorOnFileCloseError(t *testing.T) {


### PR DESCRIPTION
Close returned early on a sticky write error, leaking the descriptor of the underlying KVFile.
This PR fixes it by always close the wrapped file and join the two errors.