### PR TITLE
Increase `TestLiveTrie_DeleteLargeAccount` test timer to 1s

### DIFF
--- a/go/database/mpt/live_trie_test.go
+++ b/go/database/mpt/live_trie_test.go
@@ -864,7 +864,7 @@ func TestLiveTrie_DeleteLargeAccount(t *testing.T) {
 				t.Errorf("failed to clear storage: %v", err)
 			}
 			// If done wrong, the delete takes > 1 second.
-			if duration, limit := time.Since(start), 50*time.Millisecond; duration > limit {
+			if duration, limit := time.Since(start), 1*time.Second; duration > limit {
 				t.Errorf("delete took too long: %v, limit %v", duration, limit)
 			}
 


### PR DESCRIPTION
In this test, a call to `ClearStorage` occurs. As this should be asynchronous, there is a timer counting how much time does it take, failing if it takes > 50ms.
This time is arbitrary, and may sometimes fail in CI on slow runners. Also, the above comments refers to > 1s execution time.

I updated the time limit to reflect the comment.