### PR TITLE
Remove coverate.txt in `make clean` and add to .gitignore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ carmen-rust:
 	cargo build --release
 
 clean:
-	cd rust ; \
-	cargo clean ; \
+	rm -f go/coverage.txt
+	cd rust && cargo clean
 
 .PHONY: license-check
 license-check:

--- a/go/.gitignore
+++ b/go/.gitignore
@@ -1,3 +1,4 @@
 .idea
 build
 .venv/
+coverage.txt


### PR DESCRIPTION
The new CI check for generated files was failing because of `go/coverage.txt`, which is left from previous runs on Jenkins.
This PR adds it to the make clean command