### PR TITLE
Disable automatic compaction for PebbleDB in `codes.go`

### DIFF
--- a/go/database/mpt/io/codes.go
+++ b/go/database/mpt/io/codes.go
@@ -72,7 +72,7 @@ func newCodeSortStore(scratchDir string) (*codeSortStore, error) {
 	// The store is discarded after the export, so crash safety through the
 	// write-ahead log is not needed.
 	// No automatic compactions are needed either, as the store is append-only and short lived.
-	db, err := pebble.Open(dir, &pebble.Options{DisableWAL: true}) //DisableAutomaticCompactions: true, L0StopWritesThreshold: 1000})
+	db, err := pebble.Open(dir, &pebble.Options{DisableWAL: true, DisableAutomaticCompactions: true, L0StopWritesThreshold: 1000})
 	if err != nil {
 		return nil, errors.Join(
 			fmt.Errorf("failed to open staging store: %w", err),

--- a/go/database/mpt/io/codes.go
+++ b/go/database/mpt/io/codes.go
@@ -71,7 +71,8 @@ func newCodeSortStore(scratchDir string) (*codeSortStore, error) {
 	}
 	// The store is discarded after the export, so crash safety through the
 	// write-ahead log is not needed.
-	db, err := pebble.Open(dir, &pebble.Options{DisableWAL: true})
+	// No automatic compactions are needed either, as the store is append-only and short lived.
+	db, err := pebble.Open(dir, &pebble.Options{DisableWAL: true}) //DisableAutomaticCompactions: true, L0StopWritesThreshold: 1000})
 	if err != nil {
 		return nil, errors.Join(
 			fmt.Errorf("failed to open staging store: %w", err),

--- a/go/database/mpt/io/codes_test.go
+++ b/go/database/mpt/io/codes_test.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"maps"
 	"os"
@@ -210,6 +211,33 @@ func TestCodeSortStore_AddAndWriteTo_DeduplicatesRepeatedHashes(t *testing.T) {
 	require.NoError(err)
 	require.Equal(code, got)
 	require.Zero(buf.Len(), "a repeatedly added code must be written only once")
+}
+
+func BenchmarkCodeSortStore(b *testing.B) {
+	sizes := []int{100_000, 1_000_000, 10_000_000}
+	for _, n := range sizes {
+		b.Run(fmt.Sprintf("N=%d", n), func(b *testing.B) {
+			require := require.New(b)
+			for range b.N {
+				store, err := newCodeSortStore(b.TempDir())
+				if err != nil {
+					b.Fatal(err)
+				}
+				for i := range n {
+					code := [200]byte{byte(i >> 24), byte(i >> 16), byte(i >> 8), byte(i)}
+					// Mix i to avoid sequential key insertion.
+					u := uint32(i) * 2654435761
+					var hash common.Hash
+					binary.BigEndian.PutUint32(hash[0:4], u)
+					if err := store.add(hash, code[:]); err != nil {
+						b.Fatal(err)
+					}
+				}
+				require.NoError(store.writeTo(io.Discard))
+				require.NoError(store.close())
+			}
+		})
+	}
 }
 
 // failingWriter is an io.Writer that succeeds for the first failAfter calls

--- a/go/database/mpt/io/codes_test.go
+++ b/go/database/mpt/io/codes_test.go
@@ -241,7 +241,7 @@ func BenchmarkCodeSortStore(b *testing.B) {
 				require.NoError(store.close())
 			}
 			perOp := total.Seconds() / float64(b.N)
-			b.ReportMetric(perOp, "s/op")
+			b.ReportMetric(perOp, "Add+WriteTo/s")
 			fmt.Printf("BenchmarkCodeSortStore/N=%d: add+writeTo total=%.3fs, per-op=%.3fs (b.N=%d)\n",
 				n, total.Seconds(), perOp, b.N)
 		})

--- a/go/database/mpt/io/codes_test.go
+++ b/go/database/mpt/io/codes_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/stretchr/testify/require"
@@ -218,11 +219,13 @@ func BenchmarkCodeSortStore(b *testing.B) {
 	for _, n := range sizes {
 		b.Run(fmt.Sprintf("N=%d", n), func(b *testing.B) {
 			require := require.New(b)
+			var total time.Duration
 			for range b.N {
 				store, err := newCodeSortStore(b.TempDir())
 				if err != nil {
 					b.Fatal(err)
 				}
+				start := time.Now()
 				for i := range n {
 					code := [200]byte{byte(i >> 24), byte(i >> 16), byte(i >> 8), byte(i)}
 					// Mix i to avoid sequential key insertion.
@@ -234,8 +237,13 @@ func BenchmarkCodeSortStore(b *testing.B) {
 					}
 				}
 				require.NoError(store.writeTo(io.Discard))
+				total += time.Since(start)
 				require.NoError(store.close())
 			}
+			perOp := total.Seconds() / float64(b.N)
+			b.ReportMetric(perOp, "s/op")
+			fmt.Printf("BenchmarkCodeSortStore/N=%d: add+writeTo total=%.3fs, per-op=%.3fs (b.N=%d)\n",
+				n, total.Seconds(), perOp, b.N)
 		})
 	}
 }

--- a/go/database/mpt/io/codes_test.go
+++ b/go/database/mpt/io/codes_test.go
@@ -242,8 +242,6 @@ func BenchmarkCodeSortStore(b *testing.B) {
 			}
 			perOp := total.Seconds() / float64(b.N)
 			b.ReportMetric(perOp, "Add+WriteTo/s")
-			fmt.Printf("BenchmarkCodeSortStore/N=%d: add+writeTo total=%.3fs, per-op=%.3fs (b.N=%d)\n",
-				n, total.Seconds(), perOp, b.N)
 		})
 	}
 }


