### PR TITLE
Reduces `maxPendingFlushes` in `KVCachedFile`

### DIFF
--- a/go/backend/kv_file/kv_cached_file.go
+++ b/go/backend/kv_file/kv_cached_file.go
@@ -21,6 +21,12 @@ import (
 	"github.com/0xsoniclabs/carmen/go/common"
 )
 
+// maxPendingFlushes bounds the number of sealed buffers queued for the
+// background writer: one being written and one queued behind it. A producer
+// sealing a further buffer blocks until the writer catches up, keeping the
+// memory held by pending buffers bounded by ~2x the flush buffer threshold.
+const maxPendingFlushes = 2
+
 // KVCachedFile wraps a KVFile with an in-memory write-back cache. Buffered
 // writes are persisted asynchronously by a background writer; Flush, Iterate
 // and Close wait for those writes to complete, while a threshold-triggered
@@ -45,9 +51,6 @@ type KVCachedFile[K comparable, V any] struct {
 	fileMu sync.Mutex
 
 	flushBufferThreshold int
-	// maxPendingFlushes bounds the number of sealed buffers queued for the
-	// background writer, providing back-pressure that keeps memory bounded.
-	maxPendingFlushes int
 
 	// mu guards all mutable state below and is the locker of cond.
 	mu           sync.Mutex
@@ -75,7 +78,6 @@ func OpenKVCachedFile[K comparable, V any](file KVFileWithMemoryFootprint[K, V],
 		dirty:                make(map[K]bool),
 		file:                 file,
 		flushBufferThreshold: flushBufferThreshold,
-		maxPendingFlushes:    flushBufferThreshold + 1,
 		writerDone:           make(chan struct{}),
 	}
 	c.cond = sync.NewCond(&c.mu)
@@ -309,7 +311,7 @@ func (c *KVCachedFile[K, V]) enqueueCurrentBufferLocked() {
 		return
 	}
 	// Block while the queue is full to bound memory (back-pressure).
-	for len(c.pending) >= c.maxPendingFlushes && c.writeErr == nil && !c.closed {
+	for len(c.pending) >= maxPendingFlushes && c.writeErr == nil && !c.closed {
 		c.cond.Wait()
 	}
 	if c.writeErr != nil || c.closed {

--- a/go/backend/kv_file/kv_cached_file.go
+++ b/go/backend/kv_file/kv_cached_file.go
@@ -24,7 +24,7 @@ import (
 // maxPendingFlushes bounds the number of sealed buffers queued for the
 // background writer: one being written and one queued behind it. A producer
 // sealing a further buffer blocks until the writer catches up, keeping the
-// memory held by pending buffers bounded by ~2x the flush buffer threshold.
+// memory held by pending buffers bounded by ~2x the size of a sealed buffer.
 const maxPendingFlushes = 2
 
 // KVCachedFile wraps a KVFile with an in-memory write-back cache. Buffered

--- a/go/backend/kv_file/kv_cached_file_test.go
+++ b/go/backend/kv_file/kv_cached_file_test.go
@@ -17,6 +17,7 @@ import (
 	"maps"
 	"sync"
 	"testing"
+	"testing/synctest"
 
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/stretchr/testify/require"
@@ -53,25 +54,6 @@ func TestKVCachedFile_Open_ReturnsErrorOnInvalidArguments(t *testing.T) {
 			require := require.New(t)
 			_, err := OpenKVCachedFile[K, V](test.file, test.cacheSize, test.flushBufferThreshold)
 			require.Error(err)
-		})
-	}
-}
-
-func TestKVCachedFile_Open_SetsMaxPendingFlushesToThresholdPlusOne(t *testing.T) {
-	tests := map[string]int{
-		"threshold 1":   1,
-		"threshold 3":   3,
-		"threshold 100": 100,
-	}
-	for name, threshold := range tests {
-		t.Run(name, func(t *testing.T) {
-			require := require.New(t)
-			ctrl := gomock.NewController(t)
-			mock := NewMockKVFileWithMemoryFootprint[K, V](ctrl)
-			c, err := OpenKVCachedFile[K, V](mock, cacheSize, threshold)
-			require.NoError(err)
-			t.Cleanup(c.shutdownWriter)
-			require.Equal(threshold+1, c.maxPendingFlushes)
 		})
 	}
 }
@@ -925,6 +907,37 @@ func TestKVCachedFile_enqueueCurrentBufferLocked_RetainsBufferAfterWriteErrorOrC
 			require.Len(c.flushBuffer, 1, "unwritten entries must be retained")
 		})
 	}
+}
+
+func TestKVCachedFile_enqueueCurrentBufferLocked_BlocksWhenPendingQueueIsFull(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		require := require.New(t)
+		c, mock := openTestKVCachedFile(t)
+
+		_, unblockWriter := blockWriter(t, mock, nil)
+
+		// Two sealed buffers saturate the queue: one in flight, one queued.
+		sealBuffer(c, 1, "value-1")
+		synctest.Wait() // the writer is now parked inside SetBatch with buffer 1
+		sealBuffer(c, 2, "value-2")
+
+		// Sealing a third buffer must block until the writer catches up.
+		sealed := make(chan struct{})
+		go func() {
+			sealBuffer(c, 3, "value-3")
+			close(sealed)
+		}()
+		synctest.Wait() // the producer is now parked on the full queue
+		select {
+		case <-sealed:
+			t.Fatal("sealing beyond the pending bound did not block")
+		default:
+		}
+
+		unblockWriter()
+		<-sealed
+		require.NoError(c.Flush())
+	})
 }
 
 // The background writer must persist queued buffers oldest-first so the newest


### PR DESCRIPTION
The current limit of pending flushed in `KVCachedFIle` was set to `flushBufferThreshold+1`. This could have put a memory pressure equals to the square of `flushBufferThreshold`.
This puts an fixed upper bound to the number of pending flushed in `KVCachedFile`