### PR TITLE
Test that verification treats missing code and root files as empty

### DIFF
--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -409,6 +409,31 @@ func TestArchiveTrie_Open_Fails_InconsistentCheckpoints(t *testing.T) {
 	}
 }
 
+// Regression test: the pre-KVFile implementation served a missing root list
+// as an empty archive; moving to KVFile-based storage must not change this
+// behavior.
+func TestArchiveTrie_VerifyArchiveTrie_TreatsMissingRootsFileAsEmptyArchive(t *testing.T) {
+	for _, config := range allMptConfigs {
+		t.Run(config.Name, func(t *testing.T) {
+			require := require.New(t)
+			dir := t.TempDir()
+			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
+			require.NoError(err)
+			require.NoError(archive.Add(1, common.Update{
+				Balances: []common.BalanceUpdate{{Account: common.Address{1}, Balance: amount.New(1)}},
+			}, nil))
+			require.NoError(archive.Close())
+
+			// Dropping the root list and its checkpoint data leaves an archive
+			// without blocks; verification must treat it as empty and pass.
+			require.NoError(os.Remove(filepath.Join(dir, fileNameArchiveRoots)))
+			require.NoError(os.RemoveAll(filepath.Join(dir, fileNameArchiveRootsCheckpointDirectory)))
+
+			require.NoError(VerifyArchiveTrie(context.Background(), dir, config, NilVerificationObserver{}))
+		})
+	}
+}
+
 func TestArchiveTrie_CanTrackBlocksHeight(t *testing.T) {
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {

--- a/go/database/mpt/verification_test.go
+++ b/go/database/mpt/verification_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/common/amount"
 	"github.com/0xsoniclabs/carmen/go/common/interrupt"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -537,6 +538,21 @@ func TestVerification_UnreadableCodesReturnError(t *testing.T) {
 		if !errors.Is(got, want) {
 			t.Errorf("unexpected error, got: %v, want: %v", got, want)
 		}
+	})
+}
+
+// Regression test: the pre-KVFile implementation served a missing code file
+// as an empty code collection; moving to KVFile-based storage must not change
+// this behavior.
+func TestVerification_MissingCodeFileIsTreatedAsEmptyCodeCollection(t *testing.T) {
+	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
+		require := require.New(t)
+		require.NoError(os.Remove(filepath.Join(dir, "codes.dat")))
+
+		// A missing code file is treated as an empty code collection: the
+		// codes referenced by the accounts must be reported as missing.
+		err := VerifyMptState(context.Background(), dir, config, rootsFromSlice(roots), NilVerificationObserver{})
+		require.ErrorContains(err, "is missing in code file")
 	})
 }
 


### PR DESCRIPTION
This PR adds regression tests to check that pre-existing behavior for code and root list is preserved
In particular, it checks that a missing file is treated as an empty collection rather that an error