### PR DESCRIPTION
`database/mpt/io/codes.go` uses a temporary PebbleDb to store the codes and retrieve them in order of hash.
With the current options, PebbleDB runs a compaction job to reduce the stored size. This is detrimental for performance and not needed, as the store is append-only and it's gonna be deleted at the end of the export.

This PR disable the automatic compaction, and adds a benchmark to measure the storage write performance.

Benchmark result:
With compaction:
```bash
go test -run=BenchmarkCodeSortStore  -bench=BenchmarkCodeSortStore -benchtime=1x ./database/mpt/io/

goos: linux
goarch: amd64
pkg: github.com/0xsoniclabs/carmen/go/database/mpt/io
cpu: AMD Ryzen 9 7950X3D 16-Core Processor
BenchmarkCodeSortStore/N=100000-32                     1         107643570 ns/op                 0.08389 Add+WriteTo/s
BenchmarkCodeSortStore/N=1000000-32                    1        1842610633 ns/op                 1.787 Add+WriteTo/s
BenchmarkCodeSortStore/N=10000000-32                   1        53661795949 ns/op               53.59 Add+WriteTo/s
PASS
ok      github.com/0xsoniclabs/carmen/go/database/mpt/io        55.622s
```

Without compaction:
```bash
go test -run=BenchmarkCodeSortStore  -bench=BenchmarkCodeSortStore -benchtime=1x ./database/mpt/io/

goos: linux
goarch: amd64
pkg: github.com/0xsoniclabs/carmen/go/database/mpt/io
cpu: AMD Ryzen 9 7950X3D 16-Core Processor
BenchmarkCodeSortStore/N=100000-32                     1          89307716 ns/op                 0.08235 Add+WriteTo/s
BenchmarkCodeSortStore/N=1000000-32                    1         876684229 ns/op                 0.8698 Add+WriteTo/s
BenchmarkCodeSortStore/N=10000000-32                   1        11803493727 ns/op               11.74 Add+WriteTo/s
PASS
ok      github.com/0xsoniclabs/carmen/go/database/mpt/io        12.785s
```