### PR TITLE
Add `_mocks.go` to skip list

### DIFF
--- a/go/scripts/license/add_license_header.go
+++ b/go/scripts/license/add_license_header.go
@@ -65,7 +65,7 @@ func main() {
 	}
 
 	// Patterns to ignore
-	ignore := []string{"/build/", "_mock.go", ".pb.go", "keccak.h"}
+	ignore := []string{"/build/", "_mock.go", "_mocks.go", ".pb.go", "keccak.h"}
 
 	// Process files with specified extensions
 	for ext, prefix := range patterns {


### PR DESCRIPTION
The license header script was erroneously adding the license to mock files with multiple mocks inside which werern't starting with the line `// Code generated` (e.g. `external_state_mocks.go`)
This PR fixes it