### PR TITLE
Round up LRU Cache size to avoid panic

### DIFF
--- a/go/common/lru_cache.go
+++ b/go/common/lru_cache.go
@@ -25,6 +25,10 @@ type LruCache[K comparable, V any] struct {
 
 // NewLruCache returns a new instance
 func NewLruCache[K comparable, V any](capacity int) *LruCache[K, V] {
+	if capacity < 2 {
+		capacity = 2
+	}
+
 	return &LruCache[K, V]{
 		cache:    make(map[K]*entry[K, V], capacity),
 		capacity: capacity,

--- a/go/common/lru_cache_test.go
+++ b/go/common/lru_cache_test.go
@@ -12,7 +12,24 @@ package common
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
+
+func TestLRUCache_NewLruCache_RoundsUpCapacityIfLessThanTwo(t *testing.T) {
+	tests := map[string]int{
+		"Zero capacity":     0,
+		"Capacity of one":   1,
+		"Negative capacity": -100,
+	}
+
+	for name, capacity := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := NewLruCache[int, int](capacity)
+			require.Equal(t, 2, c.capacity)
+		})
+	}
+}
 
 func TestLruExceedCapacity(t *testing.T) {
 	c := NewLruCache[int, int](3)


### PR DESCRIPTION
`LRUCache` cannot handle a capacity of 1, and panics if an entry is evicted from it.
This PR fixes it by rounding the size to 2 when smaller