### PR TITLE
Configure dependabot for github actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2025 Sonic Operations Ltd
+#
+# Use of this software is governed by the Business Source License included
+# in the LICENSE file and at soniclabs.com/bsl11.
+#
+# Change Date: 2028-4-16
+#
+# On the date above, in accordance with the Business Source License, use of
+# this software will be governed by the GNU Lesser General Public License v3.
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    ignore:
+      # The tag is the Rust version, not an action version.
+      - dependency-name: dtolnay/rust-toolchain


### PR DESCRIPTION
This PR configures dependabot for github actions. It will open a new PR whenever a new version is available.