### PR TITLE
Add `CODEOWNERS` assigning @ihtefyw as default owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for everything in this repository.
+# Applies unless a later, more specific rule matches.
+* @ihtefyw


### PR DESCRIPTION
Adds `.github/CODEOWNERS` with a single catch-all rule:

```
* @ihtefyw
```

This makes @ihtefyw the default code owner for the whole repository, so they are automatically requested for review on every pull request.

### Notes

- @ihtefyw has `write` access to this repository, which is required for a CODEOWNERS entry to be honored — entries for users without write access are silently ignored by GitHub.
- CODEOWNERS only takes effect once merged into the default branch.
- Branch protection on `main` currently has `require_code_owner_reviews: false` and `required_approving_review_count: 0`. Review requests will be created automatically, but code owner approval will not be *required* until that setting is enabled. That is a branch-protection change, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)