### PR TITLE
Substitute experimental packages with standard library ones

### DIFF
--- a/go/backend/utils/buffered_file_test.go
+++ b/go/backend/utils/buffered_file_test.go
@@ -14,11 +14,11 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/exp/slices"
 )
 
 func TestBufferedFile_Open_NonExisting(t *testing.T) {

--- a/go/backend/utils/checkpoint/checkpoint.go
+++ b/go/backend/utils/checkpoint/checkpoint.go
@@ -17,8 +17,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 //go:generate mockgen -source checkpoint.go -destination checkpoint_mocks.go -package checkpoint

--- a/go/carmen/configurations.go
+++ b/go/carmen/configurations.go
@@ -12,10 +12,11 @@ package carmen
 
 import (
 	"fmt"
+	"iter"
+	"maps"
 
 	"github.com/0xsoniclabs/carmen/go/state"
 	"github.com/0xsoniclabs/carmen/go/state/gostate"
-	"golang.org/x/exp/maps"
 )
 
 // Configuration is a unique identifier of a Carmen DB setup option.
@@ -99,7 +100,7 @@ func GetCarmenGoS5WithArchiveConfiguration() Configuration {
 // However, by importing the carmen/experimental package or by explicitly
 // registering custom implementations using RegisterConfiguration() below,
 // additional options can be made available.
-func GetAllConfigurations() []Configuration {
+func GetAllConfigurations() iter.Seq[Configuration] {
 	return maps.Keys(registeredConfigurations)
 }
 

--- a/go/carmen/configurations_test.go
+++ b/go/carmen/configurations_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestConfiguration_OnlyContainsOfficialImplementations(t *testing.T) {
-	configs := GetAllConfigurations()
+	configs := slices.Collect(GetAllConfigurations())
 
 	want := []Configuration{
 		GetCarmenGoS5WithArchiveConfiguration(),
@@ -35,7 +35,7 @@ func TestConfiguration_OnlyContainsOfficialImplementations(t *testing.T) {
 }
 
 func TestConfiguration_RegisteredConfigurationsCanBeUsed(t *testing.T) {
-	for _, config := range GetAllConfigurations() {
+	for config := range GetAllConfigurations() {
 		config := config
 		t.Run(config.String(), func(t *testing.T) {
 			t.Parallel()

--- a/go/carmen/example_test.go
+++ b/go/carmen/example_test.go
@@ -15,12 +15,13 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"github.com/0xsoniclabs/carmen/go/carmen"
 	"github.com/0xsoniclabs/carmen/go/database/mpt/io"
-	"golang.org/x/exp/maps"
 )
 
 func ExampleDatabase_AddBlock() {
@@ -364,7 +365,7 @@ func ExampleHistoricBlockContext_GetProof() {
 
 	// ------- WitnessProof can be deserialized  -------
 
-	recoveredProof := carmen.CreateWitnessProofFromNodes(maps.Keys(completeProof)...)
+	recoveredProof := carmen.CreateWitnessProofFromNodes(slices.Collect(maps.Keys(completeProof))...)
 
 	// ------- Properties can be proven offline  -------
 	for i := 0; i < N; i++ {

--- a/go/carmen/experimental/configurations_test.go
+++ b/go/carmen/experimental/configurations_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestConfigurations_ConfigurationsAreRegisteredGlobally(t *testing.T) {
-	registeredConfigs := carmen.GetAllConfigurations()
+	registeredConfigs := slices.Collect(carmen.GetAllConfigurations())
 	for _, config := range experimental.GetDatabaseConfigurations() {
 		if !slices.Contains(registeredConfigs, config) {
 			t.Errorf("missing registration of configuration %v", config)
@@ -28,7 +28,7 @@ func TestConfigurations_ConfigurationsAreRegisteredGlobally(t *testing.T) {
 }
 
 func TestConfiguration_RegisteredConfigurationsCanBeUsed(t *testing.T) {
-	for _, config := range carmen.GetAllConfigurations() {
+	for config := range carmen.GetAllConfigurations() {
 		config := config
 		t.Run(config.String(), func(t *testing.T) {
 			t.Parallel()

--- a/go/carmen/proof_test.go
+++ b/go/carmen/proof_test.go
@@ -12,9 +12,10 @@ package carmen
 
 import (
 	"bytes"
-	"github.com/0xsoniclabs/carmen/go/common/immutable"
-	"golang.org/x/exp/slices"
+	"slices"
 	"testing"
+
+	"github.com/0xsoniclabs/carmen/go/common/immutable"
 )
 
 func TestProof_CreateWitnessProofFromNodes(t *testing.T) {
@@ -34,11 +35,11 @@ func TestProof_CreateWitnessProofFromNodes(t *testing.T) {
 	}
 	gotElements := proof.GetElements()
 
-	slices.SortFunc(gotElements, func(a, b Bytes) bool {
-		return bytes.Compare(a.ToBytes(), b.ToBytes()) < 0
+	slices.SortFunc(gotElements, func(a, b Bytes) int {
+		return bytes.Compare(a.ToBytes(), b.ToBytes())
 	})
-	slices.SortFunc(wantElements, func(a, b Bytes) bool {
-		return bytes.Compare(a.ToBytes(), b.ToBytes()) < 0
+	slices.SortFunc(wantElements, func(a, b Bytes) int {
+		return bytes.Compare(a.ToBytes(), b.ToBytes())
 	})
 
 	if got, want := gotElements, wantElements; !slices.Equal(got, want) {

--- a/go/common/cached_hasher_benchmark_test.go
+++ b/go/common/cached_hasher_benchmark_test.go
@@ -12,7 +12,7 @@ package common
 
 import (
 	"encoding/binary"
-	"golang.org/x/exp/rand"
+	"math/rand"
 	"testing"
 )
 

--- a/go/common/serializers_test.go
+++ b/go/common/serializers_test.go
@@ -11,12 +11,12 @@
 package common_test
 
 import (
+	"math/rand"
 	"slices"
 	"testing"
 
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/common/amount"
-	"golang.org/x/exp/rand"
 )
 
 func TestAddressSerializer(t *testing.T) {

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"maps"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -37,7 +38,6 @@ import (
 	"github.com/0xsoniclabs/carmen/go/database/mpt/shared"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/exp/maps"
 )
 
 // Note: most properties of the ArchiveTrie are tested through the common
@@ -2268,7 +2268,7 @@ func TestArchiveTrie_FailingOperation_InvalidatesOtherArchiveOperations(t *testi
 		return append(cp[k:], cp[:k]...)
 	}
 
-	names := maps.Keys(archiveOps)
+	names := slices.Collect(maps.Keys(archiveOps))
 
 	// rotate getters to start the experiment from all existing getters.
 	for i := 0; i < len(archiveOps); i++ {

--- a/go/database/mpt/diff.go
+++ b/go/database/mpt/diff.go
@@ -12,14 +12,15 @@ package mpt
 
 import (
 	"fmt"
+	"maps"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/common/amount"
 	"github.com/0xsoniclabs/carmen/go/database/mpt/shared"
-	"golang.org/x/exp/maps"
 )
 
 type Diff map[common.Address]*AccountDiff
@@ -36,7 +37,7 @@ func (d Diff) Equal(other Diff) bool {
 }
 
 func (d Diff) String() string {
-	addresses := maps.Keys(d)
+	addresses := slices.Collect(maps.Keys(d))
 	sort.Slice(addresses, func(i, j int) bool {
 		return string(addresses[i][:]) < string(addresses[j][:])
 	})
@@ -57,7 +58,7 @@ func (d Diff) String() string {
 		}
 
 		if len(diff.Storage) > 0 {
-			keys := maps.Keys(diff.Storage)
+			keys := slices.Collect(maps.Keys(diff.Storage))
 			sort.Slice(keys, func(i, j int) bool {
 				return string(keys[i][:]) < string(keys[j][:])
 			})

--- a/go/database/mpt/io/archive.go
+++ b/go/database/mpt/io/archive.go
@@ -17,8 +17,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path"
+	"slices"
 	"sort"
 
 	"github.com/0xsoniclabs/carmen/go/common/amount"
@@ -28,7 +30,6 @@ import (
 	"github.com/0xsoniclabs/carmen/go/backend/archive"
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/database/mpt"
-	"golang.org/x/exp/maps"
 )
 
 // This file provides a pair of import and export functions capable of
@@ -144,7 +145,7 @@ func ExportArchiveWithConfig(ctx context.Context, logger *Log, directory string,
 		}
 
 		// Encode changes of this block.
-		addresses := maps.Keys(diff)
+		addresses := slices.Collect(maps.Keys(diff))
 		sort.Slice(addresses, func(i, j int) bool { return bytes.Compare(addresses[i][:], addresses[j][:]) < 0 })
 		for _, address := range addresses {
 			if _, err := out.Write([]byte{'A'}); err != nil {
@@ -179,7 +180,7 @@ func ExportArchiveWithConfig(ctx context.Context, logger *Log, directory string,
 					return err
 				}
 			}
-			keys := maps.Keys(accountDiff.Storage)
+			keys := slices.Collect(maps.Keys(accountDiff.Storage))
 			sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i][:], keys[j][:]) < 0 })
 			for _, key := range keys {
 				value := accountDiff.Storage[key]

--- a/go/database/mpt/proof.go
+++ b/go/database/mpt/proof.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"sort"
 	"strings"
@@ -24,7 +25,6 @@ import (
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/common/amount"
 	"github.com/0xsoniclabs/carmen/go/common/tribool"
-	"golang.org/x/exp/maps"
 )
 
 //go:generate mockgen -source proof.go -destination proof_mocks.go -package mpt
@@ -246,7 +246,7 @@ func (p WitnessProof) Equals(other witness.Proof) bool {
 // The representation contains all nodes sorted by their hash.
 func (p WitnessProof) String() string {
 	// Extract keys and sort them
-	keys := maps.Keys(p.proofDb)
+	keys := slices.Collect(maps.Keys(p.proofDb))
 	cmp := common.HashComparator{}
 	sort.Slice(keys, func(i, j int) bool {
 		return cmp.Compare(&keys[i], &keys[j]) <= 0

--- a/go/database/mpt/proof/verification.go
+++ b/go/database/mpt/proof/verification.go
@@ -14,13 +14,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math/rand"
+	"slices"
 
 	"github.com/0xsoniclabs/carmen/go/common"
 	"github.com/0xsoniclabs/carmen/go/common/interrupt"
 	"github.com/0xsoniclabs/carmen/go/common/witness"
 	"github.com/0xsoniclabs/carmen/go/database/mpt"
-	"golang.org/x/exp/maps"
 )
 
 //go:generate mockgen -source verification.go -destination verification_mocks.go -package proof
@@ -394,7 +395,7 @@ func (v *storageVerifyingVisitor) Visit(n mpt.Node, _ mpt.NodeInfo) mpt.VisitRes
 
 // verifyStorage verifies the consistency of witness proofs for storage slots.
 func (v *storageVerifyingVisitor) verifyStorage() error {
-	keys := maps.Keys(v.storage)
+	keys := slices.Collect(maps.Keys(v.storage))
 
 	proof, err := v.trie.CreateWitnessProof(v.currentAddress, keys...)
 	if err != nil {

--- a/go/database/mpt/proof_test.go
+++ b/go/database/mpt/proof_test.go
@@ -15,6 +15,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
 	"testing"
 
@@ -23,7 +24,6 @@ import (
 	"github.com/0xsoniclabs/carmen/go/common/immutable"
 	"github.com/0xsoniclabs/carmen/go/database/mpt/shared"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/exp/maps"
 )
 
 func TestCreateWitnessProof_CanCreateProof(t *testing.T) {

--- a/go/fuzzing/fuzzing_test.go
+++ b/go/fuzzing/fuzzing_test.go
@@ -11,9 +11,10 @@
 package fuzzing
 
 import (
-	"go.uber.org/mock/gomock"
-	"golang.org/x/exp/slices"
+	"slices"
 	"testing"
+
+	"go.uber.org/mock/gomock"
 )
 
 func TestFuzz_TwoFuzzingLoopOneCampaignSeedOnly(t *testing.T) {

--- a/go/state/state_db_and_state_test.go
+++ b/go/state/state_db_and_state_test.go
@@ -242,7 +242,7 @@ func TestCarmenBulkLoadsCanBeInterleavedWithRegularUpdates(t *testing.T) {
 
 func testCarmenStateDbHashAfterModification(t *testing.T, mod func(s state.StateDB)) {
 	want := map[state.Schema]common.Hash{}
-	for _, s := range getAllSchemas() {
+	for s := range getAllSchemas() {
 		ref_state, err := getReferenceStateFor(t, state.Parameters{
 			Schema:  s,
 			Archive: state.NoArchive,

--- a/go/state/state_test.go
+++ b/go/state/state_test.go
@@ -15,6 +15,8 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"iter"
+	"maps"
 	"os"
 	"os/exec"
 	"strings"
@@ -25,7 +27,6 @@ import (
 	"github.com/0xsoniclabs/carmen/go/state"
 	"github.com/0xsoniclabs/carmen/go/state/gostate"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
 
 	_ "github.com/0xsoniclabs/carmen/go/state/externalstate"
 	_ "github.com/0xsoniclabs/carmen/go/state/gostate/experimental"
@@ -81,7 +82,7 @@ func initStates() []namedStateConfig {
 	return res
 }
 
-func getAllSchemas() []state.Schema {
+func getAllSchemas() iter.Seq[state.Schema] {
 	schemas := map[state.Schema]struct{}{}
 	for config := range state.GetAllRegisteredStateFactories() {
 		schemas[config.Schema] = struct{}{}
@@ -122,7 +123,7 @@ func getReferenceStateFor(t *testing.T, params state.Parameters) (state.State, e
 
 func testHashAfterModification(t *testing.T, mod func(t *testing.T, schema state.Schema, s state.State)) {
 	want := map[state.Schema]common.Hash{}
-	for _, s := range getAllSchemas() {
+	for s := range getAllSchemas() {
 		ref, err := getReferenceStateFor(t, state.Parameters{Schema: s})
 		if err != nil {
 			t.Fatalf("failed to create reference state: %v", err)


### PR DESCRIPTION
Some of the packages used in Carmen were originally only available in the golang experimental libraries.
This PR substituite some of them with the standard library ones, updating the functions accordingly.

In particular:
- `maps.Keys` returns now an iterator instead of a slice
- `slices.SortFunc` wants the comparison function to return an int and not a boolena