### PR TITLE
Fuzz daily from this repository, rotating over its entry points

### DIFF
--- a/CI/fuzzing.jenkinsfile
+++ b/CI/fuzzing.jenkinsfile
@@ -1,0 +1,159 @@
+// Copyright (c) 2025 Sonic Operations Ltd
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at soniclabs.com/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+// Fuzzes one Carmen entry point, built on the toolchain image this commit ships
+// (CI/Dockerfile.jenkins), so what is fuzzed and what it is built with can never drift apart. That
+// is why this pipeline lives here rather than in LaScala: a Jenkins dockerfile agent is resolved
+// against the pipeline's own repository, so only a pipeline in Carmen can use Carmen's image.
+//
+// Which entry point, and for how long, is decided by the rotation job in LaScala
+// (fuzzing/rotation.jenkinsfile). This job takes the entry point as a plain string and finds the
+// package it lives in itself, so adding a fuzzer to this repository needs no pipeline change here
+// and none there.
+@Library('shared-library') _
+
+// Package holding the entry point, relative to go/ where the go.mod sits, resolved from the checkout
+// in 'prepare'. Null until then, which the failure handler below has to allow for.
+def fuzzPackage
+// Repository url and commit of this checkout, for the reproduction instructions.
+def checkedOut
+
+pipeline {
+    agent {
+        dockerfile {
+            filename 'CI/Dockerfile.jenkins'
+            // ?: because the very first build of a new job has no parameter definitions yet, and a
+            // null label would put a six hour fuzzing run on whatever agent happens to be free.
+            label params.AgentLabel ?: 'fuzzing-carmen'
+        }
+    }
+
+    options {
+        timestamps()
+        // Failsafe against a misconfigured job: sets the build to ABORTED when it triggers, and an
+        // aborted build runs no failure handler, so FuzzTime is kept an hour below it (checked in
+        // 'validate-parameters') to leave a bug found in the final minutes time to be reported.
+        timeout(time: 8, unit: 'HOURS')
+    }
+
+    // No triggers: the LaScala rotation job decides when this runs and what it fuzzes.
+
+    environment {
+        CC = 'clang-19'
+        CXX = 'clang++-19'
+        GOMEMLIMIT = goMemLimit()
+        // The corpus the fuzzer builds up lives in $GOCACHE/fuzz - only the inputs that FAIL are
+        // written into the repository. The container is thrown away after every build, so the cache
+        // has to live in the workspace, which the agent keeps: otherwise every run starts from the
+        // seed corpus again and every hour ever spent fuzzing this entry point is discarded.
+        GOCACHE = "${env.WORKSPACE}/.gocache"
+    }
+
+    parameters {
+        string(
+            name: 'AgentLabel',
+            defaultValue: 'fuzzing-carmen',
+            description: 'Jenkins agent label to run this job on. It builds a Docker image, so it ' +
+                'has to be an agent that can.'
+        )
+        string(
+            name: 'EntryPoint',
+            defaultValue: '',
+            description: '''Required. Fuzzer entry point to run. Any `func FuzzXxx(f *testing.F)` of
+this repository will do: the job searches the checkout for the package it lives in, and lists every
+entry point it found if this is not one of them.
+
+At the time of writing (a hint, not a constraint - the repository decides): FuzzMapOperations,
+FuzzLruCache_RandomOps, FuzzNWays_RandomOps, FuzzBufferedFile_RandomOps, FuzzBufferedFile_ReadWrite,
+FuzzStack_RandomOps, FuzzFileStock_RandomOps, FuzzSyncStock_RandomOps, FuzzMemoryStock_RandomOps,
+FuzzLiveTrie_RandomAccountOps, FuzzLiveTrie_RandomAccountStorageOps, FuzzArchiveTrie_RandomAccountOps,
+FuzzArchiveTrie_RandomAccountStorageOps.'''
+        )
+        string(
+            name: 'FuzzTime',
+            defaultValue: '6h',
+            description: 'Time given to the fuzzer, as a Go duration. At most 7h, an hour below the ' +
+                'build timeout. Shorten it (e.g. 30s) to test this pipeline.'
+        )
+    }
+
+    stages {
+        stage('validate-parameters') {
+            steps {
+                describeBuild()
+
+                script {
+                    // Against the 8 hour timeout set above.
+                    fuzzer.requireSaneTimeout(fuzzTime: params.FuzzTime, timeoutMinutes: 8 * 60)
+                }
+            }
+        }
+
+        stage('prepare') {
+            steps {
+                script {
+                    // The SCM configuration of the job replaces the repository/version parameters a
+                    // pipeline outside this repository would need, so the reproduction instructions
+                    // read both back out of the checkout.
+                    checkedOut = fuzzer.checkoutInfo()
+
+                    // Resolved against this checkout, so a mistyped EntryPoint aborts here with the
+                    // list of what this repository actually offers rather than fuzzing nothing. The
+                    // module directory defaults to go/, which is where Carmen's go.mod sits.
+                    fuzzPackage = fuzzer.resolvePackage(entryPoint: params.EntryPoint)
+
+                    // Workspaces are reused between builds; report only what this run produced.
+                    fuzzer.resetLog()
+                }
+            }
+        }
+
+        stage('build') {
+            steps {
+                sh 'make all'
+            }
+        }
+
+        stage('fuzzing-test') {
+            steps {
+                script {
+                    fuzzer.fuzz(
+                        package: fuzzPackage,
+                        entryPoint: params.EntryPoint,
+                        fuzzTime: params.FuzzTime
+                    )
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            script {
+                fuzzer.reportProgress(channel: 'jenkins-carmen')
+            }
+        }
+
+        failure {
+            script {
+                // A build that failed before 'prepare' resolved the package has no findings to
+                // attach: the failure is reported above and there is nothing to add.
+                if (fuzzPackage) {
+                    fuzzer.archiveFindings(
+                        package: fuzzPackage,
+                        entryPoint: params.EntryPoint,
+                        repository: checkedOut.repository,
+                        version: checkedOut.version
+                    )
+                }
+            }
+        }
+    }
+}

--- a/CI/fuzzing.jenkinsfile
+++ b/CI/fuzzing.jenkinsfile
@@ -8,73 +8,56 @@
 // On the date above, in accordance with the Business Source License, use of
 // this software will be governed by the GNU Lesser General Public License v3.
 
-// Fuzzes one Carmen entry point, built on the toolchain image this commit ships
-// (CI/Dockerfile.jenkins), so what is fuzzed and what it is built with can never drift apart. That
-// is why this pipeline lives here rather than in LaScala: a Jenkins dockerfile agent is resolved
-// against the pipeline's own repository, so only a pipeline in Carmen can use Carmen's image.
+// Fuzzes one Carmen entry point a day, rotating over every `func FuzzXxx(f *testing.F)` this
+// repository has - so a new fuzzer joins the rotation without a change here. The decision and the
+// steps come from LaScala's shared library (fuzzRotation, fuzzer); the schedule and the toolchain
+// are this repository's, because a Jenkins dockerfile agent is resolved against the pipeline's own
+// repository and only a pipeline in Carmen can build on Carmen's CI/Dockerfile.jenkins.
 //
-// Which entry point, and for how long, is decided by the rotation job in LaScala
-// (fuzzing/rotation.jenkinsfile). This job takes the entry point as a plain string and finds the
-// package it lives in itself, so adding a fuzzer to this repository needs no pipeline change here
-// and none there.
+// The module root is left at its default of go/, which is where Carmen's go.mod sits.
 @Library('shared-library') _
 
-// Package holding the entry point, relative to go/ where the go.mod sits, resolved from the checkout
-// in 'prepare'. Null until then, which the failure handler below has to allow for.
+def entryPoint
 def fuzzPackage
-// Repository url and commit of this checkout, for the reproduction instructions.
 def checkedOut
 
 pipeline {
     agent {
         dockerfile {
             filename 'CI/Dockerfile.jenkins'
-            // ?: because the very first build of a new job has no parameter definitions yet, and a
-            // null label would put a six hour fuzzing run on whatever agent happens to be free.
-            label params.AgentLabel ?: 'fuzzing-carmen'
+            label 'fuzzing-carmen'
         }
     }
 
     options {
         timestamps()
-        // Failsafe against a misconfigured job: sets the build to ABORTED when it triggers, and an
-        // aborted build runs no failure handler, so FuzzTime is kept an hour below it (checked in
-        // 'validate-parameters') to leave a bug found in the final minutes time to be reported.
         timeout(time: 8, unit: 'HOURS')
+        // Two builds at once would pick the same entry point.
+        disableConcurrentBuilds()
+        // The rotation reads what was fuzzed lately out of these build descriptions, so this history
+        // is its memory: it has to hold far more builds than the repository has entry points.
+        buildDiscarder(logRotator(numToKeepStr: '200'))
     }
 
-    // No triggers: the LaScala rotation job decides when this runs and what it fuzzes.
+    triggers {
+        cron('@daily')
+    }
 
     environment {
         CC = 'clang-19'
         CXX = 'clang++-19'
         GOMEMLIMIT = goMemLimit()
-        // The corpus the fuzzer builds up lives in $GOCACHE/fuzz - only the inputs that FAIL are
-        // written into the repository. The container is thrown away after every build, so the cache
-        // has to live in the workspace, which the agent keeps: otherwise every run starts from the
-        // seed corpus again and every hour ever spent fuzzing this entry point is discarded.
+        // The corpus lives in $GOCACHE/fuzz and the container is thrown away after every build, so
+        // the cache has to sit in the workspace, which the agent keeps.
         GOCACHE = "${env.WORKSPACE}/.gocache"
     }
 
     parameters {
         string(
-            name: 'AgentLabel',
-            defaultValue: 'fuzzing-carmen',
-            description: 'Jenkins agent label to run this job on. It builds a Docker image, so it ' +
-                'has to be an agent that can.'
-        )
-        string(
             name: 'EntryPoint',
             defaultValue: '',
-            description: '''Required. Fuzzer entry point to run. Any `func FuzzXxx(f *testing.F)` of
-this repository will do: the job searches the checkout for the package it lives in, and lists every
-entry point it found if this is not one of them.
-
-At the time of writing (a hint, not a constraint - the repository decides): FuzzMapOperations,
-FuzzLruCache_RandomOps, FuzzNWays_RandomOps, FuzzBufferedFile_RandomOps, FuzzBufferedFile_ReadWrite,
-FuzzStack_RandomOps, FuzzFileStock_RandomOps, FuzzSyncStock_RandomOps, FuzzMemoryStock_RandomOps,
-FuzzLiveTrie_RandomAccountOps, FuzzLiveTrie_RandomAccountStorageOps, FuzzArchiveTrie_RandomAccountOps,
-FuzzArchiveTrie_RandomAccountStorageOps.'''
+            description: 'Fuzzer entry point to run. Empty - which is what the daily run leaves it - ' +
+                'means the one that has gone longest without a turn.'
         )
         string(
             name: 'FuzzTime',
@@ -85,31 +68,15 @@ FuzzArchiveTrie_RandomAccountStorageOps.'''
     }
 
     stages {
-        stage('validate-parameters') {
+        stage('prepare') {
             steps {
                 describeBuild()
 
                 script {
-                    // Against the 8 hour timeout set above.
                     fuzzer.requireSaneTimeout(fuzzTime: params.FuzzTime, timeoutMinutes: 8 * 60)
-                }
-            }
-        }
-
-        stage('prepare') {
-            steps {
-                script {
-                    // The SCM configuration of the job replaces the repository/version parameters a
-                    // pipeline outside this repository would need, so the reproduction instructions
-                    // read both back out of the checkout.
                     checkedOut = fuzzer.checkoutInfo()
-
-                    // Resolved against this checkout, so a mistyped EntryPoint aborts here with the
-                    // list of what this repository actually offers rather than fuzzing nothing. The
-                    // module directory defaults to go/, which is where Carmen's go.mod sits.
-                    fuzzPackage = fuzzer.resolvePackage(entryPoint: params.EntryPoint)
-
-                    // Workspaces are reused between builds; report only what this run produced.
+                    entryPoint = params.EntryPoint ?: fuzzRotation.pickTarget()
+                    fuzzPackage = fuzzer.resolvePackage(entryPoint: entryPoint)
                     fuzzer.resetLog()
                 }
             }
@@ -126,9 +93,18 @@ FuzzArchiveTrie_RandomAccountStorageOps.'''
                 script {
                     fuzzer.fuzz(
                         package: fuzzPackage,
-                        entryPoint: params.EntryPoint,
+                        entryPoint: entryPoint,
                         fuzzTime: params.FuzzTime
                     )
+                }
+            }
+
+            post {
+                // Whatever the fuzzer found: an entry point that crashes must not be picked forever.
+                always {
+                    script {
+                        fuzzRotation.recordTarget(entryPoint)
+                    }
                 }
             }
         }
@@ -143,12 +119,11 @@ FuzzArchiveTrie_RandomAccountStorageOps.'''
 
         failure {
             script {
-                // A build that failed before 'prepare' resolved the package has no findings to
-                // attach: the failure is reported above and there is nothing to add.
+                // A build that failed before 'prepare' resolved the package has nothing to attach.
                 if (fuzzPackage) {
                     fuzzer.archiveFindings(
                         package: fuzzPackage,
-                        entryPoint: params.EntryPoint,
+                        entryPoint: entryPoint,
                         repository: checkedOut.repository,
                         version: checkedOut.version
                     )


### PR DESCRIPTION
Moves Carmen's fuzzing out of LaScala and into this repository, where it is easier to maintain: the pipeline sits next to the code it fuzzes, and builds on the same `CI/Dockerfile.jenkins` the PR job already uses.

That is also why it has to live here. A Jenkins `dockerfile` agent is resolved against the *pipeline's own* SCM, so a pipeline in LaScala cannot use this image — it built Carmen with whatever the agent happened to have installed instead, none of it pinned to what this repository expects. Tosca's fuzzer broke exactly that way when its Rust version moved into the image; Carmen has the widest toolchain of the three and was next in line.

`CI/fuzzing.jenkinsfile` runs once a day and fuzzes one entry point, rotating over every `func FuzzXxx(f *testing.F)` it finds in its own checkout — so adding a fuzzer needs no change to this pipeline. `EntryPoint` is for running one by hand; empty means whichever has gone longest without a turn. The rotation and the fuzzing steps come from LaScala's shared library (0xsoniclabs/lascala#312, merged).

One line worth not deleting: `GOCACHE` points into the workspace because `go test -fuzz` keeps its corpus in `$GOCACHE/fuzz`, and the container does not survive the build.

Note the current entry points are all pure Go, so `go test` runs without the `carmen_cpp`/`carmen_rust` tags the PR job passes — same as before, but a fuzzer needing the native bindings would need them.

Needs a Jenkins job pointed at this file; nothing runs until that exists.
