### PR TITLE
Fix `Archive::Export` docstring

### DIFF
--- a/go/database/mpt/io/archive.go
+++ b/go/database/mpt/io/archive.go
@@ -58,9 +58,7 @@ var archiveMagicNumber []byte = []byte("Fantom-Archive-State")
 const archiveFormatVersion = byte(1)
 
 // ExportArchive exports the archive in the given directory to out. Temporary
-// staging data is placed under scratchDir, which should be on the same volume
-// as the export destination; an empty scratchDir falls back to the system
-// temp directory.
+// staging data is placed under scratchDir.
 func ExportArchive(ctx context.Context, logger *Log, directory string, out io.Writer, scratchDir string) error {
 	return ExportArchiveWithConfig(ctx, logger, directory, out, scratchDir, mpt.NodeCacheConfig{}, mpt.ArchiveConfig{})
 }


### PR DESCRIPTION
The docstring erroneously asserted that an empty scratch dir would have fall back to the system temp directory, which is not true