### PR TITLE
Refresh the `OffsetFile` size after a failed batch write

### DIFF
--- a/go/backend/kv_file/offset_file.go
+++ b/go/backend/kv_file/offset_file.go
@@ -90,7 +90,9 @@ func (o *OffsetFile[K, V]) SetBatch(pending map[K]V) error {
 
 	for key, value := range pending {
 		if err := o.writeEntryLocked(key, value); err != nil {
-			return err
+			// Entries written before the failure are already indexed; refresh
+			// the cached file size so they remain readable.
+			return errors.Join(err, o.updateFileSizeLocked())
 		}
 	}
 	return o.updateFileSizeLocked()

--- a/go/backend/kv_file/offset_file_test.go
+++ b/go/backend/kv_file/offset_file_test.go
@@ -225,6 +225,44 @@ func TestOffsetFile_SetBatch_EmptyBatchIsNoop(t *testing.T) {
 	require.EqualValues(0, info.Size())
 }
 
+func TestOffsetFile_SetBatch_KeepsWrittenEntriesReadableAfterPartialFailure(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "partial.dat")
+
+	// A codec that fails on the second write, so a batch of two entries is
+	// interrupted after one of them was written and indexed.
+	injected := errors.New("injected write failure")
+	calls := 0
+	writeFn := func(w io.Writer, key uint64, value uint64) error {
+		calls++
+		if calls > 1 {
+			return injected
+		}
+		return offsetWriteValue(w, key, value)
+	}
+
+	f, err := OpenOffsetFile[uint64, uint64](path, offsetReadValue, writeFn)
+	require.NoError(err)
+	defer func() { require.NoError(f.Close()) }()
+
+	entries := map[uint64]uint64{1: 10, 2: 20}
+	require.ErrorIs(f.SetBatch(entries), injected)
+
+	// The entry written before the failure is indexed and must stay readable.
+	for key, want := range entries {
+		has, err := f.Has(key)
+		require.NoError(err)
+		if !has {
+			continue
+		}
+		got, err := f.Get(key)
+		require.NoError(err)
+		require.NotNil(got)
+		require.Equal(want, *got)
+	}
+}
+
 func TestOffsetFile_Iterate_ReturnsAllEntries(t *testing.T) {
 	require := require.New(t)
 	f, _ := openTestOffsetFile(t)


### PR DESCRIPTION
A batch write failing midway left the cached file size stale while the entries written before the failure were already indexed, so reading them failed against the outdated size limit.
This PR fixes it by adding updating the size again before returning from an error