### PR TITLE
Write cleared storage slots on account clearance

### DIFF
--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -1294,19 +1294,16 @@ func (s *stateDB) EndBlock(block uint64) <-chan error {
 
 	// Update storage values in state DB
 	s.data.ForEach(func(slot slotId, value *slotValue) {
-		if value.storedKnown && value.stored == value.current {
-			// No DB write is needed, but if the account was cleared in this
-			// block its reincarnation counter was incremented; the cache
-			// entry is refreshed so that the still valid stored value is not
-			// masked as outdated by future reads. This covers slots that are
-			// explicitly set back to their stored value after a clearing.
-			if state, found := s.clearedAccounts[slot.addr]; found && (state == cleared || state == clearedAndTainted) {
-				s.storedDataCache.Set(slot, storedDataCacheValue{value.current, s.reincarnation[slot.addr]})
-			}
-			return
+		if !value.storedKnown || value.stored != value.current {
+			update.AppendSlotUpdate(slot.addr, slot.key, value.current)
+			s.storedDataCache.Set(slot, storedDataCacheValue{value.current, s.reincarnation[slot.addr]})
+		} else if state, found := s.clearedAccounts[slot.addr]; found && (state == cleared || state == clearedAndTainted) {
+			// The account was cleared in this block, incrementing its reincarnation
+			// counter; refresh the cache entry so the still valid stored value is
+			// not masked as outdated by future reads.
+			s.storedDataCache.Set(slot, storedDataCacheValue{value.current, s.reincarnation[slot.addr]})
 		}
-		update.AppendSlotUpdate(slot.addr, slot.key, value.current)
-		s.storedDataCache.Set(slot, storedDataCacheValue{value.current, s.reincarnation[slot.addr]})
+
 	})
 
 	// Update modified codes.

--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -544,9 +544,9 @@ func (s *stateDB) CreateAccount(addr common.Address) {
 				*value = backup
 			})
 
-			// Clear cached values.
-			value.stored = common.Value{}
-			value.storedKnown = true
+			// Clear cached values. The stored value and its known flag are
+			// deliberately left untouched: they keep describing the value
+			// currently present in the DB.
 			value.committed = common.Value{}
 			value.committedKnown = true
 			value.current = common.Value{}
@@ -1162,8 +1162,8 @@ func (s *stateDB) EndTransaction() {
 				if slot.addr == addr {
 					oldValue := *value
 					// Clear cached values.
-					value.stored = common.Value{}
-					value.storedKnown = true
+					// value.stored = common.Value{}
+					// value.storedKnown = true
 					value.committed = common.Value{}
 					value.committedKnown = true
 					value.current = common.Value{}
@@ -1296,10 +1296,19 @@ func (s *stateDB) EndBlock(block uint64) <-chan error {
 
 	// Update storage values in state DB
 	s.data.ForEach(func(slot slotId, value *slotValue) {
-		if !value.storedKnown || value.stored != value.current {
-			update.AppendSlotUpdate(slot.addr, slot.key, value.current)
-			s.storedDataCache.Set(slot, storedDataCacheValue{value.current, s.reincarnation[slot.addr]})
+		if value.storedKnown && value.stored == value.current {
+			// No DB write is needed, but if the account was cleared in this
+			// block its reincarnation counter was incremented; the cache
+			// entry is refreshed so that the still valid stored value is not
+			// masked as outdated by future reads. This covers slots that are
+			// explicitly set back to their stored value after a clearing.
+			if state, found := s.clearedAccounts[slot.addr]; found && (state == cleared || state == clearedAndTainted) {
+				s.storedDataCache.Set(slot, storedDataCacheValue{value.current, s.reincarnation[slot.addr]})
+			}
+			return
 		}
+		update.AppendSlotUpdate(slot.addr, slot.key, value.current)
+		s.storedDataCache.Set(slot, storedDataCacheValue{value.current, s.reincarnation[slot.addr]})
 	})
 
 	// Update modified codes.

--- a/go/state/state_db.go
+++ b/go/state/state_db.go
@@ -1162,8 +1162,6 @@ func (s *stateDB) EndTransaction() {
 				if slot.addr == addr {
 					oldValue := *value
 					// Clear cached values.
-					// value.stored = common.Value{}
-					// value.storedKnown = true
 					value.committed = common.Value{}
 					value.committedKnown = true
 					value.current = common.Value{}

--- a/go/state/state_db_inter_tx_snapshot_test.go
+++ b/go/state/state_db_inter_tx_snapshot_test.go
@@ -229,8 +229,10 @@ func DeletingAccountWithData(t *testing.T, state *stateDB, beginOp func(state *s
 	state.EndTransaction()
 
 	require.Equal(state.clearedAccounts[addr], cleared)
-	require.Equal(testSlotValue.stored, common.Value{})
-	require.Equal(testSlotValue.storedKnown, true)
+	// The stored value and its known flag are not touched by the clearing;
+	// they keep describing the value present in the DB.
+	require.Equal(testSlotValue.stored, common.Value{0x1})
+	require.Equal(testSlotValue.storedKnown, false)
 	require.Equal(testSlotValue.committed, common.Value{})
 	require.Equal(testSlotValue.committedKnown, true)
 	require.Equal(testSlotValue.current, common.Value{})

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -537,7 +537,8 @@ func TestStateDB_QueryingStoredDataOfDestroyedAccountIsNotReturningDeletedValues
 
 	db.BeginBlock()
 	db.BeginTransaction()
-	// This will lookup in the storadDataCache, but since the reincarnation is higher, it's gonna return an empty value
+	// The reincarnation value is the same, so it reads from the reincarnation map.
+	// The value has been zeroed-out and saved into the cache.
 	got = db.GetState(address1, key1)
 	require.Equal(got, common.Value{})
 

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -179,9 +179,12 @@ func TestStateDB_RecreatingAnAccountSetsStorageToZero(t *testing.T) {
 	// Simulate a non-existing account.
 	setExpectationForEmptyAccount(t, mock, address1)
 	mock.EXPECT().Check().AnyTimes()
+	// The written slot has an unknown stored value, so an explicit
+	// zero-write is emitted for it after the clearing.
 	mock.EXPECT().Apply(uint64(1), common.Update{
 		Nonces: []common.NonceUpdate{{Account: address1}},
 		Codes:  []common.CodeUpdate{{Account: address1, Code: []byte{}}},
+		Slots:  []common.SlotUpdate{{Account: address1, Key: key1, Value: common.Value{}}},
 	})
 
 	db.CreateAccount(address1)
@@ -236,9 +239,16 @@ func TestStateDB_RecreatingAccountResetsStorage(t *testing.T) {
 	// Initially the account is non-existing, it gets recreated.
 	setExpectationForEmptyAccount(t, mock, address1)
 	mock.EXPECT().Check().AnyTimes()
+	// The slots written before the account clearing have an unknown stored
+	// value (they were never read), so explicit zero-writes are emitted for
+	// them to make sure no former value is retained in the DB.
 	mock.EXPECT().Apply(uint64(1), common.Update{
 		Nonces: []common.NonceUpdate{{Account: address1, Nonce: common.Nonce{0, 0, 0, 0, 0, 0, 0, 1}}},
 		Codes:  []common.CodeUpdate{{Account: address1, Code: []byte{}}},
+		Slots: []common.SlotUpdate{
+			{Account: address1, Key: key2, Value: common.Value{}},
+			{Account: address1, Key: key1, Value: common.Value{}},
+		},
 	})
 
 	// First transaction creates an account and sets some storage values.
@@ -294,12 +304,16 @@ func TestStateDB_RecreatingAccountResetsStorageButRetainsNewState(t *testing.T) 
 	mock.EXPECT().GetStorage(address1, key1).Return(val1, nil)
 	mock.EXPECT().GetStorage(address1, key2).Return(val2, nil)
 
-	// At the end the account is recreated with the new state.
+	// At the end the account is recreated with the new state. The slot key2,
+	// known to hold val2 in the DB, is explicitly zeroed by the clearing.
 	mock.EXPECT().Apply(uint64(123), common.Update{
 		Balances: []common.BalanceUpdate{{Account: address1}},
 		Nonces:   []common.NonceUpdate{{Account: address1, Nonce: common.ToNonce(12)}},
 		Codes:    []common.CodeUpdate{{Account: address1, Code: []byte{}}},
-		Slots:    []common.SlotUpdate{{Account: address1, Key: key1, Value: val2}},
+		Slots: []common.SlotUpdate{
+			{Account: address1, Key: key2, Value: common.Value{}},
+			{Account: address1, Key: key1, Value: val2},
+		},
 	})
 
 	if got := db.GetState(address1, key1); got != val1 {
@@ -340,6 +354,73 @@ func TestStateDB_RecreatingAccountResetsStorageButRetainsNewState(t *testing.T) 
 
 	db.EndTransaction()
 	db.EndBlock(123)
+}
+
+func TestStateDB_EndBlock_ClearedSlotsWithKnownStoredValueAreWrittenAsZero(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	state := NewMockState(ctrl)
+	state.EXPECT().Check().AnyTimes()
+	state.EXPECT().GetBalance(gomock.Any()).Return(amount.New(), nil).AnyTimes()
+	state.EXPECT().GetNonce(gomock.Any()).Return(common.ToNonce(1), nil).AnyTimes()
+	state.EXPECT().GetCodeSize(gomock.Any()).Return(0, nil).AnyTimes()
+	state.EXPECT().GetStorage(gomock.Any(), gomock.Any()).Return(val1, nil).AnyTimes()
+
+	address := common.Address{1, 2, 3}
+	// The cleared slot is known to hold val1 in the DB. Since the clearing
+	// of the account is not part of the block update, an explicit zero is
+	// written to purge the retained value, even without any SetState call.
+	state.EXPECT().Apply(uint64(1), common.Update{
+		Slots: []common.SlotUpdate{{Account: address, Key: key1, Value: common.Value{}}},
+	}).Return(nil, nil)
+
+	stateDB := CreateCustomStateDBUsing(state, 10).(*stateDB)
+	stateDB.BeginTransaction()
+	stateDB.GetState(address, key1) // caches the stored value val1
+	stateDB.CreateAccount(address)  // clears the storage
+	stateDB.EndTransaction()
+	stateDB.EndBlock(1)
+}
+
+func TestStateDB_EndBlock_SlotResetToStoredValueAfterClearingStaysVisible(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	state := NewMockState(ctrl)
+	state.EXPECT().Check().AnyTimes()
+	state.EXPECT().GetBalance(gomock.Any()).Return(amount.New(), nil).AnyTimes()
+	state.EXPECT().GetNonce(gomock.Any()).Return(common.ToNonce(1), nil).AnyTimes()
+	state.EXPECT().GetCodeSize(gomock.Any()).Return(0, nil).AnyTimes()
+	// The stored value is fetched exactly once; later reads must be served
+	// from the caches.
+	state.EXPECT().GetStorage(gomock.Any(), gomock.Any()).Times(1).Return(val1, nil)
+
+	address := common.Address{1, 2, 3}
+	// The slot is set back to the value the DB already holds, so no slot
+	// update is emitted for it.
+	state.EXPECT().Apply(uint64(1), common.Update{
+		Nonces: []common.NonceUpdate{{Account: address, Nonce: common.ToNonce(5)}},
+		Codes:  []common.CodeUpdate{{Account: address, Code: []byte{}}},
+	}).Return(nil, nil)
+
+	stateDB := CreateCustomStateDBUsing(state, 10).(*stateDB)
+	stateDB.BeginTransaction()
+	require.Equal(val1, stateDB.GetState(address, key1)) // caches the stored value val1
+	stateDB.CreateAccount(address)                       // clears the storage
+	stateDB.SetState(address, key1, val1)                // sets the slot back to its stored value
+	stateDB.SetNonce(address, 5)                         // keeps the account alive
+	stateDB.EndTransaction()
+	stateDB.EndBlock(1)
+
+	// The stored data cache entry carries the incremented reincarnation, so
+	// the still valid value is not masked as outdated.
+	cached, exists := stateDB.storedDataCache.Get(slotId{address, key1})
+	require.True(exists)
+	require.Equal(val1, cached.value)
+	require.Equal(stateDB.reincarnation[address], cached.reincarnation)
+
+	// The value remains visible in the next block.
+	stateDB.BeginTransaction()
+	require.Equal(val1, stateDB.GetState(address, key1))
+	stateDB.EndTransaction()
 }
 
 func TestStateDB_DestroyingRecreatedAccountIsNotResettingClearingState(t *testing.T) {
@@ -433,7 +514,10 @@ func TestStateDB_QueryingStoredDataOfDestroyedAccountIsNotReturningDeletedValues
 	mock.EXPECT().GetBalance(gomock.Any()).AnyTimes().Return(amount.New(0), nil)
 	mock.EXPECT().GetNonce(gomock.Any()).AnyTimes().Return(common.Nonce{}, nil)
 	mock.EXPECT().GetCodeSize(gomock.Any()).AnyTimes().Return(0, nil)
-	mock.EXPECT().Apply(uint64(0), common.Update{}) // Empty because it's a non-existing account
+	// The leftover stored value of the deleted account is explicitly zeroed.
+	mock.EXPECT().Apply(uint64(0), common.Update{
+		Slots: []common.SlotUpdate{{Account: address1, Key: key1, Value: common.Value{}}},
+	})
 	mock.EXPECT().GetStorage(address1, key1).Times(1).Return(val2, nil)
 
 	db.BeginBlock()
@@ -445,12 +529,11 @@ func TestStateDB_QueryingStoredDataOfDestroyedAccountIsNotReturningDeletedValues
 	db.EndTransaction() // Account will be deleted because empty
 	db.EndBlock(0)
 
-	// Value is still in the storadDataCache
+	// The stored data cache reflects the zeroed value with the current reincarnation.
 	cachedValue, exists := db.storedDataCache.Get(slotId{address1, key1})
 	require.True(exists)
-	require.Equal(cachedValue.value, val2)
-	// Reincarnation value of the cached entry is higher than the current one
-	require.Greater(db.reincarnation[address1], cachedValue.reincarnation)
+	require.Equal(cachedValue.value, common.Value{})
+	require.Equal(db.reincarnation[address1], cachedValue.reincarnation)
 
 	db.BeginBlock()
 	db.BeginTransaction()
@@ -923,7 +1006,10 @@ func TestStateDB_RepeatedSuicide(t *testing.T) {
 		Balances: []common.BalanceUpdate{{Account: address1, Balance: newBalance}},
 		Nonces:   []common.NonceUpdate{{Account: address1}},
 		Codes:    []common.CodeUpdate{{Account: address1, Code: []byte{}}},
-		Slots:    []common.SlotUpdate{{Account: address1, Key: key2, Value: val2}},
+		Slots: []common.SlotUpdate{
+			{Account: address1, Key: key2, Value: val2},
+			{Account: address1, Key: key1, Value: common.Value{}},
+		},
 	})
 
 	// The changes are applied to the state at the end of the block.
@@ -1965,10 +2051,14 @@ func TestStateDB_ImplicitAccountCreatedBySetStateIsDroppedSinceEmptyIfNothingEls
 	mock := NewMockState(ctrl)
 	db := CreateStateDBUsing(mock)
 
-	// The account is not created at the end of the transaction, nor is the value set.
+	// The account is not created at the end of the transaction. For the
+	// written slot the stored value is unknown, so an explicit zero-write is
+	// emitted to make sure no former value is retained in the DB.
 	mock.EXPECT().Check().AnyTimes()
 	setExpectationForEmptyAccount(t, mock, address1)
-	mock.EXPECT().Apply(uint64(1), common.Update{})
+	mock.EXPECT().Apply(uint64(1), common.Update{
+		Slots: []common.SlotUpdate{{Account: address1, Key: key1, Value: common.Value{}}},
+	})
 
 	db.SetState(address1, key1, val1)
 	db.EndTransaction()
@@ -3152,6 +3242,9 @@ func TestStateDB_SuicidedAccountNotRecreatedBySettingBalance(t *testing.T) {
 		Balances: []common.BalanceUpdate{{Account: address1}},
 		Nonces:   []common.NonceUpdate{{Account: address1}},
 		Codes:    []common.CodeUpdate{{Account: address1, Code: []byte{}}},
+		// The slot written after the suicide has an unknown stored value, so
+		// an explicit zero-write is emitted for it after the clearing.
+		Slots: []common.SlotUpdate{{Account: address1, Key: key1, Value: common.Value{}}},
 	})
 
 	// The account is suicided


### PR DESCRIPTION
Clearing an account (re-creation via `CreateAccount` or the removal of empty or self-destructed accounts at the end of a transaction) used to reset the cached slot values of the account to `stored = 0, storedKnown= true`. This encoded the assumption that the clearing of the account physically purges its storage in the DB, making explicit zero-writes unnecessary.

That assumption no longer holds for one specific case. An account that is destroyed and stays destroyed is still purged completely: zeroing its balance, nonce, and code makes its account info empty, upon which the MPT removes the account node together with its entire storage. But if the account is re-created within the same block, its info is never empty at the end of the block, the node survives, and its former
storage is retained in the DB: nothing at the account level purges it, and slots whose final value matched the pretended zero stored value were skipped by the write-back in `EndBlock`.

This case cannot arise on post-Dencun chains: deploying onto an address with retained code or a non-zero nonce fails the create collision check (EIP-684), and an address holding storage without code can no longer come into existence, since SELFDESTRUCT either deletes nothing (for established contracts) or the entire account (for contracts created within the same transaction, whose storage never reaches the DB), as specified by EIP-6780. The only re-creation still occurring, deploying over an account holding nothing but a balance, involves no storage. Replaying pre-Dencun history (e.g. Sepolia), however, destroys and re-creates accounts with existing storage, which corrupted the state.

The clearing now leaves `stored` and `storedKnown` untouched, so they keep describing the value present in the DB. The `EndBlock` write-back then emits, for the cached slots of a cleared account:  
- an explicit zero for slots whose stored value is non-zero, purging the retained value;
- an explicit zero for slots whose stored value is unknown, making sure no former value is retained;
- an explicit value for slots re-written after the clearing, including writes of the zero value, which are now distinguishable from the cleared state;
- no write for slots whose final value equals their known stored value. For these, the stored data cache entry is refreshed with the account's incremented reincarnation counter: without the refresh, the still valid cached value would be masked as outdated and read as zero in future blocks, while the DB still holds the value.

The unit tests asserting the former contract are adapted:
- the clearing no longer resets `stored`/`storedKnown` of cached slots (`TestStateDB_CreateAccount_*`, `DeletingAccountWithData`);
- block updates now contain explicit zero-writes for cleared slots, including slots of accounts created and deleted within the same block, whose stored value is unknown (`RecreatingAnAccount*`, `RepeatedSuicide`, `ImplicitAccountCreatedBySetState*`, `SuicidedAccountNotRecreatedBySettingBalance`);
- the stored data cache is expected to hold the written zero with the current reincarnation instead of the masked stale value (`QueryingStoredDataOfDestroyedAccountIsNotReturningDeletedValues`).

**NOTE:** this fix does not address for stored values that are NOT cached. Those values will not be zeroed, and will persist in the underlying state. However, the scope of this PR is not to support pre-Dencun chains but rather to fix a behavior happening during the Sepolia history run.

Two new tests cover the explicit zero-write for a cleared slot with a known non-zero stored value, and the stored data cache refresh for a slot that is re-set to its stored value after a clearing.

Closes: https://github.com/0xsoniclabs/sonic-admin/issues/864