### PR TITLE
Add `ResultSeq` to iter_utils

### DIFF
--- a/go/common/iter_utils/iter.go
+++ b/go/common/iter_utils/iter.go
@@ -12,6 +12,7 @@ package iter_utils
 
 import (
 	"iter"
+	"slices"
 
 	"github.com/0xsoniclabs/carmen/go/common/result"
 )
@@ -39,22 +40,29 @@ type ResultSeq[V any] = iter.Seq[result.Result[V]]
 // equivalent of an `iter.Seq2`.
 type ResultSeq2[K, V any] = ResultSeq[Pair[K, V]]
 
-// OkSeq lifts an `iter.Seq` into a `ResultSeq` that never fails.
-func OkSeq[V any](seq iter.Seq[V]) ResultSeq[V] {
-	return func(yield func(result.Result[V]) bool) {
+// Map maps an `iter.Seq` of values to another `iter.Seq` of values using the provided mapping function.
+func Map[VIn, VOut any](
+	seq iter.Seq[VIn],
+	f func(VIn) VOut,
+) iter.Seq[VOut] {
+	return func(yield func(VOut) bool) {
 		for v := range seq {
-			if !yield(result.Ok(v)) {
+			if !yield(f(v)) {
 				return
 			}
 		}
 	}
 }
 
-// OkSeq2 lifts an `iter.Seq2` into a `ResultSeq2` that never fails.
-func OkSeq2[K, V any](seq iter.Seq2[K, V]) ResultSeq2[K, V] {
-	return func(yield func(result.Result[Pair[K, V]]) bool) {
+// Map2 maps an `iter.Seq2` of key-value pairs to another `iter.Seq2` of key-value pairs using the provided mapping function.
+func Map2[KIn, VIn, KOut, VOut any](
+	seq iter.Seq2[KIn, VIn],
+	f func(KIn, VIn) (KOut, VOut),
+) iter.Seq2[KOut, VOut] {
+	return func(yield func(KOut, VOut) bool) {
 		for k, v := range seq {
-			if !yield(result.Ok(Pair[K, V]{Key: k, Value: v})) {
+			k2, v2 := f(k, v)
+			if !yield(k2, v2) {
 				return
 			}
 		}
@@ -93,14 +101,22 @@ func Unwrap2[K, V any](seq ResultSeq2[K, V]) (iter.Seq2[K, V], func() error) {
 	}, seqErr
 }
 
-// Map maps an `iter.Seq` of values to another `iter.Seq` of values using the provided mapping function.
-func Map[VIn, VOut any](
-	seq iter.Seq[VIn],
-	f func(VIn) VOut,
-) iter.Seq[VOut] {
-	return func(yield func(VOut) bool) {
+// OkSeq lifts an `iter.Seq` into a `ResultSeq` that never fails.
+func OkSeq[V any](seq iter.Seq[V]) ResultSeq[V] {
+	return func(yield func(result.Result[V]) bool) {
 		for v := range seq {
-			if !yield(f(v)) {
+			if !yield(result.Ok(v)) {
+				return
+			}
+		}
+	}
+}
+
+// OkSeq2 lifts an `iter.Seq2` into a `ResultSeq2` that never fails.
+func OkSeq2[K, V any](seq iter.Seq2[K, V]) ResultSeq2[K, V] {
+	return func(yield func(result.Result[Pair[K, V]]) bool) {
+		for k, v := range seq {
+			if !yield(result.Ok(Pair[K, V]{Key: k, Value: v})) {
 				return
 			}
 		}
@@ -114,11 +130,7 @@ func MapOk[VIn, VOut any](
 	f func(VIn) VOut,
 ) ResultSeq[VOut] {
 	return Map(seq, func(r result.Result[VIn]) result.Result[VOut] {
-		v, err := r.Get()
-		if err != nil {
-			return result.Err[VOut](err)
-		}
-		return result.Ok(f(v))
+		return result.Map(r, f)
 	})
 }
 
@@ -128,14 +140,11 @@ func MapOk2[KIn, VIn, KOut, VOut any](
 	seq ResultSeq2[KIn, VIn],
 	f func(KIn, VIn) (KOut, VOut),
 ) ResultSeq2[KOut, VOut] {
-	return Map(seq, func(r result.Result[Pair[KIn, VIn]]) result.Result[Pair[KOut, VOut]] {
-		in, err := r.Get()
-		if err != nil {
-			return result.Err[Pair[KOut, VOut]](err)
-		}
+	return MapOk(seq, func(in Pair[KIn, VIn]) Pair[KOut, VOut] {
 		key, value := f(in.Unpack())
-		return result.Ok(Pair[KOut, VOut]{Key: key, Value: value})
+		return Pair[KOut, VOut]{Key: key, Value: value}
 	})
+
 }
 
 func DropKeys[K, V any](seq iter.Seq2[K, V]) iter.Seq[V] {
@@ -157,11 +166,5 @@ func DropKeysOk2[K, V any](seq ResultSeq2[K, V]) ResultSeq[V] {
 // Enumerate creates an `iter.Seq2` from a slice of values, pairing each value
 // with its `uint64` index.
 func Enumerate[V any](slice []V) iter.Seq2[uint64, V] {
-	return func(yield func(uint64, V) bool) {
-		for i, v := range slice {
-			if !yield(uint64(i), v) {
-				return
-			}
-		}
-	}
+	return Map2(slices.All(slice), func(i int, v V) (uint64, V) { return uint64(i), v })
 }

--- a/go/common/iter_utils/iter.go
+++ b/go/common/iter_utils/iter.go
@@ -12,7 +12,86 @@ package iter_utils
 
 import (
 	"iter"
+
+	"github.com/0xsoniclabs/carmen/go/common/result"
 )
+
+// Pair combines a key and a value into a single value. It allows key-value
+// pairs to be transported through the single-element `iter.Seq`, which is
+// required whenever the elements need to be wrapped, for instance in a
+// `result.Result`.
+type Pair[K, V any] struct {
+	Key   K
+	Value V
+}
+
+// Unpack splits the pair into its key and value.
+func (p Pair[K, V]) Unpack() (K, V) {
+	return p.Key, p.Value
+}
+
+// ResultSeq is a sequence of values whose production may fail. Producers report
+// a failure by yielding an error element and stopping the iteration; consumers
+// must inspect every element, which `Unwrap` facilitates.
+type ResultSeq[V any] = iter.Seq[result.Result[V]]
+
+// ResultSeq2 is the key-value counterpart of `ResultSeq`. It is the fallible
+// equivalent of an `iter.Seq2`.
+type ResultSeq2[K, V any] = ResultSeq[Pair[K, V]]
+
+// OkSeq lifts an `iter.Seq` into a `ResultSeq` that never fails.
+func OkSeq[V any](seq iter.Seq[V]) ResultSeq[V] {
+	return func(yield func(result.Result[V]) bool) {
+		for v := range seq {
+			if !yield(result.Ok(v)) {
+				return
+			}
+		}
+	}
+}
+
+// OkSeq2 lifts an `iter.Seq2` into a `ResultSeq2` that never fails.
+func OkSeq2[K, V any](seq iter.Seq2[K, V]) ResultSeq2[K, V] {
+	return func(yield func(result.Result[Pair[K, V]]) bool) {
+		for k, v := range seq {
+			if !yield(result.Ok(Pair[K, V]{Key: k, Value: v})) {
+				return
+			}
+		}
+	}
+}
+
+// Unwrap converts a `ResultSeq` into a plain `iter.Seq` that stops at the first
+// failure. The returned function reports that failure and must only be
+// consulted once the iteration has ended.
+func Unwrap[V any](seq ResultSeq[V]) (iter.Seq[V], func() error) {
+	var err error
+	return func(yield func(V) bool) {
+		err = nil
+		for r := range seq {
+			v, e := r.Get()
+			if e != nil {
+				err = e
+				return
+			}
+			if !yield(v) {
+				return
+			}
+		}
+	}, func() error { return err }
+}
+
+// Unwrap2 is the key-value counterpart of `Unwrap`.
+func Unwrap2[K, V any](seq ResultSeq2[K, V]) (iter.Seq2[K, V], func() error) {
+	pairs, seqErr := Unwrap(seq)
+	return func(yield func(K, V) bool) {
+		for pair := range pairs {
+			if !yield(pair.Unpack()) {
+				return
+			}
+		}
+	}, seqErr
+}
 
 // Map maps an `iter.Seq` of values to another `iter.Seq` of values using the provided mapping function.
 func Map[VIn, VOut any](
@@ -28,11 +107,59 @@ func Map[VIn, VOut any](
 	}
 }
 
-// DropKeys drops the keys from an `iter.Seq2` of key-value pairs and returns an `iter.Seq` of values.
+// MapOk maps the successful values of a `ResultSeq` using the provided mapping
+// function. Failures are forwarded unchanged.
+func MapOk[VIn, VOut any](
+	seq ResultSeq[VIn],
+	f func(VIn) VOut,
+) ResultSeq[VOut] {
+	return Map(seq, func(r result.Result[VIn]) result.Result[VOut] {
+		v, err := r.Get()
+		if err != nil {
+			return result.Err[VOut](err)
+		}
+		return result.Ok(f(v))
+	})
+}
+
+// MapOk2 maps the successful key-value pairs of a `ResultSeq2` using the
+// provided mapping function. Failures are forwarded unchanged.
+func MapOk2[KIn, VIn, KOut, VOut any](
+	seq ResultSeq2[KIn, VIn],
+	f func(KIn, VIn) (KOut, VOut),
+) ResultSeq2[KOut, VOut] {
+	return Map(seq, func(r result.Result[Pair[KIn, VIn]]) result.Result[Pair[KOut, VOut]] {
+		in, err := r.Get()
+		if err != nil {
+			return result.Err[Pair[KOut, VOut]](err)
+		}
+		key, value := f(in.Unpack())
+		return result.Ok(Pair[KOut, VOut]{Key: key, Value: value})
+	})
+}
+
 func DropKeys[K, V any](seq iter.Seq2[K, V]) iter.Seq[V] {
 	return func(yield func(V) bool) {
 		for _, v := range seq {
 			if !yield(v) {
+				return
+			}
+		}
+	}
+}
+
+// DropKeysOk2 drops the keys of a `ResultSeq2`, yielding a `ResultSeq` of the values.
+// Failures are forwarded unchanged.
+func DropKeysOk2[K, V any](seq ResultSeq2[K, V]) ResultSeq[V] {
+	return MapOk(seq, func(pair Pair[K, V]) V { return pair.Value })
+}
+
+// Enumerate creates an `iter.Seq2` from a slice of values, pairing each value
+// with its `uint64` index.
+func Enumerate[V any](slice []V) iter.Seq2[uint64, V] {
+	return func(yield func(uint64, V) bool) {
+		for i, v := range slice {
+			if !yield(uint64(i), v) {
 				return
 			}
 		}

--- a/go/common/iter_utils/iter_test.go
+++ b/go/common/iter_utils/iter_test.go
@@ -11,13 +11,91 @@
 package iter_utils
 
 import (
+	"fmt"
 	"maps"
 	"slices"
 	"strconv"
 	"testing"
 
+	"github.com/0xsoniclabs/carmen/go/common/result"
 	"github.com/stretchr/testify/require"
 )
+
+func TestIter_Unpack_ReturnsKeyAndValue(t *testing.T) {
+	require := require.New(t)
+
+	key, value := Pair[int, string]{Key: 1, Value: "one"}.Unpack()
+
+	require.Equal(1, key)
+	require.Equal("one", value)
+}
+
+func TestIter_OkSeq_YieldsAllValuesAsSuccesses(t *testing.T) {
+	require := require.New(t)
+
+	seq := OkSeq(slices.Values([]string{"a", "b"}))
+
+	values, seqErr := Unwrap(seq)
+	require.Equal([]string{"a", "b"}, slices.Collect(values))
+	require.NoError(seqErr())
+}
+
+func TestIter_OkSeq2_YieldsAllPairsAsSuccesses(t *testing.T) {
+	require := require.New(t)
+
+	seq := OkSeq2(Enumerate([]string{"a", "ab"}))
+
+	pairs, seqErr := Unwrap2(seq)
+	require.Equal(map[uint64]string{0: "a", 1: "ab"}, maps.Collect(pairs))
+	require.NoError(seqErr())
+}
+
+func TestIter_Unwrap_StopsAtFirstFailureAndReportsIt(t *testing.T) {
+	require := require.New(t)
+
+	injected := fmt.Errorf("injected failure")
+	seq, seqErr := Unwrap(func(yield func(result.Result[string]) bool) {
+		if !yield(result.Ok("one")) {
+			return
+		}
+		if !yield(result.Err[string](injected)) {
+			return
+		}
+		yield(result.Ok("three"))
+	})
+
+	require.Equal([]string{"one"}, slices.Collect(seq))
+	require.ErrorIs(seqErr(), injected)
+}
+
+func TestIter_Unwrap2_YieldsAllPairsWithoutError(t *testing.T) {
+	require := require.New(t)
+
+	seq, seqErr := Unwrap2(OkSeq2(Enumerate([]string{"a", "b"})))
+
+	require.Equal(map[uint64]string{0: "a", 1: "b"}, maps.Collect(seq))
+	require.NoError(seqErr())
+}
+
+func TestIter_Unwrap2_StopsAtFirstFailureAndReportsIt(t *testing.T) {
+	require := require.New(t)
+
+	injected := fmt.Errorf("injected failure")
+	seq, seqErr := Unwrap2(func(yield func(result.Result[Pair[int, string]]) bool) {
+		if !yield(result.Ok(Pair[int, string]{Key: 1, Value: "one"})) {
+			return
+		}
+		if !yield(result.Err[Pair[int, string]](injected)) {
+			return
+		}
+		yield(result.Ok(Pair[int, string]{Key: 3, Value: "three"}))
+	})
+
+	results := maps.Collect(seq)
+
+	require.ErrorIs(seqErr(), injected)
+	require.Equal(map[int]string{1: "one"}, results)
+}
 
 func TestIter_Map_ReturnsMappedSeq(t *testing.T) {
 	input := []int{1, 2, 3}
@@ -30,12 +108,96 @@ func TestIter_Map_ReturnsMappedSeq(t *testing.T) {
 	require.Equal(t, expected, slices.Collect(seq))
 }
 
-func TestIter_DropKeys_ReturnsSeqOfValues(t *testing.T) {
-	input := map[int]string{1: "A", 2: "B", 3: "C"}
-	expected := []string{"A", "B", "C"}
+func TestIter_MapOk_MapsSuccessfulValues(t *testing.T) {
+	require := require.New(t)
 
-	seq := DropKeys(maps.All(input))
-	got := slices.Collect(seq)
-	slices.Sort(got)
-	require.Equal(t, expected, got)
+	seq := MapOk(OkSeq(slices.Values([]int{1, 2, 3})), strconv.Itoa)
+
+	values, seqErr := Unwrap(seq)
+	require.Equal([]string{"1", "2", "3"}, slices.Collect(values))
+	require.NoError(seqErr())
+}
+
+func TestIter_MapOk_ForwardsFailures(t *testing.T) {
+	require := require.New(t)
+
+	injected := fmt.Errorf("injected failure")
+	seq := MapOk(
+		func(yield func(result.Result[int]) bool) {
+			yield(result.Err[int](injected))
+		},
+		func(v int) string {
+			t.Fatal("the mapping function must not be applied to a failure")
+			return ""
+		},
+	)
+
+	for r := range seq {
+		_, err := r.Get()
+		require.ErrorIs(err, injected)
+	}
+}
+
+func TestIter_MapOk2_MapsSuccessfulPairs(t *testing.T) {
+	require := require.New(t)
+
+	seq := MapOk2(OkSeq2(Enumerate([]string{"a", "ab"})), func(k uint64, v string) (string, int) {
+		return v, int(k) + len(v)
+	})
+
+	pairs, seqErr := Unwrap2(seq)
+	require.Equal(map[string]int{"a": 1, "ab": 3}, maps.Collect(pairs))
+	require.NoError(seqErr())
+}
+
+func TestIter_MapOk2_ForwardsFailures(t *testing.T) {
+	require := require.New(t)
+
+	injected := fmt.Errorf("injected failure")
+	seq := MapOk2(
+		func(yield func(result.Result[Pair[int, string]]) bool) {
+			yield(result.Err[Pair[int, string]](injected))
+		},
+		func(k int, v string) (int, string) {
+			t.Fatal("the mapping function must not be applied to a failure")
+			return k, v
+		},
+	)
+
+	for r := range seq {
+		_, err := r.Get()
+		require.ErrorIs(err, injected)
+	}
+}
+
+func TestIter_DropKeysOk2_YieldsValuesWithoutKeys(t *testing.T) {
+	require := require.New(t)
+
+	seq := DropKeysOk2(OkSeq2(Enumerate([]string{"a", "b"})))
+
+	values, seqErr := Unwrap(seq)
+	require.Equal([]string{"a", "b"}, slices.Collect(values))
+	require.NoError(seqErr())
+}
+
+func TestIter_DropKeysOk2_ForwardsFailures(t *testing.T) {
+	require := require.New(t)
+
+	injected := fmt.Errorf("injected failure")
+	seq := DropKeysOk2(func(yield func(result.Result[Pair[int, string]]) bool) {
+		yield(result.Err[Pair[int, string]](injected))
+	})
+
+	for r := range seq {
+		_, err := r.Get()
+		require.ErrorIs(err, injected)
+	}
+}
+
+func TestIter_Enumerate_PairsValuesWithTheirIndices(t *testing.T) {
+	require := require.New(t)
+
+	seq := Enumerate([]string{"a", "b", "c"})
+
+	require.Equal(map[uint64]string{0: "a", 1: "b", 2: "c"}, maps.Collect(seq))
 }

--- a/go/common/iter_utils/iter_test.go
+++ b/go/common/iter_utils/iter_test.go
@@ -68,6 +68,15 @@ func TestIter_Unwrap_StopsAtFirstFailureAndReportsIt(t *testing.T) {
 	require.ErrorIs(seqErr(), injected)
 }
 
+func TestIter_Unwrap_YieldsAllValuesWithoutError(t *testing.T) {
+	require := require.New(t)
+
+	seq, seqErr := Unwrap(OkSeq(slices.Values([]string{"a", "b"})))
+
+	require.Equal([]string{"a", "b"}, slices.Collect(seq))
+	require.NoError(seqErr())
+}
+
 func TestIter_Unwrap2_YieldsAllPairsWithoutError(t *testing.T) {
 	require := require.New(t)
 

--- a/go/common/iter_utils/iter_test.go
+++ b/go/common/iter_utils/iter_test.go
@@ -117,6 +117,17 @@ func TestIter_Map_ReturnsMappedSeq(t *testing.T) {
 	require.Equal(t, expected, slices.Collect(seq))
 }
 
+func TestIter_Map2_ReturnsMappedSeq(t *testing.T) {
+	input := map[string]int{"a": 1, "b": 2}
+	expected := map[string]string{"a": "1", "b": "2"}
+
+	mapFunc := func(k string, v int) (string, string) {
+		return k, strconv.Itoa(v)
+	}
+	seq := Map2(maps.All(input), mapFunc)
+	require.Equal(t, expected, maps.Collect(seq))
+}
+
 func TestIter_MapOk_MapsSuccessfulValues(t *testing.T) {
 	require := require.New(t)
 
@@ -141,10 +152,10 @@ func TestIter_MapOk_ForwardsFailures(t *testing.T) {
 		},
 	)
 
-	for r := range seq {
-		_, err := r.Get()
-		require.ErrorIs(err, injected)
-	}
+	values := slices.Collect(seq)
+	require.Equal(1, len(values))
+	_, err := values[0].Get()
+	require.ErrorIs(err, injected)
 }
 
 func TestIter_MapOk2_MapsSuccessfulPairs(t *testing.T) {
@@ -173,10 +184,18 @@ func TestIter_MapOk2_ForwardsFailures(t *testing.T) {
 		},
 	)
 
-	for r := range seq {
-		_, err := r.Get()
-		require.ErrorIs(err, injected)
-	}
+	values := slices.Collect(seq)
+	require.Equal(1, len(values))
+	_, err := values[0].Get()
+	require.ErrorIs(err, injected)
+}
+
+func TestIter_DropKeys_YieldsValuesWithoutKeys(t *testing.T) {
+	require := require.New(t)
+
+	seq := DropKeys(Enumerate([]string{"a", "b"}))
+
+	require.Equal([]string{"a", "b"}, slices.Collect(seq))
 }
 
 func TestIter_DropKeysOk2_YieldsValuesWithoutKeys(t *testing.T) {
@@ -197,10 +216,10 @@ func TestIter_DropKeysOk2_ForwardsFailures(t *testing.T) {
 		yield(result.Err[Pair[int, string]](injected))
 	})
 
-	for r := range seq {
-		_, err := r.Get()
-		require.ErrorIs(err, injected)
-	}
+	values := slices.Collect(seq)
+	require.Equal(1, len(values))
+	_, err := values[0].Get()
+	require.ErrorIs(err, injected)
 }
 
 func TestIter_Enumerate_PairsValuesWithTheirIndices(t *testing.T) {

--- a/go/common/result/result.go
+++ b/go/common/result/result.go
@@ -34,3 +34,12 @@ func Err[T any](err error) Result[T] {
 func (r Result[T]) Get() (T, error) {
 	return r.value, r.err
 }
+
+// Map applies a transformation function to the value contained in the Result,
+func Map[TIn, TOut any](r Result[TIn], f func(TIn) TOut) Result[TOut] {
+	value, err := r.Get()
+	if err != nil {
+		return Err[TOut](err)
+	}
+	return Ok(f(value))
+}

--- a/go/common/result/result_test.go
+++ b/go/common/result/result_test.go
@@ -31,3 +31,24 @@ func TestResult_Err_ProducesResultWithError(t *testing.T) {
 	require.ErrorIs(t, err, issue)
 	require.Zero(t, value)
 }
+
+func TestResult_Map_TransformsValueOnSuccess(t *testing.T) {
+	result := Ok[int](42)
+	mapped := Map(result, func(x int) string {
+		return fmt.Sprintf("Value: %d", x)
+	})
+	value, err := mapped.Get()
+	require.NoError(t, err)
+	require.Equal(t, "Value: 42", value)
+}
+
+func TestResult_Map_PreservesErrorOnFailure(t *testing.T) {
+	issue := fmt.Errorf("test error")
+	result := Err[int](issue)
+	mapped := Map(result, func(x int) string {
+		return fmt.Sprintf("Value: %d", x)
+	})
+	value, err := mapped.Get()
+	require.ErrorIs(t, err, issue)
+	require.Zero(t, value)
+}


### PR DESCRIPTION
This PR adds a couple of utility to the `iter_utils` module, in preparation for returning errors from the `KVFile::Iterate` function.

It adds the new type `ResultSeq[V]`, which is an iterator over a `Result[V]`, and a couple of ergonomic functions.
The key-value counterpart is `ResultSeq2[K,V]`, which is defined as an iterator over `Result[Pair[K,V]]`. This was preferred instead of using a `iter.Seq2` to allow both key and value into the result.

To iterate it, the user calls `Unwrap[2]`, which returns the underlying value iterator and a function to query for possible errors.
When the iterator stops, the user must call the error functions to check the iterator ending status
