### PR TITLE
Return Result from `KVFile::Iterate`

### DIFF
--- a/go/backend/kv_file/kv_cached_file.go
+++ b/go/backend/kv_file/kv_cached_file.go
@@ -13,12 +13,12 @@ package kv_file
 import (
 	"errors"
 	"fmt"
-	"iter"
 	"slices"
 	"sync"
 	"unsafe"
 
 	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
 )
 
 // maxPendingFlushes bounds the number of sealed buffers queued for the
@@ -205,7 +205,7 @@ func (c *KVCachedFile[K, V]) FileSize() (uint64, error) {
 }
 
 // Iterate returns an iterator over all stored key-value pairs.
-func (c *KVCachedFile[K, V]) Iterate() (iter.Seq2[K, V], error) {
+func (c *KVCachedFile[K, V]) Iterate() (iter_utils.ResultSeq2[K, V], error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/go/backend/kv_file/kv_cached_file_test.go
+++ b/go/backend/kv_file/kv_cached_file_test.go
@@ -13,12 +13,12 @@ package kv_file
 import (
 	"errors"
 	"fmt"
-	"iter"
 	"maps"
 	"testing"
 	"testing/synctest"
 
 	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
@@ -673,12 +673,13 @@ func TestKVCachedFile_Iterate_YieldsFileContents(t *testing.T) {
 	// No pending writes: draining is a no-op, Iterate delegates directly
 	// to the underlying file.
 	fileContents := map[K]V{0: "value0", 1: "value1", 2: "value2"}
-	mock.EXPECT().Iterate().Return(mockIterateSeq(fileContents), nil)
+	mock.EXPECT().Iterate().Return(iter_utils.OkSeq2(maps.All(fileContents)), nil)
 
 	seq, err := c.Iterate()
 	require.NoError(err)
 
-	got := maps.Collect(seq)
+	got, err := iter_utils.CollectOk2(seq)
+	require.NoError(err)
 	require.Equal(fileContents, got)
 }
 
@@ -697,15 +698,16 @@ func TestKVCachedFile_Iterate_FlushesDirtyEntriesBeforeIterating(t *testing.T) {
 			return nil
 		}),
 		mock.EXPECT().Flush().Return(nil),
-		mock.EXPECT().Iterate().DoAndReturn(func() (iter.Seq2[K, V], error) {
-			return mockIterateSeq(written), nil
+		mock.EXPECT().Iterate().DoAndReturn(func() (iter_utils.ResultSeq2[K, V], error) {
+			return iter_utils.OkSeq2(maps.All(written)), nil
 		}),
 	)
 
 	seq, err := c.Iterate()
 	require.NoError(err)
 
-	got := maps.Collect(seq)
+	got, err := iter_utils.CollectOk2(seq)
+	require.NoError(err)
 	require.Equal(map[K]V{1: "value-1", 2: "value-2", 3: "value-3"}, got)
 }
 

--- a/go/backend/kv_file/kv_file.go
+++ b/go/backend/kv_file/kv_file.go
@@ -12,9 +12,9 @@ package kv_file
 
 import (
 	"io"
-	"iter"
 
 	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
 )
 
 //go:generate mockgen -source kv_file.go -destination kv_file_mocks.go -package kv_file
@@ -42,7 +42,7 @@ type KVFile[K comparable, V any] interface {
 	FileSize() (uint64, error)
 
 	// Iterate returns an iterator over the key-value pairs in the file.
-	Iterate() (iter.Seq2[K, V], error)
+	Iterate() (iter_utils.ResultSeq2[K, V], error)
 
 	// Close closes the file and releases any resources associated with it.
 	Close() error

--- a/go/backend/kv_file/kv_file.go
+++ b/go/backend/kv_file/kv_file.go
@@ -41,7 +41,10 @@ type KVFile[K comparable, V any] interface {
 	// FileSize returns the size of the file in bytes.
 	FileSize() (uint64, error)
 
-	// Iterate returns an iterator over the key-value pairs in the file.
+	// Iterate returns an iterator over the key-value pairs in the file. A pair
+	// that cannot be read is yielded as an error element which ends the
+	// iteration, so consumers must inspect every element to tell a complete
+	// iteration from one cut short by a failure.
 	Iterate() (iter_utils.ResultSeq2[K, V], error)
 
 	// Close closes the file and releases any resources associated with it.

--- a/go/backend/kv_file/kv_file_mocks.go
+++ b/go/backend/kv_file/kv_file_mocks.go
@@ -10,10 +10,10 @@
 package kv_file
 
 import (
-	iter "iter"
 	reflect "reflect"
 
 	common "github.com/0xsoniclabs/carmen/go/common"
+	iter_utils "github.com/0xsoniclabs/carmen/go/common/iter_utils"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -115,10 +115,10 @@ func (mr *MockKVFileMockRecorder[K, V]) Has(key any) *gomock.Call {
 }
 
 // Iterate mocks base method.
-func (m *MockKVFile[K, V]) Iterate() (iter.Seq2[K, V], error) {
+func (m *MockKVFile[K, V]) Iterate() (iter_utils.ResultSeq2[K, V], error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Iterate")
-	ret0, _ := ret[0].(iter.Seq2[K, V])
+	ret0, _ := ret[0].(iter_utils.ResultSeq2[K, V])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -269,10 +269,10 @@ func (mr *MockKVFileWithMemoryFootprintMockRecorder[K, V]) Has(key any) *gomock.
 }
 
 // Iterate mocks base method.
-func (m *MockKVFileWithMemoryFootprint[K, V]) Iterate() (iter.Seq2[K, V], error) {
+func (m *MockKVFileWithMemoryFootprint[K, V]) Iterate() (iter_utils.ResultSeq2[K, V], error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Iterate")
-	ret0, _ := ret[0].(iter.Seq2[K, V])
+	ret0, _ := ret[0].(iter_utils.ResultSeq2[K, V])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/go/backend/kv_file/kv_file_test.go
+++ b/go/backend/kv_file/kv_file_test.go
@@ -12,13 +12,13 @@ package kv_file
 
 import (
 	"fmt"
-	"maps"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 
+	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -167,7 +167,9 @@ func TestKVFile_SetBatchAndIterate_YieldsAllWrittenEntries(t *testing.T) {
 
 		seq, err := file.Iterate()
 		require.NoError(err)
-		require.Equal(entries, maps.Collect(seq))
+		got, err := iter_utils.CollectOk2(seq)
+		require.NoError(err)
+		require.Equal(entries, got)
 	})
 }
 
@@ -319,9 +321,11 @@ func TestKVFile_ConcurrentReadsAndWritesAreSafe(t *testing.T) {
 			for range rounds / 100 {
 				seq, err := file.Iterate()
 				require.NoError(err)
-				for key, got := range seq {
+				pairs, seqErr := iter_utils.Unwrap2(seq)
+				for key, got := range pairs {
 					checkValue(key, got)
 				}
+				require.NoError(seqErr())
 			}
 		})
 		wg.Wait()
@@ -413,14 +417,16 @@ func TestKVFile_Iterate_YieldsCompleteValuesDuringConcurrentWrites(t *testing.T)
 
 		seq, err := file.Iterate()
 		require.NoError(err)
+		pairs, seqErr := iter_utils.Unwrap2(seq)
 		seen := map[K]bool{}
-		for key, value := range seq {
+		for key, value := range pairs {
 			// Overwritten keys may yield any version, but never a value
 			// belonging to another key or a torn record.
 			require.True(strings.HasPrefix(value, fmt.Sprintf("k%d-", key)),
 				"value %q does not belong to key %d", value, key)
 			seen[key] = true
 		}
+		require.NoError(seqErr())
 		close(stop)
 		wg.Wait()
 

--- a/go/backend/kv_file/offset_file.go
+++ b/go/backend/kv_file/offset_file.go
@@ -14,13 +14,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"iter"
 	"maps"
 	"os"
 	"sync"
 	"unsafe"
 
 	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
+	"github.com/0xsoniclabs/carmen/go/common/result"
 )
 
 // OffsetFile is a KVFile backed by a single append-only file with an in-memory
@@ -184,7 +185,8 @@ func (o *OffsetFile[K, V]) Has(key K) (bool, error) {
 	return exists, nil
 }
 
-func (o *OffsetFile[K, V]) Iterate() (iter.Seq2[K, V], error) {
+func (o *OffsetFile[K, V]) Iterate() (iter_utils.ResultSeq2[K, V], error) {
+	type keyValuePair = iter_utils.Pair[K, V]
 	o.mutex.Lock()
 	defer o.mutex.Unlock()
 
@@ -196,13 +198,14 @@ func (o *OffsetFile[K, V]) Iterate() (iter.Seq2[K, V], error) {
 	// terminates.
 	offsets := maps.Clone(o.offsets)
 	limit := o.fileSize
-	return func(yield func(K, V) bool) {
+	return func(yield func(result.Result[keyValuePair]) bool) {
 		for key, offset := range offsets {
 			_, value, err := readFromDiskAtOffset(o.file, offset, limit, o.readValueFn)
 			if err != nil {
+				yield(result.Err[keyValuePair](err))
 				return
 			}
-			if !yield(key, *value) {
+			if !yield(result.Ok(keyValuePair{Key: key, Value: *value})) {
 				return
 			}
 		}

--- a/go/backend/kv_file/offset_file_test.go
+++ b/go/backend/kv_file/offset_file_test.go
@@ -16,11 +16,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"maps"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -274,8 +274,9 @@ func TestOffsetFile_Iterate_ReturnsAllEntries(t *testing.T) {
 
 	seq, err := f.Iterate()
 	require.NoError(err)
-	all := maps.Collect(seq)
-	require.Equal(map[uint64]uint64{1: 11, 2: 22, 3: 33}, all)
+	res, err := iter_utils.CollectOk2(seq)
+	require.NoError(err)
+	require.Equal(map[uint64]uint64{1: 11, 2: 22, 3: 33}, res)
 }
 
 func TestOffsetFile_Iterate_ReturnsLatestValueAfterOverwrite(t *testing.T) {
@@ -287,11 +288,12 @@ func TestOffsetFile_Iterate_ReturnsLatestValueAfterOverwrite(t *testing.T) {
 
 	seq, err := f.Iterate()
 	require.NoError(err)
-	all := maps.Collect(seq)
-	require.Equal(map[uint64]uint64{1: 100}, all)
+	res, err := iter_utils.CollectOk2(seq)
+	require.NoError(err)
+	require.Equal(map[uint64]uint64{1: 100}, res)
 }
 
-func TestOffsetFile_Iterate_YieldsNothingAfterClose(t *testing.T) {
+func TestOffsetFile_Iterate_ReportsErrorAfterClose(t *testing.T) {
 	require := require.New(t)
 	f, _ := openTestOffsetFile(t)
 
@@ -301,11 +303,9 @@ func TestOffsetFile_Iterate_YieldsNothingAfterClose(t *testing.T) {
 	seq, err := f.Iterate()
 	require.NoError(err)
 
-	yielded := 0
-	for range seq {
-		yielded++
-	}
-	require.Equal(0, yielded)
+	entries, seqErr := iter_utils.CollectOk2(seq)
+	require.Empty(entries)
+	require.ErrorIs(seqErr, os.ErrClosed)
 }
 
 func TestOffsetFile_Size_CountsUniqueKeys(t *testing.T) {

--- a/go/backend/kv_file/ordered_file.go
+++ b/go/backend/kv_file/ordered_file.go
@@ -14,12 +14,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"iter"
 	"os"
 	"sync"
 	"unsafe"
 
 	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
+	"github.com/0xsoniclabs/carmen/go/common/result"
 )
 
 // OrderedFile is a KVFile that stores fixed-size values in a single file,
@@ -152,7 +153,8 @@ func (o *OrderedFile[V]) FileSize() (uint64, error) {
 
 // Iterate returns an iterator over all stored key-value pairs in ascending key
 // order. The set of keys visited is fixed when Iterate is called.
-func (o *OrderedFile[V]) Iterate() (iter.Seq2[uint64, V], error) {
+func (o *OrderedFile[V]) Iterate() (iter_utils.ResultSeq2[uint64, V], error) {
+	type keyValuePair = iter_utils.Pair[uint64, V]
 	o.mutex.Lock()
 	defer o.mutex.Unlock()
 
@@ -161,16 +163,17 @@ func (o *OrderedFile[V]) Iterate() (iter.Seq2[uint64, V], error) {
 		return nil, err
 	}
 
-	return func(yield func(uint64, V) bool) {
+	return func(yield func(result.Result[keyValuePair]) bool) {
 		for key := range size {
 			o.mutex.Lock()
 			value, err := o.readAtLocked(key)
 			o.mutex.Unlock()
 			if err != nil {
 				// Includes os.ErrClosed when the file is closed mid-iteration.
+				yield(result.Err[keyValuePair](err))
 				return
 			}
-			if !yield(key, value) {
+			if !yield(result.Ok(keyValuePair{Key: key, Value: value})) {
 				return
 			}
 		}

--- a/go/backend/kv_file/ordered_file_test.go
+++ b/go/backend/kv_file/ordered_file_test.go
@@ -16,12 +16,12 @@ import (
 	"fmt"
 	"io"
 	"iter"
-	"maps"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/0xsoniclabs/carmen/go/backend/utils"
+	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -300,8 +300,9 @@ func TestOrderedFile_Iterate_ReturnsAllStoredValuesIndexedByPosition(t *testing.
 	seq, err := f.Iterate()
 	require.NoError(err)
 
-	all := maps.Collect(seq)
-	require.Equal(map[uint64]uint64{0: 100, 1: 101, 2: 102}, all)
+	res, err := iter_utils.CollectOk2(seq)
+	require.NoError(err)
+	require.Equal(map[uint64]uint64{0: 100, 1: 101, 2: 102}, res)
 }
 
 func TestOrderedFile_Iterate_ReturnsEmptyIteratorForEmptyFile(t *testing.T) {
@@ -311,14 +312,12 @@ func TestOrderedFile_Iterate_ReturnsEmptyIteratorForEmptyFile(t *testing.T) {
 	seq, err := f.Iterate()
 	require.NoError(err)
 
-	count := 0
-	for range seq {
-		count++
-	}
-	require.Equal(0, count)
+	res, err := iter_utils.CollectOk2(seq)
+	require.NoError(err)
+	require.Empty(res)
 }
 
-func TestOrderedFile_Iterate_StopsOnReadError(t *testing.T) {
+func TestOrderedFile_Iterate_ReportsReadError(t *testing.T) {
 	require := require.New(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "err.dat")
@@ -334,19 +333,17 @@ func TestOrderedFile_Iterate_StopsOnReadError(t *testing.T) {
 	defer func() { require.NoError(f.Close()) }()
 
 	// The iterator is lazy, so Iterate itself does not read the file and
-	// therefore cannot surface the read error. Consuming the sequence
-	// terminates silently once the read fails.
+	// therefore cannot surface the read error. It is reported by the sequence
+	// instead, which aborts the iteration at the failing read.
 	seq, err := f.Iterate()
 	require.NoError(err)
 
-	yielded := 0
-	for range seq {
-		yielded++
-	}
-	require.Equal(0, yielded, "read errors must abort the iterator before yielding")
+	entries, seqErr := iter_utils.CollectOk2(seq)
+	require.Empty(entries, "read errors must abort the iterator before yielding")
+	require.ErrorIs(seqErr, injected)
 }
 
-func TestOrderedFile_Iterate_TerminatesWhenFileIsClosed(t *testing.T) {
+func TestOrderedFile_Iterate_ReportsErrorWhenFileIsClosed(t *testing.T) {
 	require := require.New(t)
 	f, _ := openTestOrderedFile(t)
 
@@ -357,18 +354,22 @@ func TestOrderedFile_Iterate_TerminatesWhenFileIsClosed(t *testing.T) {
 	seq, err := f.Iterate()
 	require.NoError(err)
 
-	next, _ := iter.Pull2(seq)
-	key, val, ok := next()
+	next, stop := iter.Pull(seq)
+	defer stop()
+	res, ok := next()
 	require.True(ok)
-	require.EqualValues(0, key)
-	require.EqualValues(1, val)
+	pair, err := res.Get()
+	require.NoError(err)
+	require.EqualValues(0, pair.Key)
+	require.EqualValues(1, pair.Value)
 
 	// Close the file before consuming the iterator.
 	require.NoError(f.Close())
 
-	// TODO: Check that the iterator terminated because the file was closed, not because it reached the end of the file.
-	_, _, ok = next()
-	require.False(ok)
+	res, ok = next()
+	require.True(ok)
+	_, err = res.Get()
+	require.ErrorIs(err, os.ErrClosed)
 }
 
 func TestOrderedFile_Iterate_HandlesChunkedReader(t *testing.T) {
@@ -409,7 +410,8 @@ func TestOrderedFile_Iterate_HandlesChunkedReader(t *testing.T) {
 			seq, err := f.Iterate()
 			require.NoError(err)
 
-			all := maps.Collect(seq)
+			all, err := iter_utils.CollectOk2(seq)
+			require.NoError(err)
 			require.Len(all, len(values))
 			for i, v := range values {
 				require.EqualValues(v, all[uint64(i)], "position %d", i)

--- a/go/backend/kv_file/utils_test.go
+++ b/go/backend/kv_file/utils_test.go
@@ -14,13 +14,13 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"iter"
 	"maps"
 	"sync"
 	"testing"
 	"testing/synctest"
 
 	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
@@ -100,26 +100,14 @@ func (f *fakeKVFile) Flush() error { return nil }
 
 func (f *fakeKVFile) FileSize() (uint64, error) { return 0, nil }
 
-func (f *fakeKVFile) Iterate() (iter.Seq2[K, V], error) {
-	return mockIterateSeq(maps.Clone(f.data)), nil
+func (f *fakeKVFile) Iterate() (iter_utils.ResultSeq2[K, V], error) {
+	return iter_utils.OkSeq2(maps.All(maps.Clone(f.data))), nil
 }
 
 func (f *fakeKVFile) Close() error { return nil }
 
 func (f *fakeKVFile) GetMemoryFootprint() *common.MemoryFootprint {
 	return common.NewMemoryFootprint(0)
-}
-
-// mockIterateSeq returns an iter.Seq2 mock return value that yields the
-// key/value pairs from the given map.
-func mockIterateSeq(entries map[K]V) iter.Seq2[K, V] {
-	return func(yield func(K, V) bool) {
-		for k, v := range entries {
-			if !yield(k, v) {
-				return
-			}
-		}
-	}
 }
 
 func getCacheSize[K comparable, V any](cache *common.LruCache[K, V]) int {

--- a/go/common/iter_utils/iter.go
+++ b/go/common/iter_utils/iter.go
@@ -12,6 +12,7 @@ package iter_utils
 
 import (
 	"iter"
+	"maps"
 	"slices"
 
 	"github.com/0xsoniclabs/carmen/go/common/result"
@@ -144,17 +145,24 @@ func MapOk2[KIn, VIn, KOut, VOut any](
 		key, value := f(in.Unpack())
 		return Pair[KOut, VOut]{Key: key, Value: value}
 	})
-
 }
 
-func DropKeys[K, V any](seq iter.Seq2[K, V]) iter.Seq[V] {
-	return func(yield func(V) bool) {
-		for _, v := range seq {
-			if !yield(v) {
-				return
-			}
-		}
-	}
+// CollectOk collects the successful values of a `ResultSeq` into a slice.
+// If the sequence reports a failure, it is returned alongside the values
+// collected before the failure.
+func CollectOk[V any](seq ResultSeq[V]) ([]V, error) {
+	pairs, seqErr := Unwrap(seq)
+	entries := slices.Collect(pairs)
+	return entries, seqErr()
+}
+
+// CollectOk2 collects the successful key-value pairs of a `ResultSeq2` into a map.
+// If the sequence reports a failure, it is returned alongside the pairs
+// collected before the failure.
+func CollectOk2[K comparable, V any](seq ResultSeq2[K, V]) (map[K]V, error) {
+	pairs, seqErr := Unwrap2(seq)
+	entries := maps.Collect(pairs)
+	return entries, seqErr()
 }
 
 // DropKeysOk2 drops the keys of a `ResultSeq2`, yielding a `ResultSeq` of the values.

--- a/go/common/iter_utils/iter_test.go
+++ b/go/common/iter_utils/iter_test.go
@@ -190,12 +190,64 @@ func TestIter_MapOk2_ForwardsFailures(t *testing.T) {
 	require.ErrorIs(err, injected)
 }
 
-func TestIter_DropKeys_YieldsValuesWithoutKeys(t *testing.T) {
+func TestIter_CollectOk_YieldsAllValuesWithoutError(t *testing.T) {
+	require := require.New(t)
+	data := []string{"a", "b"}
+
+	seq := OkSeq(slices.Values(data))
+
+	values, seqErr := CollectOk(seq)
+	require.Equal(data, values)
+	require.NoError(seqErr)
+}
+
+func TestIter_CollectOk_StopsAtFirstFailureAndReportsIt(t *testing.T) {
 	require := require.New(t)
 
-	seq := DropKeys(Enumerate([]string{"a", "b"}))
+	injected := fmt.Errorf("injected failure")
+	seq := func(yield func(result.Result[string]) bool) {
+		if !yield(result.Ok("one")) {
+			return
+		}
+		if !yield(result.Err[string](injected)) {
+			return
+		}
+		yield(result.Ok("three"))
+	}
 
-	require.Equal([]string{"a", "b"}, slices.Collect(seq))
+	values, seqErr := CollectOk(seq)
+	require.Equal([]string{"one"}, values)
+	require.ErrorIs(seqErr, injected)
+}
+
+func TestIter_CollectOk2_YieldsAllPairsWithoutError(t *testing.T) {
+	require := require.New(t)
+	data := map[uint64]string{0: "a", 1: "b"}
+
+	seq := OkSeq2(maps.All(data))
+
+	pairs, seqErr := CollectOk2(seq)
+	require.Equal(data, pairs)
+	require.NoError(seqErr)
+}
+
+func TestIter_CollectOk2_StopsAtFirstFailureAndReportsIt(t *testing.T) {
+	require := require.New(t)
+
+	injected := fmt.Errorf("injected failure")
+	seq := func(yield func(result.Result[Pair[int, string]]) bool) {
+		if !yield(result.Ok(Pair[int, string]{Key: 1, Value: "one"})) {
+			return
+		}
+		if !yield(result.Err[Pair[int, string]](injected)) {
+			return
+		}
+		yield(result.Ok(Pair[int, string]{Key: 3, Value: "three"}))
+	}
+
+	pairs, seqErr := CollectOk2(seq)
+	require.Equal(map[int]string{1: "one"}, pairs)
+	require.ErrorIs(seqErr, injected)
 }
 
 func TestIter_DropKeysOk2_YieldsValuesWithoutKeys(t *testing.T) {

--- a/go/database/mpt/archive_trie.go
+++ b/go/database/mpt/archive_trie.go
@@ -328,7 +328,7 @@ func (a *ArchiveTrie) GetCodeForHash(hash common.Hash) ([]byte, error) {
 	return a.head.GetCodeForHash(hash)
 }
 
-func (a *ArchiveTrie) GetCodes() (iter.Seq2[common.Hash, []byte], error) {
+func (a *ArchiveTrie) GetCodes() (iter_utils.ResultSeq2[common.Hash, []byte], error) {
 	return a.head.GetCodes()
 }
 
@@ -467,9 +467,10 @@ func (a *ArchiveTrie) Check() error {
 	}
 	return errors.Join(
 		a.CheckErrors(),
-		a.forest.CheckAll(iter_utils.Map(iter_utils.DropKeys(it), func(v Root) *NodeReference {
+		a.forest.CheckAll(iter_utils.MapOk(iter_utils.DropKeysOk2(it), func(v Root) *NodeReference {
 			return &v.NodeRef
-		})),
+		}),
+		),
 	)
 }
 
@@ -793,7 +794,7 @@ func writeRoot(writer io.Writer, pos uint64, root Root) error {
 }
 
 // Iterate returns a sequence of all (block, root) pairs in the list.
-func (l *rootList) Iterate() (iter.Seq2[uint64, Root], error) {
+func (l *rootList) Iterate() (iter_utils.ResultSeq2[uint64, Root], error) {
 	return l.roots.Iterate()
 }
 

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"iter"
 	"maps"
 	"math/rand"
 	"os"
@@ -35,6 +34,7 @@ import (
 	"github.com/0xsoniclabs/carmen/go/backend/utils/checkpoint"
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/common/amount"
+	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
 	"github.com/0xsoniclabs/carmen/go/database/mpt/shared"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -1272,11 +1272,6 @@ func TestArchiveTrie_GettingView_Block_OutOfRange(t *testing.T) {
 }
 
 func TestArchiveTrie_GetCodes(t *testing.T) {
-	collect := func(it iter.Seq2[common.Hash, []byte]) map[common.Hash][]byte {
-		codes := maps.Collect(it)
-		return codes
-	}
-
 	for _, config := range allMptConfigs {
 		t.Run(config.Name, func(t *testing.T) {
 			require := require.New(t)
@@ -1289,7 +1284,8 @@ func TestArchiveTrie_GetCodes(t *testing.T) {
 
 			codesIterator, err := archive.GetCodes()
 			require.NoError(err)
-			codes := collect(codesIterator)
+			codes, err := iter_utils.CollectOk2(codesIterator)
+			require.NoError(err)
 			if len(codes) != 0 {
 				t.Errorf("unexpected number of codes in archive, expected 0, got %d", len(codes))
 			}
@@ -1311,7 +1307,8 @@ func TestArchiveTrie_GetCodes(t *testing.T) {
 			if err != nil {
 				t.Fatalf("cannot get codes: %v", err)
 			}
-			codes = collect(codesIterator)
+			codes, err = iter_utils.CollectOk2(codesIterator)
+			require.NoError(err)
 			if len(codes) != 2 {
 				t.Errorf("unexpected number of codes in archive, wanted 2, got %d", len(codes))
 			}
@@ -2103,7 +2100,8 @@ func TestRootList_Iterate_YieldsAllAppendedRoots(t *testing.T) {
 	seq, err := list.Iterate()
 	require.NoError(err)
 
-	got := maps.Collect(seq)
+	got, err := iter_utils.CollectOk2(seq)
+	require.NoError(err)
 	require.Len(got, len(want))
 	for i, r := range want {
 		require.Equal(r, got[uint64(i)])
@@ -2119,11 +2117,9 @@ func TestRootList_Iterate_EmptyListYieldsNothing(t *testing.T) {
 	seq, err := list.Iterate()
 	require.NoError(err)
 
-	count := 0
-	for range seq {
-		count++
-	}
-	require.Zero(count)
+	roots, err := iter_utils.CollectOk2(seq)
+	require.NoError(err)
+	require.Empty(roots)
 }
 
 func TestRootList_Iterate_CanBeInvokedMultipleTimes(t *testing.T) {
@@ -2143,8 +2139,9 @@ func TestRootList_Iterate_CanBeInvokedMultipleTimes(t *testing.T) {
 	seq, err := list.Iterate()
 	require.NoError(err)
 
-	for pass := range 2 {
-		got := maps.Collect(seq)
+	for pass := 0; pass < 2; pass++ {
+		got, rootsErr := iter_utils.CollectOk2(seq)
+		require.NoError(rootsErr, "pass %d", pass)
 		require.Len(got, len(want), "pass %d", pass)
 		for i, r := range want {
 			require.Equal(r, got[uint64(i)], "pass %d", pass)
@@ -3819,14 +3816,15 @@ func collectRoots(l *rootList) ([]Root, error) {
 	if err != nil {
 		return nil, err
 	}
+	roots, rootsErr := iter_utils.Unwrap2(seq)
 	out := make([]Root, l.length())
-	for i, r := range seq {
+	for i, r := range roots {
 		if i >= uint64(len(out)) {
 			continue
 		}
 		out[i] = r
 	}
-	return out, nil
+	return out, rootsErr()
 }
 
 func BenchmarkArchiveFlush_Roots(b *testing.B) {

--- a/go/database/mpt/codes.go
+++ b/go/database/mpt/codes.go
@@ -16,8 +16,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"iter"
-	"maps"
 	"os"
 	"path/filepath"
 	"unsafe"
@@ -26,6 +24,7 @@ import (
 	"github.com/0xsoniclabs/carmen/go/backend/utils"
 	"github.com/0xsoniclabs/carmen/go/backend/utils/checkpoint"
 	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -111,7 +110,7 @@ func (c *codes) getCodeForHash(hash common.Hash) ([]byte, error) {
 	return *code, nil
 }
 
-func (c *codes) getCodes() (iter.Seq2[common.Hash, []byte], error) {
+func (c *codes) getCodes() (iter_utils.ResultSeq2[common.Hash, []byte], error) {
 	return c.codes.Iterate()
 }
 
@@ -122,7 +121,7 @@ func (c *codes) getCodesForTesting() (map[common.Hash][]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return maps.Collect(it), nil
+	return iter_utils.CollectOk2(it)
 }
 
 func (c *codes) Flush() error {
@@ -252,8 +251,7 @@ func readCodesForTesting(path string) (codes map[common.Hash][]byte, err error) 
 	if err != nil {
 		return nil, err
 	}
-	codes = maps.Collect(seq)
-	return codes, nil
+	return iter_utils.CollectOk2(seq)
 }
 
 // writeCodesForTesting writes the given map of codes to the given file.

--- a/go/database/mpt/codes_test.go
+++ b/go/database/mpt/codes_test.go
@@ -13,7 +13,6 @@ package mpt
 import (
 	"bytes"
 	"errors"
-	"maps"
 	"os"
 	"path/filepath"
 	"testing"
@@ -21,6 +20,7 @@ import (
 	"github.com/0xsoniclabs/carmen/go/backend/kv_file"
 	"github.com/0xsoniclabs/carmen/go/backend/utils/checkpoint"
 	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/crypto/sha3"
@@ -293,7 +293,8 @@ func TestCodes_getCodes_ReturnsAllCodes(t *testing.T) {
 
 	it, err := codes.getCodes()
 	require.NoError(err)
-	got := maps.Collect(it)
+	got, itErr := iter_utils.CollectOk2(it)
+	require.NoError(itErr)
 
 	if want, got := 2, len(got); want != got {
 		t.Fatalf("expected %d codes, got %d", want, got)
@@ -325,7 +326,7 @@ func TestCodes_getCodes_ReturnsErrorOnIterateError(t *testing.T) {
 	require.Nil(got)
 }
 
-func TestCodes_getCodes_IteratorTerminatesGracefullyOnClose(t *testing.T) {
+func TestCodes_getCodes_IteratorReportsErrorOnClose(t *testing.T) {
 	require := require.New(t)
 	codes, err := openCodes(t.TempDir())
 	require.NoError(err)
@@ -342,9 +343,10 @@ func TestCodes_getCodes_IteratorTerminatesGracefullyOnClose(t *testing.T) {
 
 	// After the store has been closed, iterating the previously obtained
 	// sequence must not panic; it may yield fewer entries than the store
-	// contained but must terminate gracefully.
-	for range it {
-	}
+	// contained, but the close must be reported instead of silently
+	// truncating the iteration.
+	_, itErr := iter_utils.CollectOk2(it)
+	require.ErrorIs(itErr, os.ErrClosed)
 }
 
 func TestCodes_GetMemoryFootprint_ReturnsProperSize(t *testing.T) {

--- a/go/database/mpt/forest.go
+++ b/go/database/mpt/forest.go
@@ -15,7 +15,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"iter"
 	"log"
 	"os"
 	"path/filepath"
@@ -30,6 +29,7 @@ import (
 	"github.com/0xsoniclabs/carmen/go/backend/stock/memory"
 	"github.com/0xsoniclabs/carmen/go/backend/stock/synced"
 	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
 	"github.com/0xsoniclabs/carmen/go/database/mpt/shared"
 )
 
@@ -674,12 +674,13 @@ func (s *Forest) Dump(rootRef *NodeReference) {
 // errors are detected, the Trie is to be considered in an invalid state and
 // the behavior of all other operations is undefined.
 func (s *Forest) Check(rootRef *NodeReference) error {
-	return s.CheckAll(slices.Values([]*NodeReference{rootRef}))
+	return s.CheckAll(iter_utils.OkSeq(slices.Values(
+		[]*NodeReference{rootRef})))
 }
 
 // CheckAll verifies internal invariants of a set of Trie instances rooted by
 // the given nodes. It is a generalization of the Check() function.
-func (s *Forest) CheckAll(rootRefs iter.Seq[*NodeReference]) error {
+func (s *Forest) CheckAll(rootRefs iter_utils.ResultSeq[*NodeReference]) error {
 	return CheckForest(s, rootRefs)
 }
 

--- a/go/database/mpt/io/codes.go
+++ b/go/database/mpt/io/codes.go
@@ -15,16 +15,16 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"iter"
 	"os"
 
 	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
 	"github.com/cockroachdb/pebble"
 )
 
 // writeCodes serialises all codes yielded by the iterator to out, ordered by
 // hash.
-func writeCodes(codes iter.Seq2[common.Hash, []byte], out io.Writer, scratchDir string) (retErr error) {
+func writeCodes(codes iter_utils.ResultSeq2[common.Hash, []byte], out io.Writer, scratchDir string) (retErr error) {
 	store, err := newCodeSortStore(scratchDir)
 	if err != nil {
 		return err
@@ -33,10 +33,14 @@ func writeCodes(codes iter.Seq2[common.Hash, []byte], out io.Writer, scratchDir 
 		retErr = errors.Join(retErr, store.close())
 	}()
 
-	for hash, code := range codes {
+	seq, seqErr := iter_utils.Unwrap2(codes)
+	for hash, code := range seq {
 		if err := store.add(hash, code); err != nil {
 			return err
 		}
+	}
+	if err := seqErr(); err != nil {
+		return err
 	}
 	return store.writeTo(out)
 }

--- a/go/database/mpt/io/codes_test.go
+++ b/go/database/mpt/io/codes_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,7 +37,7 @@ func TestWriteCodes_WritesCodesOrderedByHash(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	require.NoError(writeCodes(maps.All(codes), &buf, t.TempDir()))
+	require.NoError(writeCodes(iter_utils.OkSeq2(maps.All(codes)), &buf, t.TempDir()))
 
 	// Output must be ordered by hash regardless of iteration order.
 	want := [][]byte{
@@ -64,7 +65,7 @@ func TestWriteCodes_WritesNothingForEmptyIterator(t *testing.T) {
 	require := require.New(t)
 
 	var buf bytes.Buffer
-	require.NoError(writeCodes(maps.All(map[common.Hash][]byte{}), &buf, t.TempDir()))
+	require.NoError(writeCodes(iter_utils.OkSeq2(maps.All(map[common.Hash][]byte{})), &buf, t.TempDir()))
 	require.Zero(buf.Len())
 }
 
@@ -84,7 +85,7 @@ func TestWriteCodes_PropagatesWriteError(t *testing.T) {
 			w := &failingWriter{failAfter: test.failAfter, err: injected}
 			codes := map[common.Hash][]byte{{1}: {1, 2, 3}}
 
-			err := writeCodes(maps.All(codes), w, t.TempDir())
+			err := writeCodes(iter_utils.OkSeq2(maps.All(codes)), w, t.TempDir())
 			require.ErrorContains(err, injected.Error())
 		})
 	}
@@ -114,7 +115,7 @@ func TestWriteCodes_RemovesStagingStore(t *testing.T) {
 			}
 
 			codes := map[common.Hash][]byte{{1}: {1, 2, 3}}
-			_ = writeCodes(maps.All(codes), test.out, scratchDir)
+			_ = writeCodes(iter_utils.OkSeq2(maps.All(codes)), test.out, scratchDir)
 
 			entries, err := os.ReadDir(tempRoot)
 			require.NoError(err)
@@ -130,7 +131,7 @@ func TestReadCode_ReturnsCodeWrittenByWriteCodes(t *testing.T) {
 	codes := map[common.Hash][]byte{{1}: want}
 
 	var buf bytes.Buffer
-	require.NoError(writeCodes(maps.All(codes), &buf, t.TempDir()))
+	require.NoError(writeCodes(iter_utils.OkSeq2(maps.All(codes)), &buf, t.TempDir()))
 
 	tag, err := buf.ReadByte()
 	require.NoError(err)

--- a/go/database/mpt/io/codes_test.go
+++ b/go/database/mpt/io/codes_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
+	"github.com/0xsoniclabs/carmen/go/common/result"
 	"github.com/stretchr/testify/require"
 )
 
@@ -261,4 +262,23 @@ func (w *failingWriter) Write(p []byte) (int, error) {
 	}
 	w.calls++
 	return len(p), nil
+}
+
+func TestWriteCodes_ReportsIteratorFailureWithoutWritingArchive(t *testing.T) {
+	require := require.New(t)
+
+	code := []byte{1, 2, 3}
+	injected := errors.New("injected failure")
+	codes := func(yield func(result.Result[iter_utils.Pair[common.Hash, []byte]]) bool) {
+		if !yield(result.Ok(iter_utils.Pair[common.Hash, []byte]{Key: common.Keccak256(code), Value: code})) {
+			return
+		}
+		yield(result.Err[iter_utils.Pair[common.Hash, []byte]](injected))
+	}
+
+	var buf bytes.Buffer
+	err := writeCodes(codes, &buf, t.TempDir())
+
+	require.ErrorIs(err, injected)
+	require.Empty(buf.Bytes(), "a failed iteration must not write a partial archive")
 }

--- a/go/database/mpt/io/live_test.go
+++ b/go/database/mpt/io/live_test.go
@@ -15,13 +15,13 @@ import (
 	"context"
 	"errors"
 	"io"
-	"iter"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/common/amount"
+	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
 	"github.com/0xsoniclabs/carmen/go/database/mpt"
 	"github.com/0xsoniclabs/carmen/go/state"
 	"github.com/stretchr/testify/require"
@@ -131,7 +131,7 @@ func TestIO_ExportedDataDoesNotContainExtraCodes(t *testing.T) {
 		require.NoError(t, s.SetCode(addr1, code))
 		codesAfter, err := s.GetCodes()
 		require.NoError(t, err)
-		if before, after := countCodes(codesBefore), countCodes(codesAfter); before+1 != after {
+		if before, after := countCodes(t, codesBefore), countCodes(t, codesAfter); before+1 != after {
 			t.Fatalf("modification did not had expected code-altering effect: %d -> %d", before, after)
 		}
 	})
@@ -204,12 +204,11 @@ func readAllCodes(t *testing.T, r io.Reader) [][]byte {
 }
 
 // countCodes drains a codes iterator returning the number of entries.
-func countCodes(codes iter.Seq2[common.Hash, []byte]) int {
-	n := 0
-	for range codes {
-		n++
-	}
-	return n
+func countCodes(t *testing.T, codes iter_utils.ResultSeq2[common.Hash, []byte]) int {
+	t.Helper()
+	entries, err := iter_utils.CollectOk2(codes)
+	require.NoError(t, err)
+	return len(entries)
 }
 
 func exportExampleState(t *testing.T) ([]byte, common.Hash) {

--- a/go/database/mpt/live_trie.go
+++ b/go/database/mpt/live_trie.go
@@ -20,6 +20,7 @@ import (
 	"unsafe"
 
 	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
 	"github.com/0xsoniclabs/carmen/go/common/witness"
 )
 
@@ -86,10 +87,11 @@ func VerifyFileLiveTrie(ctx context.Context, directory string, config MptConfig,
 	if !exists {
 		return nil
 	}
-	return verifyFileForest(ctx, directory, config, rootsFromSlice([]Root{{
-		NewNodeReference(metadata.RootNode),
-		metadata.RootHash,
-	}}), observer)
+	roots := iter_utils.OkSeq2(iter_utils.Enumerate([]Root{{
+		NodeRef: NewNodeReference(metadata.RootNode),
+		Hash:    metadata.RootHash,
+	}}))
+	return verifyFileForest(ctx, directory, config, roots, observer)
 }
 
 func makeTrie(

--- a/go/database/mpt/nodes.go
+++ b/go/database/mpt/nodes.go
@@ -17,10 +17,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"iter"
 	"slices"
 
 	"github.com/0xsoniclabs/carmen/go/common"
+	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
 	"github.com/0xsoniclabs/carmen/go/common/tribool"
 	"github.com/0xsoniclabs/carmen/go/database/mpt/shared"
 )
@@ -484,19 +484,23 @@ func visitPathTo(
 // nodes. A reuse is only valid if the node's position within the respective
 // tries is compatible -- thus, the node is reachable through the same
 // navigation path.
-func CheckForest(source NodeSource, roots iter.Seq[*NodeReference]) error {
+func CheckForest(source NodeSource, roots iter_utils.ResultSeq[*NodeReference]) error {
 	// The check algorithm is based on an iterative depth-first traversal
 	// where information on encountered nodes is cached to avoid multiple
 	// evaluations.
 	workList := []NodeId{}
 	contexts := map[NodeId]nodeCheckContext{}
-	for ref := range roots {
+	rootRefs, rootsErr := iter_utils.Unwrap(roots)
+	for ref := range rootRefs {
 		workList = append(workList, ref.Id())
 		contexts[ref.Id()] = nodeCheckContext{
 			root:           ref.Id(),
 			hasSeenAccount: false,
 			path:           nil,
 		}
+	}
+	if err := rootsErr(); err != nil {
+		return err
 	}
 
 	// scheduleNode verifies that the given node is reached consistently

--- a/go/database/mpt/nodes_test.go
+++ b/go/database/mpt/nodes_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
+	"github.com/0xsoniclabs/carmen/go/common/result"
 	"github.com/0xsoniclabs/carmen/go/common/tribool"
 
 	"github.com/0xsoniclabs/carmen/go/common"
@@ -4534,6 +4535,24 @@ func TestCheckForest_DetectsIssuesInTrees(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCheckForest_ReportsRootIteratorFailure(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	ctxt := newNodeContext(t, ctrl)
+
+	ref, _ := ctxt.Build(&Account{address: common.Address{0x12}, info: AccountInfo{Nonce: common.Nonce{1}}})
+
+	injected := errors.New("injected failure")
+	roots := func(yield func(result.Result[*NodeReference]) bool) {
+		if !yield(result.Ok(&ref)) {
+			return
+		}
+		yield(result.Err[*NodeReference](injected))
+	}
+
+	require.ErrorIs(CheckForest(ctxt, roots), injected)
 }
 
 func TestCheckForest_AcceptsValidReUse(t *testing.T) {

--- a/go/database/mpt/nodes_test.go
+++ b/go/database/mpt/nodes_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
 	"github.com/0xsoniclabs/carmen/go/common/tribool"
 
 	"github.com/0xsoniclabs/carmen/go/common"
@@ -4488,6 +4489,12 @@ func TestValueNode_CheckDetectsIssues(t *testing.T) {
 //                             CheckForest
 // ----------------------------------------------------------------------------
 
+// refsFromSlice adapts node references to the iterator type expected by CheckForest.
+// It yields the provided references in the given order.
+func refsFromSlice(refs ...*NodeReference) iter_utils.ResultSeq[*NodeReference] {
+	return iter_utils.OkSeq(slices.Values(refs))
+}
+
 func TestCheckForest_DetectsIssuesInTrees(t *testing.T) {
 	tests := map[string]struct {
 		tree NodeDesc
@@ -4518,7 +4525,7 @@ func TestCheckForest_DetectsIssuesInTrees(t *testing.T) {
 			ctxt := newNodeContext(t, ctrl)
 			ref, _ := ctxt.Build(test.tree)
 
-			err := CheckForest(ctxt, slices.Values([]*NodeReference{&ref}))
+			err := CheckForest(ctxt, refsFromSlice(&ref))
 			if test.ok && err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -4555,7 +4562,7 @@ func TestCheckForest_AcceptsValidReUse(t *testing.T) {
 	handle.Get().(*BranchNode).children[4] = refMock
 	handle.Release()
 
-	if err := CheckForest(ctxt, slices.Values([]*NodeReference{&ref1, &ref2})); err != nil {
+	if err := CheckForest(ctxt, refsFromSlice(&ref1, &ref2)); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
@@ -4571,7 +4578,7 @@ func TestCheckForest_DetectsInvalidReUse(t *testing.T) {
 
 	ref2, _ := ctxt.Get("A")
 
-	err := CheckForest(ctxt, slices.Values([]*NodeReference{&ref1, &ref2}))
+	err := CheckForest(ctxt, refsFromSlice(&ref1, &ref2))
 	if err == nil || !strings.Contains(err.Error(), "invalid reuse") {
 		t.Errorf("expected an invalid reuse error but got: %v", err)
 	}
@@ -4993,7 +5000,7 @@ func (t *trie) Check() error {
 }
 
 func (t *trie) CheckForest() error {
-	return CheckForest(t.manager, slices.Values([]*NodeReference{&t.root}))
+	return CheckForest(t.manager, refsFromSlice(&t.root))
 }
 
 func (t *trie) Dump() error {
@@ -8297,7 +8304,7 @@ func (c *nodeContext) nextIndex() uint64 {
 
 func (c *nodeContext) Check(t *testing.T, ref NodeReference) {
 	t.Helper()
-	if err := CheckForest(c, slices.Values([]*NodeReference{&ref})); err != nil {
+	if err := CheckForest(c, refsFromSlice(&ref)); err != nil {
 		handle := c.tryGetNode(t, ref.Id())
 		defer handle.Release()
 		out := &bytes.Buffer{}

--- a/go/database/mpt/state.go
+++ b/go/database/mpt/state.go
@@ -13,10 +13,10 @@ package mpt
 import (
 	"errors"
 	"fmt"
-	"iter"
 	"unsafe"
 
 	"github.com/0xsoniclabs/carmen/go/common/amount"
+	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
 	"github.com/0xsoniclabs/carmen/go/database/mpt/shared"
 	"github.com/0xsoniclabs/carmen/go/state"
 
@@ -80,7 +80,7 @@ type Database interface {
 
 	// CheckAll verifies internal invariants of a set of Trie instances rooted by
 	// the given nodes. It is a generalization of the Check() function.
-	CheckAll(rootRefs iter.Seq[*NodeReference]) error
+	CheckAll(rootRefs iter_utils.ResultSeq[*NodeReference]) error
 
 	// CheckErrors returns an error that might have been
 	// encountered on this forest in the past.
@@ -112,7 +112,7 @@ type LiveState interface {
 	GetCodeForHash(hash common.Hash) ([]byte, error)
 
 	// GetCodes retrieves all codes and their hashes.
-	GetCodes() (iter.Seq2[common.Hash, []byte], error)
+	GetCodes() (iter_utils.ResultSeq2[common.Hash, []byte], error)
 
 	// UpdateHashes recomputes hash root of this trie.
 	UpdateHashes() (common.Hash, *NodeHashes, error)
@@ -331,7 +331,7 @@ func (s *MptState) Visit(mode AccessMode, visitor NodeVisitor) error {
 	return s.trie.VisitTrie(mode, visitor)
 }
 
-func (s *MptState) GetCodes() (iter.Seq2[common.Hash, []byte], error) {
+func (s *MptState) GetCodes() (iter_utils.ResultSeq2[common.Hash, []byte], error) {
 	return s.codes.getCodes()
 }
 

--- a/go/database/mpt/state_mocks.go
+++ b/go/database/mpt/state_mocks.go
@@ -10,11 +10,11 @@
 package mpt
 
 import (
-	iter "iter"
 	reflect "reflect"
 
 	common "github.com/0xsoniclabs/carmen/go/common"
 	amount "github.com/0xsoniclabs/carmen/go/common/amount"
+	iter_utils "github.com/0xsoniclabs/carmen/go/common/iter_utils"
 	shared "github.com/0xsoniclabs/carmen/go/database/mpt/shared"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -58,7 +58,7 @@ func (mr *MockDatabaseMockRecorder) Check(rootRef any) *gomock.Call {
 }
 
 // CheckAll mocks base method.
-func (m *MockDatabase) CheckAll(rootRefs iter.Seq[*NodeReference]) error {
+func (m *MockDatabase) CheckAll(rootRefs iter_utils.ResultSeq[*NodeReference]) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckAll", rootRefs)
 	ret0, _ := ret[0].(error)
@@ -638,10 +638,10 @@ func (mr *MockLiveStateMockRecorder) GetCodeSize(address any) *gomock.Call {
 }
 
 // GetCodes mocks base method.
-func (m *MockLiveState) GetCodes() (iter.Seq2[common.Hash, []byte], error) {
+func (m *MockLiveState) GetCodes() (iter_utils.ResultSeq2[common.Hash, []byte], error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCodes")
-	ret0, _ := ret[0].(iter.Seq2[common.Hash, []byte])
+	ret0, _ := ret[0].(iter_utils.ResultSeq2[common.Hash, []byte])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/go/database/mpt/verification.go
+++ b/go/database/mpt/verification.go
@@ -16,13 +16,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"iter"
 	"slices"
 
 	"github.com/0xsoniclabs/carmen/go/backend/stock"
 	"github.com/0xsoniclabs/carmen/go/backend/stock/file"
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/common/interrupt"
+	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
 	"github.com/0xsoniclabs/carmen/go/database/mpt/shared"
 	"github.com/pbnjay/memory"
 )
@@ -44,18 +44,6 @@ func (NilVerificationObserver) StartVerification()        {}
 func (NilVerificationObserver) Progress(msg string)       {}
 func (NilVerificationObserver) EndVerification(res error) {}
 
-// rootsFromSlice adapts a slice of roots to the iterator type expected by
-// the verification API.
-func rootsFromSlice(roots []Root) iter.Seq2[uint64, Root] {
-	return func(yield func(uint64, Root) bool) {
-		for i, r := range roots {
-			if !yield(uint64(i), r) {
-				return
-			}
-		}
-	}
-}
-
 // VerifyMptState runs validation checks on the forest and code hashes
 // stored in the given directory.
 // Forest checks:
@@ -69,7 +57,7 @@ func rootsFromSlice(roots []Root) iter.Seq2[uint64, Root] {
 //     - all byte-codes within the code file matches their hashed representation in accounts
 //  2. Non-fatal checks
 //     - there are no extra Code Hashes not referenced by any account
-func VerifyMptState(ctx context.Context, directory string, config MptConfig, roots iter.Seq2[uint64, Root], observer VerificationObserver) (res error) {
+func VerifyMptState(ctx context.Context, directory string, config MptConfig, roots iter_utils.ResultSeq2[uint64, Root], observer VerificationObserver) (res error) {
 	if observer == nil {
 		observer = NilVerificationObserver{}
 	}
@@ -105,7 +93,7 @@ func VerifyMptState(ctx context.Context, directory string, config MptConfig, roo
 //   - all required files are present and can be read
 //   - all referenced nodes are present
 //   - all hashes are consistent
-func verifyFileForest(ctx context.Context, directory string, config MptConfig, roots iter.Seq2[uint64, Root], observer VerificationObserver) (res error) {
+func verifyFileForest(ctx context.Context, directory string, config MptConfig, roots iter_utils.ResultSeq2[uint64, Root], observer VerificationObserver) (res error) {
 	if observer == nil {
 		observer = NilVerificationObserver{}
 	}
@@ -125,7 +113,7 @@ func verifyFileForest(ctx context.Context, directory string, config MptConfig, r
 	return verifyForest(directory, config, roots, source, observer)
 }
 
-func verifyForest(directory string, config MptConfig, roots iter.Seq2[uint64, Root], source *verificationNodeSource, observer VerificationObserver) (res error) {
+func verifyForest(directory string, config MptConfig, roots iter_utils.ResultSeq2[uint64, Root], source *verificationNodeSource, observer VerificationObserver) (res error) {
 	// ------------------------- Meta-Data Checks -----------------------------
 
 	observer.Progress(fmt.Sprintf("Checking forest stored in %s ...", directory))
@@ -159,10 +147,14 @@ func verifyForest(directory string, config MptConfig, roots iter.Seq2[uint64, Ro
 
 	// Check that roots are valid.
 	errs := []error{}
-	for _, root := range roots {
+	rootSeq, rootsErr := iter_utils.Unwrap2(roots)
+	for _, root := range rootSeq {
 		if err := checkId(&root.NodeRef); err != nil {
 			errs = append(errs, err)
 		}
+	}
+	if err := rootsErr(); err != nil {
+		errs = append(errs, err)
 	}
 	if len(errs) > 0 {
 		return errors.Join(errs...)
@@ -212,20 +204,28 @@ func verifyForest(directory string, config MptConfig, roots iter.Seq2[uint64, Ro
 		// Check hashes of roots.
 		observer.Progress("Checking root hashes ...")
 		refIds := newNodeIds()
-		for _, root := range roots {
+		refSeq, refSeqErr := iter_utils.Unwrap2(roots)
+		for _, root := range refSeq {
 			refIds.Put(root.NodeRef.id)
+		}
+		if err := refSeqErr(); err != nil {
+			return err
 		}
 		isEmbedded := func(node Node) (bool, error) { return false, nil } // root node cannot be embedded
 		hashes, _, err := loadNodeHashes(refIds, source, isEmbedded, emptyNodeHash)
 		if err != nil {
 			return err
 		}
-		for block, root := range roots {
+		hashSeq, hashSeqErr := iter_utils.Unwrap2(roots)
+		for block, root := range hashSeq {
 			want := hashes[root.NodeRef.Id()]
 			got := root.Hash
 			if want != got {
 				return fmt.Errorf("inconsistent hash for root node %v of block %d, want %v, got %v", root.NodeRef.Id(), block, want, got)
 			}
+		}
+		if err := hashSeqErr(); err != nil {
+			return err
 		}
 	}
 
@@ -321,7 +321,7 @@ func verifyHashes[N any](
 	stock stock.Stock[uint64, N],
 	ids stock.IndexSet[uint64],
 	hashOfEmptyNode common.Hash,
-	roots iter.Seq2[uint64, Root],
+	roots iter_utils.ResultSeq2[uint64, Root],
 	observer VerificationObserver,
 	hash func(*N) (common.Hash, error),
 	readHash func(*N) (common.Hash, bool),
@@ -545,7 +545,7 @@ func verifyHashesStoredWithParents[N any](
 	source *verificationNodeSource,
 	stock stock.Stock[uint64, N],
 	ids stock.IndexSet[uint64],
-	roots iter.Seq2[uint64, Root],
+	roots iter_utils.ResultSeq2[uint64, Root],
 	observer VerificationObserver,
 	hash func(*N) (common.Hash, error),
 	isNodeType func(NodeId) bool,
@@ -587,10 +587,14 @@ func verifyHashesStoredWithParents[N any](
 			return fmt.Errorf("inconsistent hash for node %v, want %v, got %v", id, want, hash)
 		}
 
-		for _, root := range roots {
+		rootSeq, rootsErr := iter_utils.Unwrap2(roots)
+		for _, root := range rootSeq {
 			if err := checkNodeHash(root.NodeRef.Id(), root.Hash); err != nil {
 				return err
 			}
+		}
+		if err := rootsErr(); err != nil {
+			return err
 		}
 
 		// Check that all nodes referencing other nodes use the right hashes.
@@ -651,10 +655,14 @@ func verifyContractCodes(directory string, source *verificationNodeSource, obser
 	if err != nil {
 		return err
 	}
-	for hash, code := range codeIterator {
+	codeSeq, codeSeqErr := iter_utils.Unwrap2(codeIterator)
+	for hash, code := range codeSeq {
 		if got, want := common.Keccak256(code), hash; got != want {
 			return fmt.Errorf("unexpected code hash, got: %x want: %x", got, want)
 		}
+	}
+	if err := codeSeqErr(); err != nil {
+		return err
 	}
 
 	// Check that all referenced codes are present in the code file.
@@ -681,10 +689,14 @@ func verifyContractCodes(directory string, source *verificationNodeSource, obser
 	if err != nil {
 		return err
 	}
-	for hash := range codeIterator {
+	codeSeq, codeSeqErr = iter_utils.Unwrap2(codeIterator)
+	for hash := range codeSeq {
 		if _, exists := usedHashes[hash]; !exists {
 			observer.Progress(fmt.Sprintf("Contract %x is not referenced by any account\n", hash))
 		}
+	}
+	if err := codeSeqErr(); err != nil {
+		return err
 	}
 
 	return nil

--- a/go/database/mpt/verification_test.go
+++ b/go/database/mpt/verification_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/0xsoniclabs/carmen/go/common/amount"
 	"github.com/0xsoniclabs/carmen/go/common/interrupt"
 	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
+	"github.com/0xsoniclabs/carmen/go/common/result"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
@@ -82,6 +83,23 @@ func TestVerification_VerificationObserverIsKeptUpdatedOnEvents(t *testing.T) {
 		if err := verifyFileForest(context.Background(), dir, config, rootsFromSlice(roots), observer); err != nil {
 			t.Errorf("found unexpected error in fresh forest: %v", err)
 		}
+	})
+}
+
+func TestVerification_RootIteratorFailureIsDetected(t *testing.T) {
+	runVerificationTest(t, func(t *testing.T, dir string, config MptConfig, roots []Root) {
+		require := require.New(t)
+
+		injected := errors.New("injected failure")
+		failing := func(yield func(result.Result[iter_utils.Pair[uint64, Root]]) bool) {
+			if !yield(result.Ok(iter_utils.Pair[uint64, Root]{Key: 0, Value: roots[0]})) {
+				return
+			}
+			yield(result.Err[iter_utils.Pair[uint64, Root]](injected))
+		}
+
+		err := verifyFileForest(context.Background(), dir, config, failing, NilVerificationObserver{})
+		require.ErrorIs(err, injected)
 	})
 }
 

--- a/go/database/mpt/verification_test.go
+++ b/go/database/mpt/verification_test.go
@@ -16,7 +16,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"iter"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,9 +26,16 @@ import (
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/common/amount"
 	"github.com/0xsoniclabs/carmen/go/common/interrupt"
+	"github.com/0xsoniclabs/carmen/go/common/iter_utils"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
+
+// rootsFromSlice adapts a slice of roots to the iterator type expected by
+// the verification API.
+func rootsFromSlice(roots []Root) iter_utils.ResultSeq2[uint64, Root] {
+	return iter_utils.OkSeq2(iter_utils.Enumerate(roots))
+}
 
 const N = 100
 
@@ -703,7 +709,7 @@ func TestVerification_VerifyValidMptState(t *testing.T) {
 }
 
 func TestVerification_CanInterrupt(t *testing.T) {
-	type verifyFunc func(context.Context, string, MptConfig, iter.Seq2[uint64, Root], VerificationObserver) error
+	type verifyFunc func(context.Context, string, MptConfig, iter_utils.ResultSeq2[uint64, Root], VerificationObserver) error
 	tests := map[string]verifyFunc{"VerifyMptState": VerifyMptState, "VerifyFileForest": verifyFileForest}
 
 	for name, verify := range tests {


### PR DESCRIPTION
Currently, `KVFile::Iterate` returns only values. Errors causes the iterator to silently stop without notifying the user.

This PR fixes it by making it return a `ResultSeq2`, n iterator over a `Result[Pair[K,V]]`, which is a type that can hold either a value or an error.
The `Database::CheckAll` interface function signature has been updated to reflect the change, and now takes an `ResultSeq`.

Closes https://github.com/0xsoniclabs/sonic-admin/issues/881