### PR TITLE
Modernize code with `go fix`

### DIFF
--- a/go/backend/archive/benchmark_test.go
+++ b/go/backend/archive/benchmark_test.go
@@ -33,7 +33,7 @@ func BenchmarkAdding(b *testing.B) {
 
 		// initialize
 		var update common.Update
-		for i := byte(0); i < byte(bmAddressToCreate); i++ {
+		for i := range byte(bmAddressToCreate) {
 			update.AppendBalanceUpdate(common.Address{i}, amount.New(uint64(i)))
 		}
 		if err := a.Add(1, update, nil); err != nil {
@@ -42,11 +42,11 @@ func BenchmarkAdding(b *testing.B) {
 
 		var block uint64 = 2
 		b.Run(factory.label, func(b *testing.B) {
-			for i := 0; i < bmBlocksToInsert; i++ {
+			for range bmBlocksToInsert {
 				var update common.Update
-				for addrIt := 0; addrIt < bmAddressToUseParBlock; addrIt++ {
+				for range bmAddressToUseParBlock {
 					addr := byte(rand.Intn(bmAddressToCreate))
-					for keyIt := 0; keyIt < bmKeysToInsertParAddressAndBlock; keyIt++ {
+					for range bmKeysToInsertParAddressAndBlock {
 						key := byte(rand.Intn(0xFF))
 						update.AppendSlotUpdate(common.Address{addr}, common.Key{key}, common.Value{addr + key})
 					}

--- a/go/backend/kv_file/offset_file_test.go
+++ b/go/backend/kv_file/offset_file_test.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"testing"
@@ -273,10 +274,7 @@ func TestOffsetFile_Iterate_ReturnsAllEntries(t *testing.T) {
 
 	seq, err := f.Iterate()
 	require.NoError(err)
-	all := map[uint64]uint64{}
-	for k, v := range seq {
-		all[k] = v
-	}
+	all := maps.Collect(seq)
 	require.Equal(map[uint64]uint64{1: 11, 2: 22, 3: 33}, all)
 }
 
@@ -289,10 +287,7 @@ func TestOffsetFile_Iterate_ReturnsLatestValueAfterOverwrite(t *testing.T) {
 
 	seq, err := f.Iterate()
 	require.NoError(err)
-	all := map[uint64]uint64{}
-	for k, v := range seq {
-		all[k] = v
-	}
+	all := maps.Collect(seq)
 	require.Equal(map[uint64]uint64{1: 100}, all)
 }
 
@@ -515,10 +510,7 @@ func (r *chunkedReadSeeker) Read(p []byte) (int, error) {
 		return 0, io.EOF
 	}
 	remaining := int64(len(r.data)) - r.pos
-	n := int64(len(p))
-	if n > remaining {
-		n = remaining
-	}
+	n := min(int64(len(p)), remaining)
 	if r.chunkSize > 0 && n > int64(r.chunkSize) {
 		n = int64(r.chunkSize)
 	}

--- a/go/backend/kv_file/ordered_file_test.go
+++ b/go/backend/kv_file/ordered_file_test.go
@@ -409,10 +409,7 @@ func TestOrderedFile_Iterate_HandlesChunkedReader(t *testing.T) {
 			seq, err := f.Iterate()
 			require.NoError(err)
 
-			all := map[uint64]uint64{}
-			for k, v := range seq {
-				all[k] = v
-			}
+			all := maps.Collect(seq)
 			require.Len(all, len(values))
 			for i, v := range values {
 				require.EqualValues(v, all[uint64(i)], "position %d", i)

--- a/go/backend/stock/file/file_test.go
+++ b/go/backend/stock/file/file_test.go
@@ -45,7 +45,7 @@ func initFileStock(directory string, items int) (*fileStock[int, int], error) {
 		return nil, err
 	}
 
-	for i := 0; i < items; i++ {
+	for i := range items {
 		id, err := s.New()
 		if err != nil {
 			return nil, err
@@ -941,7 +941,7 @@ func TestRestore_CorruptedStockCanBeRestored(t *testing.T) {
 			}
 
 			// Fill the stock with some data (more than a single buffer size).
-			for i := 0; i < N; i++ {
+			for i := range N {
 				id, err := stock.New()
 				if err != nil {
 					t.Fatalf("failed to create item in stock: %v", err)
@@ -1223,7 +1223,7 @@ func BenchmarkFileStock_Commit(b *testing.B) {
 	if err != nil {
 		b.Fatalf("failed to open stock")
 	}
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		id, err := stock.New()
 		if err != nil {
 			b.Fatalf("failed to create item in stock")

--- a/go/backend/stock/file/readonly_test.go
+++ b/go/backend/stock/file/readonly_test.go
@@ -43,7 +43,7 @@ func TestReadOnlyFile_Get(t *testing.T) {
 		t.Fatalf("cannot open stock: %s", err)
 	}
 
-	for i := 0; i < Items; i++ {
+	for i := range Items {
 		got, err := readonly.Get(i)
 		if err != nil {
 			t.Fatalf("cannot get value: %s", err)

--- a/go/backend/stock/file/stack.go
+++ b/go/backend/stock/file/stack.go
@@ -68,7 +68,7 @@ func initFileBasedStack[I stock.Index](file utils.OsFile) (*fileBasedStack[I], e
 		}
 
 		valueBuffer := make([]byte, valueSize)
-		for i := 0; i < toLoad; i++ {
+		for range toLoad {
 			if _, err := io.ReadFull(file, valueBuffer); err != nil {
 				return nil, err
 			}

--- a/go/backend/stock/file/stack_test.go
+++ b/go/backend/stock/file/stack_test.go
@@ -61,7 +61,7 @@ func TestStack_LargePushAndPop(t *testing.T) {
 	}
 	defer func() { require.NoError(t, stack.Close()) }()
 
-	for i := 0; i < 10*stackBufferSize; i++ {
+	for i := range 10 * stackBufferSize {
 		if got, want := stack.Size(), i; got != want {
 			t.Fatalf("invalid size, wanted %d, got %d", want, got)
 		}
@@ -132,7 +132,7 @@ func TestStack_CloseAndReopenLarge(t *testing.T) {
 			t.Fatalf("failed to open empty stack: %v", err)
 		}
 
-		for i := 0; i < N; i++ {
+		for i := range N {
 			if got, want := stack.Size(), i; got != want {
 				t.Fatalf("invalid size, wanted %d, got %d", want, got)
 			}

--- a/go/backend/stock/index_set_test.go
+++ b/go/backend/stock/index_set_test.go
@@ -24,7 +24,7 @@ func TestComplementSet_LowerAndUpperBoundsAreRetained(t *testing.T) {
 
 func TestComplementSet_ContainsElementInRange(t *testing.T) {
 	set := MakeComplementSet[int](12, 15)
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		got := set.Contains(i)
 		want := (i >= 12) && (i < 15)
 		if got != want {
@@ -39,7 +39,7 @@ func TestComplementSet_DoesNotContainExcludedElements(t *testing.T) {
 	set.Remove(14)
 	set.Remove(16)
 	set.Remove(20)
-	for i := 0; i < 30; i++ {
+	for i := range 30 {
 		got := set.Contains(i)
 		want := (i >= 12) && (i < 19) && (i != 14) && (i != 16)
 		if got != want {

--- a/go/backend/stock/stock_fuzzing_utils_test.go
+++ b/go/backend/stock/stock_fuzzing_utils_test.go
@@ -247,7 +247,7 @@ func TestFuzzing_Deserialize_Expensive_ops_Skipped(t *testing.T) {
 	data := []fuzzing.Operation[stockFuzzContext]{
 		&opNewId{}, &opGetIds{}, &opGetIds{}, &opGetIds{}, &opGetIds{}, &opGet{0}}
 
-	for i := 0; i < 30; i++ {
+	for range 30 {
 		data = append(data, &opGetIds{})
 		data = append(data, &opGet{0})
 	}
@@ -262,7 +262,7 @@ func TestFuzzing_Deserialize_Expensive_ops_Skipped(t *testing.T) {
 		&opNewId{}, &opGetIds{}, &opGetIds{}, &opGetIds{}, &opGet{0}}
 
 	numExpensive := 4 // already four
-	for i := 0; i < 30; i++ {
+	for range 30 {
 		if numExpensive < 20 {
 			want = append(want, &opGetIds{})
 		}
@@ -291,7 +291,7 @@ func assertOperationsEquals(t *testing.T, got, want []fuzzing.Operation[stockFuz
 		t.Fatalf("number of got and wanted operations do not match: %d != %d", got, want)
 	}
 
-	for i := 0; i < len(got); i++ {
+	for i := range got {
 		gotOp, gotPayload := getOpAndData(got[i])
 		wantOp, wantPayload := getOpAndData(want[i])
 

--- a/go/backend/stock/stock_test_utils.go
+++ b/go/backend/stock/stock_test_utils.go
@@ -142,7 +142,7 @@ func testDeletedElementsAreReused(t *testing.T, factory NamedStockFactory) {
 	defer func() { require.NoError(t, stock.Close()) }()
 
 	seen := map[int]bool{}
-	for i := 0; i < 1_000_000; i++ {
+	for range 1_000_000 {
 		index, err := stock.New()
 		if err != nil {
 			t.Fatalf("failed to create new element: %v", err)
@@ -166,7 +166,7 @@ func testReusedElementsAreCleared(t *testing.T, factory NamedStockFactory) {
 	defer func() { require.NoError(t, stock.Close()) }()
 
 	seen := map[int]bool{}
-	for i := 0; i < 1_000_000; i++ {
+	for range 1_000_000 {
 		index, err := stock.New()
 		if err != nil {
 			t.Fatalf("failed to create new element: %v", err)
@@ -193,7 +193,7 @@ func testLargeNumberOfElements(t *testing.T, factory NamedStockFactory) {
 	}
 	defer func() { require.NoError(t, stock.Close()) }()
 	indexes := map[int]int{}
-	for i := 0; i < N; i++ {
+	for i := range N {
 		index, err := stock.New()
 		if err != nil {
 			t.Fatalf("failed to create new entry: %v", err)
@@ -204,7 +204,7 @@ func testLargeNumberOfElements(t *testing.T, factory NamedStockFactory) {
 		}
 	}
 
-	for i := 0; i < N; i++ {
+	for i := range N {
 		got, err := stock.Get(indexes[i])
 		if err != nil {
 			t.Fatalf("failed to locate element: %v", err)
@@ -352,7 +352,7 @@ func testGetIdsProducesAllIdsInTheStock(t *testing.T, factory NamedStockFactory)
 
 	const N = 100
 	ids := map[int]struct{}{}
-	for i := 0; i < N; i++ {
+	for range N {
 		i, err := stock.New()
 		if err != nil {
 			t.Fatalf("failed to insert single element into empty stock: %v", err)

--- a/go/backend/stock/synced/synced_test.go
+++ b/go/backend/stock/synced/synced_test.go
@@ -64,11 +64,9 @@ func testCanBeAccessedConcurrently(t *testing.T, factory stock.NamedStockFactory
 
 	var wg sync.WaitGroup
 	var errors [N]error
-	for i := 0; i < N; i++ {
+	for i := range N {
 		i := i
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			id, err := stock.New()
 			if err != nil {
 				errors[i] = fmt.Errorf("unable to create new item: %v", err)
@@ -86,7 +84,7 @@ func testCanBeAccessedConcurrently(t *testing.T, factory stock.NamedStockFactory
 				errors[i] = fmt.Errorf("failed to free item: %v", err)
 				return
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/go/backend/utils/buffered_file_fuzz_test.go
+++ b/go/backend/utils/buffered_file_fuzz_test.go
@@ -27,7 +27,7 @@ func FuzzBufferedFile_RandomOps(f *testing.F) {
 func FuzzBufferedFile_ReadWrite(f *testing.F) {
 	length := 5 * bufferSize // length above the buffer size
 	long := make([]byte, length)
-	for i := 0; i < length; i++ {
+	for i := range length {
 		long[i]++
 	}
 
@@ -42,7 +42,7 @@ func FuzzBufferedFile_ReadWrite(f *testing.F) {
 	}
 
 	// sample variants of the updates to seed the fuzzing
-	for start := 0; start < len(updates); start++ {
+	for start := range updates {
 		for end := start; end < len(updates); end++ {
 			var raw []byte
 			for _, update := range updates[start:end] {

--- a/go/backend/utils/buffered_file_test.go
+++ b/go/backend/utils/buffered_file_test.go
@@ -121,7 +121,7 @@ func TestBufferedFile_ReadPartlyBeyondSize(t *testing.T) {
 		t.Fatalf("openning file should not produce error, %s", err)
 	}
 
-	for i := 0; i < bufferSize; i++ {
+	for i := range bufferSize {
 		bf.buffer[i] = byte(i)
 	}
 
@@ -185,7 +185,7 @@ func TestBufferedFile_ReadSplit(t *testing.T) {
 		t.Fatalf("openning file should not produce error, %s", err)
 	}
 
-	for i := 0; i < bufferSize; i++ {
+	for i := range bufferSize {
 		bf.buffer[i] = byte(i)
 	}
 
@@ -355,13 +355,13 @@ func TestBufferedFile_WrittenDataCanBeRead(t *testing.T) {
 				t.Fatalf("failed to open buffered file: %v", err)
 			}
 
-			for i := 0; i < n; i++ {
+			for i := range n {
 				if _, err := file.WriteAt([]byte{byte(i)}, int64(i)); err != nil {
 					t.Fatalf("failed to write at position %d: %v", i, err)
 				}
 			}
 
-			for i := 0; i < n; i++ {
+			for i := range n {
 				dst := []byte{0}
 				if _, err := file.ReadAt(dst, int64(i)); err != nil {
 					t.Fatalf("failed to read at position %d: %v", i, err)
@@ -387,7 +387,7 @@ func TestBufferedFile_DataIsPersistent(t *testing.T) {
 				t.Fatalf("failed to open buffered file: %v", err)
 			}
 
-			for i := 0; i < n; i++ {
+			for i := range n {
 				if _, err := file.WriteAt([]byte{byte(i + 1)}, int64(i)); err != nil {
 					t.Fatalf("failed to write at position %d: %v", i, err)
 				}
@@ -403,7 +403,7 @@ func TestBufferedFile_DataIsPersistent(t *testing.T) {
 				t.Fatalf("failed to reopen buffered file: %v", err)
 			}
 
-			for i := 0; i < n; i++ {
+			for i := range n {
 				dst := []byte{0}
 				if _, err := file.ReadAt(dst, int64(i)); err != nil {
 					t.Fatalf("failed to read at position %d: %v", i, err)
@@ -429,13 +429,13 @@ func TestBufferedFile_ReadAndWriteCanHandleUnalignedData(t *testing.T) {
 
 	// By writing data of length 3 we are sometimes writing data crossing
 	// the internal aligned buffer-page boundary.
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		if _, err := file.WriteAt([]byte{byte(i), byte(i + 1), byte(i + 2)}, int64(i)*3); err != nil {
 			t.Fatalf("failed to write at position %d: %v", i, err)
 		}
 	}
 
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		dst := []byte{0, 0, 0}
 		if _, err := file.ReadAt(dst, int64(i)*3); err != nil {
 			t.Fatalf("failed to read at position %d: %v", i, err)

--- a/go/backend/utils/checkpoint/checkpoint_test.go
+++ b/go/backend/utils/checkpoint/checkpoint_test.go
@@ -128,7 +128,7 @@ func TestCheckpointCoordinator_ErrorsDuringAbortAreCollected(t *testing.T) {
 func TestCheckpointCoordinator_CommitNumberIsPersisted(t *testing.T) {
 	dir := t.TempDir()
 
-	for commit := Checkpoint(0); commit < 10; commit++ {
+	for commit := range Checkpoint(10) {
 		coordinator, err := NewCoordinator(dir)
 		if err != nil {
 			t.Fatalf("failed to create coordinator: %v", err)
@@ -153,7 +153,7 @@ func TestCheckpointCoordinator_ParticipantsAreCheckedForLastCommitNumber(t *test
 	if err != nil {
 		t.Fatalf("failed to create coordinator: %v", err)
 	}
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		if _, err := coordinator.CreateCheckpoint(); err != nil {
 			t.Fatalf("failed to run commit: %v", err)
 		}

--- a/go/backend/utils/chunk_reader_test.go
+++ b/go/backend/utils/chunk_reader_test.go
@@ -20,7 +20,7 @@ import (
 func TestChunkReader_ReadChunks(t *testing.T) {
 	const size = 10_000
 	want := make([]byte, size)
-	for i := 0; i < size; i++ {
+	for i := range size {
 		want[i] = byte(i)
 	}
 

--- a/go/carmen/block_test.go
+++ b/go/carmen/block_test.go
@@ -26,7 +26,7 @@ func TestBlockContext_CanCreateSequenceOfTransactions(t *testing.T) {
 	for name, factory := range initBlockContexts() {
 		t.Run(name, func(t *testing.T) {
 			block := factory(t)
-			for i := 0; i < 10; i++ {
+			for i := range 10 {
 				tx, err := block.BeginTransaction()
 				if err != nil {
 					t.Fatalf("failed to create transaction %d: %v", i, err)
@@ -77,7 +77,7 @@ func TestBlockContext_RunTransaction_Parallel(t *testing.T) {
 
 			// non-sync counter as only one txs can run at a time
 			var counter int32
-			for i := 0; i < loops; i++ {
+			for i := range loops {
 				go func(i int) {
 					defer wg.Done()
 					if err := block.RunTransaction(func(context TransactionContext) error {
@@ -110,7 +110,7 @@ func TestBlockContext_BeginTransaction_Parallel(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			wg.Add(loops)
 
-			for i := 0; i < loops; i++ {
+			for i := range loops {
 				go func(i int) {
 					defer wg.Done()
 					ctx, err := block.BeginTransaction()

--- a/go/carmen/configurations_test.go
+++ b/go/carmen/configurations_test.go
@@ -36,7 +36,6 @@ func TestConfiguration_OnlyContainsOfficialImplementations(t *testing.T) {
 
 func TestConfiguration_RegisteredConfigurationsCanBeUsed(t *testing.T) {
 	for config := range GetAllConfigurations() {
-		config := config
 		t.Run(config.String(), func(t *testing.T) {
 			t.Parallel()
 			db, err := OpenDatabase(t.TempDir(), config, testProperties)

--- a/go/carmen/database_test.go
+++ b/go/carmen/database_test.go
@@ -331,7 +331,7 @@ func TestHeadBlockContext_CanCreateSequenceOfBlocks(t *testing.T) {
 				t.Fatalf("failed to open database: %v", err)
 			}
 
-			for i := 0; i < 10; i++ {
+			for i := range 10 {
 				block, err := db.BeginBlock(uint64(i))
 				if err != nil {
 					t.Fatalf("failed to create block %d: %v", i, err)
@@ -831,7 +831,7 @@ func TestDatabase_CloseDB_Unfinished_Queries(t *testing.T) {
 
 	const loops = 10
 	ctxs := make([]HistoricBlockContext, 0, loops)
-	for i := 0; i < loops; i++ {
+	for range loops {
 		ctx, err := db.GetHistoricContext(0)
 		if err != nil {
 			t.Errorf("cannot get history: %v", err)
@@ -840,7 +840,7 @@ func TestDatabase_CloseDB_Unfinished_Queries(t *testing.T) {
 	}
 
 	// each close should fail as there are running queries
-	for i := 0; i < loops; i++ {
+	for i := range loops {
 		if err := db.Close(); !errors.Is(err, errBlockContextRunning) {
 			t.Fatalf("closing database should fail while block is not committed")
 		}
@@ -867,9 +867,9 @@ func TestDatabase_GetProof(t *testing.T) {
 	const numBlocks = 100
 	const numAccounts = 11
 	const numKeys = 12
-	for i := 0; i < numBlocks; i++ {
+	for i := range numBlocks {
 		if err := db.AddBlock(uint64(i), func(context HeadBlockContext) error {
-			for j := 0; j < numAccounts; j++ {
+			for j := range numAccounts {
 				if err := context.RunTransaction(func(tc TransactionContext) error {
 					addr := Address{byte(j)}
 					tc.CreateAccount(addr)
@@ -877,7 +877,7 @@ func TestDatabase_GetProof(t *testing.T) {
 					codeHashes[addr] = Hash(common.Keccak256([]byte{byte(j)}))
 					tc.SetNonce(addr, uint64(i<<8+j+1))
 					tc.AddBalance(addr, NewAmount(uint64(i<<8+j+1)))
-					for k := 0; k < numKeys; k++ {
+					for k := range numKeys {
 						key := Key{byte(k)}
 						tc.SetState(addr, key, Value{byte(i), byte(j), byte(k)})
 					}
@@ -898,7 +898,7 @@ func TestDatabase_GetProof(t *testing.T) {
 
 	// collect all roots
 	roots := make([]Hash, 0, numBlocks)
-	for i := 0; i < numBlocks; i++ {
+	for i := range numBlocks {
 		if err := db.QueryHistoricState(uint64(i), func(context QueryContext) {
 			roots = append(roots, context.GetStateHash())
 		}); err != nil {
@@ -909,16 +909,16 @@ func TestDatabase_GetProof(t *testing.T) {
 	sums := make(map[Address]Amount)
 
 	// proof properties
-	for i := 0; i < numBlocks; i++ {
+	for i := range numBlocks {
 		block, err := db.GetHistoricContext(uint64(i))
 		if err != nil {
 			t.Fatalf("cannot get block: %v", err)
 		}
 		// proof each account and all keys of the account
-		for j := 0; j < numAccounts; j++ {
+		for j := range numAccounts {
 			addr := Address{byte(j)}
 			keys := make([]Key, 0, numKeys)
-			for k := 0; k < numKeys; k++ {
+			for k := range numKeys {
 				keys = append(keys, Key{byte(k)})
 			}
 			proof, err := block.GetProof(addr, keys...)
@@ -975,7 +975,7 @@ func TestDatabase_GetProof(t *testing.T) {
 			}
 
 			/// proof keys
-			for k := 0; k < numKeys; k++ {
+			for k := range numKeys {
 				key := Key{byte(k)}
 				value, complete, err := proof.GetState(roots[i], addr, key)
 				if err != nil {
@@ -1009,14 +1009,14 @@ func TestDatabase_GetProof_Serialise_Deserialize(t *testing.T) {
 	const numBlocks = 100
 	const numAccounts = 11
 	const numKeys = 12
-	for i := 0; i < numBlocks; i++ {
+	for i := range numBlocks {
 		if err := db.AddBlock(uint64(i), func(context HeadBlockContext) error {
-			for j := 0; j < numAccounts; j++ {
+			for j := range numAccounts {
 				if err := context.RunTransaction(func(tc TransactionContext) error {
 					addr := Address{byte(j)}
 					tc.CreateAccount(addr)
 					tc.SetNonce(addr, uint64(i<<8+j+1))
-					for k := 0; k < numKeys; k++ {
+					for k := range numKeys {
 						key := Key{byte(k)}
 						tc.SetState(addr, key, Value{byte(i), byte(j), byte(k)})
 					}
@@ -1037,7 +1037,7 @@ func TestDatabase_GetProof_Serialise_Deserialize(t *testing.T) {
 
 	// collect all roots
 	roots := make([]Hash, 0, numBlocks)
-	for i := 0; i < numBlocks; i++ {
+	for i := range numBlocks {
 		if err := db.QueryHistoricState(uint64(i), func(context QueryContext) {
 			roots = append(roots, context.GetStateHash())
 		}); err != nil {
@@ -1047,16 +1047,16 @@ func TestDatabase_GetProof_Serialise_Deserialize(t *testing.T) {
 
 	// proof properties
 	serialized := make([]Bytes, 0, 1024)
-	for i := 0; i < numBlocks; i++ {
+	for i := range numBlocks {
 		block, err := db.GetHistoricContext(uint64(i))
 		if err != nil {
 			t.Fatalf("cannot get block: %v", err)
 		}
 		// proof each account and all keys of the account
-		for j := 0; j < numAccounts; j++ {
+		for j := range numAccounts {
 			addr := Address{byte(j)}
 			keys := make([]Key, 0, numKeys)
-			for k := 0; k < numKeys; k++ {
+			for k := range numKeys {
 				keys = append(keys, Key{byte(k)})
 			}
 			proof, err := block.GetProof(addr, keys...)
@@ -1075,8 +1075,8 @@ func TestDatabase_GetProof_Serialise_Deserialize(t *testing.T) {
 	}
 
 	recovered := CreateWitnessProofFromNodes(serialized...)
-	for i := 0; i < numBlocks; i++ {
-		for j := 0; j < numAccounts; j++ {
+	for i := range numBlocks {
+		for j := range numAccounts {
 			addr := Address{byte(j)}
 
 			nonce, complete, err := recovered.GetNonce(roots[i], addr)
@@ -1093,7 +1093,7 @@ func TestDatabase_GetProof_Serialise_Deserialize(t *testing.T) {
 			}
 
 			/// proof keys
-			for k := 0; k < numKeys; k++ {
+			for k := range numKeys {
 				key := Key{byte(k)}
 				value, complete, err := recovered.GetState(roots[i], addr, key)
 				if err != nil {
@@ -1121,7 +1121,7 @@ func TestDatabase_GetProof_Extract_SubProofs(t *testing.T) {
 	const numKeys = 12
 
 	keys := make([]Key, 0, numKeys)
-	for k := 0; k < numKeys; k++ {
+	for k := range numKeys {
 		keys = append(keys, Key{byte(k)})
 	}
 
@@ -1133,7 +1133,7 @@ func TestDatabase_GetProof_Extract_SubProofs(t *testing.T) {
 				tc.SetNonce(addr, uint64(j))
 				if j > 1 { // the second account will have no code and state
 					tc.SetCode(addr, []byte{byte(j)})
-					for k := 0; k < numKeys; k++ {
+					for k := range numKeys {
 						tc.SetState(addr, keys[k], Value{byte(j), byte(k)})
 					}
 				}
@@ -1168,7 +1168,7 @@ func TestDatabase_GetProof_Extract_SubProofs(t *testing.T) {
 	// proof each account and all keys of the account
 	shadowProofs := make(map[Address]WitnessProof, numAccounts)
 	serialized := make([]Bytes, 0, 1024)
-	for j := 0; j < numAccounts; j++ {
+	for j := range numAccounts {
 		addr := Address{byte(j)}
 		proof, err := block.GetProof(addr, keys...)
 		if err != nil {
@@ -1188,7 +1188,7 @@ func TestDatabase_GetProof_Extract_SubProofs(t *testing.T) {
 
 	recovered := CreateWitnessProofFromNodes(serialized...)
 	t.Run("extract subproofs", func(t *testing.T) {
-		for j := 0; j < numAccounts; j++ {
+		for j := range numAccounts {
 			addr := Address{byte(j)}
 			wantProof := shadowProofs[addr]
 
@@ -1218,7 +1218,7 @@ func TestDatabase_GetProof_Extract_SubProofs(t *testing.T) {
 	})
 
 	t.Run("extract account and storage nodes", func(t *testing.T) {
-		for j := 0; j < numAccounts; j++ {
+		for j := range numAccounts {
 			addr := Address{byte(j)}
 
 			// extract address nodes only
@@ -1510,7 +1510,7 @@ func TestDatabase_BeginBlock_Parallel(t *testing.T) {
 	success := &atomic.Int32{}
 	wg := &sync.WaitGroup{}
 	wg.Add(loops)
-	for i := 0; i < loops; i++ {
+	for i := range loops {
 		go func(i int) {
 			defer wg.Done()
 			bctx, err := db.BeginBlock(uint64(i))
@@ -1547,7 +1547,7 @@ func TestDatabase_AddBlock_Parallel(t *testing.T) {
 	success := &atomic.Int32{}
 	wg := &sync.WaitGroup{}
 	wg.Add(loops)
-	for i := 0; i < loops; i++ {
+	for i := range loops {
 		go func(i int) {
 			defer wg.Done()
 			err := db.AddBlock(uint64(i), func(context HeadBlockContext) error {
@@ -1579,7 +1579,7 @@ func TestDatabase_GetHistoricBlock_Parallel(t *testing.T) {
 	}
 
 	// init a few blocks
-	for i := 0; i < loops; i++ {
+	for i := range loops {
 		if err := db.AddBlock(uint64(i), func(context HeadBlockContext) error {
 			return nil
 		}); err != nil {
@@ -1593,7 +1593,7 @@ func TestDatabase_GetHistoricBlock_Parallel(t *testing.T) {
 
 	wg := &sync.WaitGroup{}
 	wg.Add(loops)
-	for i := 0; i < loops; i++ {
+	for i := range loops {
 		go func(i int) {
 			defer wg.Done()
 			bctx, err := db.GetHistoricContext(uint64(i))
@@ -1622,7 +1622,7 @@ func TestDatabase_QueryBlock_Parallel(t *testing.T) {
 	}
 
 	// init a few blocks
-	for i := 0; i < loops; i++ {
+	for i := range loops {
 		if err := db.AddBlock(uint64(i), func(context HeadBlockContext) error {
 			return nil
 		}); err != nil {
@@ -1636,7 +1636,7 @@ func TestDatabase_QueryBlock_Parallel(t *testing.T) {
 
 	wg := &sync.WaitGroup{}
 	wg.Add(loops)
-	for i := 0; i < loops; i++ {
+	for i := range loops {
 		go func(i int) {
 			defer wg.Done()
 			if err := db.QueryBlock(uint64(i), func(context HistoricBlockContext) error {
@@ -1663,7 +1663,7 @@ func TestDatabase_AddBlock_QueryBlock_Parallel(t *testing.T) {
 	}
 
 	// init a few blocks
-	for i := 0; i < loops; i++ {
+	for i := range loops {
 		if err := db.AddBlock(uint64(i), func(context HeadBlockContext) error {
 			return nil
 		}); err != nil {
@@ -1678,7 +1678,7 @@ func TestDatabase_AddBlock_QueryBlock_Parallel(t *testing.T) {
 	// keep adding more blocks while querying already created once
 	wg := &sync.WaitGroup{}
 	wg.Add(loops)
-	for i := 0; i < loops; i++ {
+	for i := range loops {
 		go func(i int) {
 			defer wg.Done()
 			if err := db.QueryBlock(uint64(i), func(context HistoricBlockContext) error {
@@ -1691,7 +1691,7 @@ func TestDatabase_AddBlock_QueryBlock_Parallel(t *testing.T) {
 
 	wg.Add(loops)
 	added := &atomic.Int32{}
-	for i := 0; i < loops; i++ {
+	for i := range loops {
 		go func(block int) {
 			defer wg.Done()
 			if err := db.AddBlock(uint64(block), func(context HeadBlockContext) error {
@@ -1843,7 +1843,7 @@ func TestDatabase_Historic_Block_Available(t *testing.T) {
 
 	var transactions int
 	// query historic blocks
-	for i := 0; i < loops; i++ {
+	for i := range loops {
 		err := db.QueryBlock(uint64(i), func(context HistoricBlockContext) error {
 			if err := context.RunTransaction(func(context TransactionContext) error {
 				if got, want := context.GetBalance(addr), NewAmount(uint64(i*100)+1000); got != want {
@@ -1876,7 +1876,7 @@ func TestDatabase_StartBulkLoad_Can_Run_Consecutive(t *testing.T) {
 		t.Fatalf("failed to open database: %v", err)
 	}
 
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		ctx, err := db.StartBulkLoad(uint64(i))
 		if err != nil {
 			t.Errorf("cannot start bulk load: %v", err)
@@ -1999,7 +1999,7 @@ func TestDatabase_Async_AddBlock_QueryHistory_Close_ShouldNotThrowUnexpectedErro
 
 	// init a few blocks
 	const loops = 10
-	for i := 0; i < loops; i++ {
+	for i := range loops {
 		if err := addBlock(uint64(i)); err != nil {
 			t.Fatalf("cannot add block: %v", err)
 		}
@@ -2135,7 +2135,7 @@ func TestDatabase_Async_QueryHead_Accesses_ConsistentState(t *testing.T) {
 	// Have a few goroutines testing that nonces are in sync.
 	var group sync.WaitGroup
 	group.Add(numReaders)
-	for i := 0; i < numReaders; i++ {
+	for range numReaders {
 		go func() {
 			defer group.Done()
 			nonce := uint64(0)
@@ -2321,7 +2321,7 @@ func TestDatabase_Export(t *testing.T) {
 
 	const N = 3
 
-	for i := 0; i < N; i++ {
+	for i := range N {
 		if err = db.AddBlock(uint64(i), func(context HeadBlockContext) error {
 			if err = context.RunTransaction(func(context TransactionContext) error {
 				context.CreateAccount(Address{byte(i)})
@@ -2428,12 +2428,12 @@ func TestHeadBlockContext_Can_Update_Code(t *testing.T) {
 	const transactions = 12
 
 	// create a few blocks with transactions updating code
-	for i := 0; i < blocks; i++ {
+	for i := range blocks {
 		code := make([]byte, i+2)
 		code[i+1] = byte(i) // code size is growing, last byte is the index of the block, first byte is txs index
 		if err := db.AddBlock(uint64(i), func(context HeadBlockContext) error {
 			// insert transactions updating code
-			for j := 0; j < transactions; j++ {
+			for j := range transactions {
 				if err := context.RunTransaction(func(context TransactionContext) error {
 					code[0] = byte(j)
 					context.SetCode(addr, code)
@@ -2486,12 +2486,12 @@ func TestDatabase_Codes_Versioned_Archive(t *testing.T) {
 	codeHashes := make([]Hash, 0, blocks)
 
 	// create a few blocks with transactions updating code
-	for i := 0; i < blocks; i++ {
+	for i := range blocks {
 		code := make([]byte, i+2)
 		code[i+1] = byte(i) // code size is growing, last byte is the index of the block, first byte is txs index
 		if err := db.AddBlock(uint64(i), func(context HeadBlockContext) error {
 			// insert transactions updating code
-			for j := 0; j < transactions; j++ {
+			for j := range transactions {
 				if err := context.RunTransaction(func(context TransactionContext) error {
 					code[0] = byte(j)
 					context.SetCode(addr, code)
@@ -2517,7 +2517,7 @@ func TestDatabase_Codes_Versioned_Archive(t *testing.T) {
 		t.Fatalf("cannot flush db: %v", err)
 	}
 
-	for i := 0; i < blocks; i++ {
+	for i := range blocks {
 		if err := db.QueryHistoricState(uint64(i), func(context QueryContext) {
 			if got, want := context.GetCodeHash(addr), codeHashes[i]; got != want {
 				t.Errorf("error retrieving code hash, wanted %v, got %v", want, got)
@@ -2557,11 +2557,9 @@ func TestDatabase_Archive_Query_Proof_While_Updating_Race_Detection(t *testing.T
 
 	const workers = 100
 
-	for i := 0; i < workers; i++ {
-		wg.Add(1)
+	for range workers {
 		// query proof in parallel to appending data to the archive
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			// a tight loop querying the archive
 			for run.Load() {
 				lastBlock, err := db.GetArchiveBlockHeight()
@@ -2573,7 +2571,7 @@ func TestDatabase_Archive_Query_Proof_While_Updating_Race_Detection(t *testing.T
 				}
 
 				if err := db.QueryBlock(uint64(lastBlock), func(context HistoricBlockContext) error {
-					for j := 0; j < keys; j++ {
+					for j := range keys {
 						key := Key{byte(j), byte(j >> 8), byte(lastBlock), byte(lastBlock >> 8)}
 						if _, err := context.GetProof(addr, key); err != nil {
 							return err
@@ -2585,14 +2583,14 @@ func TestDatabase_Archive_Query_Proof_While_Updating_Race_Detection(t *testing.T
 					t.Errorf("failed to query archive state: %v", err)
 				}
 			}
-		}()
+		})
 	}
 
-	for i := 0; i < blocks; i++ {
+	for i := range blocks {
 		if err := db.AddBlock(uint64(i), func(context HeadBlockContext) error {
 			if err := context.RunTransaction(func(context TransactionContext) error {
 				context.AddBalance(addr, NewAmount(uint64(i)))
-				for j := 0; j < keys; j++ {
+				for j := range keys {
 					key := Key{byte(j), byte(j >> 8), byte(i), byte(i >> 8)}
 					value := Value{byte(j), byte(j >> 8), byte(i), byte(i >> 8)}
 					context.SetState(addr, key, value)

--- a/go/carmen/example_test.go
+++ b/go/carmen/example_test.go
@@ -303,7 +303,7 @@ func ExampleHistoricBlockContext_GetProof() {
 
 	const N = 10
 	// Add N blocks with one address and storage slot each
-	for i := 0; i < N; i++ {
+	for i := range N {
 		if err := db.AddBlock(uint64(i), func(context carmen.HeadBlockContext) error {
 			if err := context.RunTransaction(func(context carmen.TransactionContext) error {
 				context.CreateAccount(carmen.Address{byte(i)})
@@ -328,7 +328,7 @@ func ExampleHistoricBlockContext_GetProof() {
 
 	completeProof := make(map[carmen.Bytes]struct{}, 1024)
 	// proof each address and key from each block, and merge all in one proof
-	for i := 0; i < N; i++ {
+	for i := range N {
 		if err := db.QueryBlock(uint64(i), func(ctxt carmen.HistoricBlockContext) error {
 			proof, err := ctxt.GetProof(carmen.Address{byte(i)}, carmen.Key{byte(i)})
 			if err != nil {
@@ -347,7 +347,7 @@ func ExampleHistoricBlockContext_GetProof() {
 	}
 
 	rootHashes := make([]carmen.Hash, N)
-	for i := 0; i < N; i++ {
+	for i := range N {
 		if err := db.QueryHistoricState(uint64(i), func(ctxt carmen.QueryContext) {
 			rootHashes[i] = ctxt.GetStateHash()
 		}); err != nil {
@@ -368,7 +368,7 @@ func ExampleHistoricBlockContext_GetProof() {
 	recoveredProof := carmen.CreateWitnessProofFromNodes(slices.Collect(maps.Keys(completeProof))...)
 
 	// ------- Properties can be proven offline  -------
-	for i := 0; i < N; i++ {
+	for i := range N {
 		{
 			// query account balance
 			balance, complete, err := recoveredProof.GetBalance(rootHashes[i], carmen.Address{byte(i)})

--- a/go/carmen/experimental/configurations_test.go
+++ b/go/carmen/experimental/configurations_test.go
@@ -29,7 +29,6 @@ func TestConfigurations_ConfigurationsAreRegisteredGlobally(t *testing.T) {
 
 func TestConfiguration_RegisteredConfigurationsCanBeUsed(t *testing.T) {
 	for config := range carmen.GetAllConfigurations() {
-		config := config
 		t.Run(config.String(), func(t *testing.T) {
 			t.Parallel()
 			db, err := carmen.OpenDatabase(t.TempDir(), config, nil)

--- a/go/carmen/proof_test.go
+++ b/go/carmen/proof_test.go
@@ -23,7 +23,7 @@ func TestProof_CreateWitnessProofFromNodes(t *testing.T) {
 
 	wantElements := make([]Bytes, 0, N)
 	b := make([]byte, 0, N)
-	for i := 0; i < N; i++ {
+	for i := range N {
 		b = append(b, byte(i))
 		wantElements = append(wantElements, immutable.NewBytes(b))
 	}

--- a/go/common/amount/amount.go
+++ b/go/common/amount/amount.go
@@ -34,7 +34,7 @@ func New(args ...uint64) Amount {
 	}
 	result := Amount{}
 	offset := 4 - len(args)
-	for i := 0; i < len(args); i++ {
+	for i := range args {
 		result.internal[3-i-offset] = args[i]
 	}
 	return result

--- a/go/common/benchmarkhasher_test.go
+++ b/go/common/benchmarkhasher_test.go
@@ -191,7 +191,7 @@ func BenchmarkMapHashCompute32BytesInLoop(b *testing.B) {
 	for j := 1; j <= b.N; j++ {
 
 		hash := uint64(17)
-		for i := 0; i < 32; i++ {
+		for i := range 32 {
 			hash = hash*prime + uint64(data[i])
 		}
 

--- a/go/common/cache_benchmark_test.go
+++ b/go/common/cache_benchmark_test.go
@@ -23,7 +23,7 @@ func BenchmarkCacheMissLatency(b *testing.B) {
 	for name, c := range initCaches(cacheSize) {
 		b.Run(fmt.Sprintf("cache %s", name), func(b *testing.B) {
 			b.StopTimer()
-			for i := 0; i < cacheSize; i++ {
+			for i := range cacheSize {
 				c.Set(i, i)
 			}
 			b.StartTimer()
@@ -43,7 +43,7 @@ func BenchmarkCacheHitLatency(b *testing.B) {
 	for name, c := range initCaches(cacheSize) {
 		b.Run(fmt.Sprintf("cache %s", name), func(b *testing.B) {
 			b.StopTimer()
-			for i := 0; i < cacheSize; i++ {
+			for i := range cacheSize {
 				c.Set(i, i)
 			}
 			b.StartTimer()
@@ -94,7 +94,7 @@ func BenchmarkCacheSingleThreadReads(b *testing.B) {
 
 	for name, c := range initCaches(N) {
 		b.StopTimer()
-		for i := 0; i < N; i++ {
+		for i := range N {
 			c.Set(keys[i], i)
 		}
 		b.StartTimer()
@@ -108,7 +108,7 @@ func BenchmarkCacheSingleThreadReads(b *testing.B) {
 
 func generateRandomKeys(count int) []int {
 	keys := make([]int, 0, count)
-	for i := 0; i < count; i++ {
+	for range count {
 		keys = append(keys, rand.Intn(1024*count))
 	}
 	return keys

--- a/go/common/cache_fuzzing_test.go
+++ b/go/common/cache_fuzzing_test.go
@@ -61,11 +61,11 @@ type cacheFuzzingCampaign struct {
 
 func (c *cacheFuzzingCampaign) Init() []fuzzing.OperationSequence[cacheFuzzingContext] {
 	setMany := make([]fuzzing.Operation[cacheFuzzingContext], 0, 255)
-	for i := 0; i < 255; i++ {
+	for i := range 255 {
 		setMany = append(setMany, &opSet{int8(i), int16(i * 100)})
 	}
 	getMany := make([]fuzzing.Operation[cacheFuzzingContext], 0, 255)
-	for i := 0; i < 255; i++ {
+	for i := range 255 {
 		getMany = append(getMany, &opGet{int8(i)})
 	}
 

--- a/go/common/cache_test.go
+++ b/go/common/cache_test.go
@@ -133,7 +133,7 @@ func TestCache_Clear_FullCache(t *testing.T) {
 		t.Run(fmt.Sprintf("cache %s", name), func(t *testing.T) {
 			// insert test data
 			inserted := make(map[int]int)
-			for i := 0; i < 255; i++ {
+			for i := range 255 {
 				inserted[i] = i * 100
 				c.Set(i, i*100)
 			}
@@ -403,7 +403,7 @@ func TestCache_Iterate_FullCache(t *testing.T) {
 		t.Run(fmt.Sprintf("cache %s", name), func(t *testing.T) {
 			// insert test data
 			expected := make(map[int]int)
-			for i := 0; i < 255; i++ {
+			for i := range 255 {
 				expected[i] = i * 100
 				evictedKey, _, evicted := c.Set(i, i*100)
 				if evicted {
@@ -443,7 +443,7 @@ func EvalPrintNumberOfEvictions() {
 
 	for name, c := range initCaches(CAPACITY) {
 		evictions[name] = 0
-		for i := 0; i < N; i++ {
+		for i := range N {
 			if _, _, evicted := c.Set(keys[i], i); evicted {
 				evictions[name]++
 			}

--- a/go/common/cached_hasher_benchmark_test.go
+++ b/go/common/cached_hasher_benchmark_test.go
@@ -42,7 +42,7 @@ func BenchmarkAddressHitLatency(b *testing.B) {
 	cacheSize := 1000
 	hasher := NewCachedHasher[Address](cacheSize, AddressSerializer{})
 	addresses := make([]Address, 0, cacheSize)
-	for i := 0; i < cacheSize; i++ {
+	for i := range cacheSize {
 		arr := binary.BigEndian.AppendUint32([]byte{}, uint32(i))
 		var addr Address
 		copy(addr[:], arr)
@@ -71,7 +71,7 @@ func BenchmarkKeyHitLatency(b *testing.B) {
 	cacheSize := 1000
 	hasher := NewCachedHasher[Key](cacheSize, KeySerializer{})
 	keys := make([]Key, 0, cacheSize)
-	for i := 0; i < cacheSize; i++ {
+	for i := range cacheSize {
 		arr := binary.BigEndian.AppendUint32([]byte{}, uint32(i))
 		var key Key
 		copy(key[:], arr)

--- a/go/common/cached_hasher_test.go
+++ b/go/common/cached_hasher_test.go
@@ -59,7 +59,7 @@ func TestMemoryFootprint(t *testing.T) {
 
 	// fully utilised cache
 	var adr Address
-	for i := 0; i < cacheSize; i++ {
+	for i := range cacheSize {
 		if got, want := hasher.Hash(adr), GetHash(sha3.NewLegacyKeccak256(), adr[:]); got != want {
 			t.Errorf("hashes do not match: %v != %v", got, want)
 		}

--- a/go/common/distribution_test.go
+++ b/go/common/distribution_test.go
@@ -25,7 +25,7 @@ func TestDistribution_ReturnRandValues(t *testing.T) {
 				dis := dis
 				t.Parallel()
 				data := make([]uint32, 0, nums)
-				for i := 0; i < nums; i++ {
+				for range nums {
 					data = append(data, dis.GetNext())
 				}
 				// test that at least 30% of values is not the same

--- a/go/common/fast_map_test.go
+++ b/go/common/fast_map_test.go
@@ -215,8 +215,8 @@ func TestMapInsertedIsContainedExhaustive(t *testing.T) {
 		data := config.get()
 		t.Run(config.name, func(t *testing.T) {
 			key := Key{}
-			for i := 0; i < N; i++ {
-				for j := 0; j < N; j++ {
+			for i := range N {
+				for j := range N {
 					key[30] = byte(j >> 8)
 					key[31] = byte(j)
 					want := j < i
@@ -268,7 +268,7 @@ func TestMapDeleteRemovesSelectedKeyFromBucket(t *testing.T) {
 				t.Errorf("Failed to delete key 10")
 			}
 
-			for i := 0; i < 10; i++ {
+			for i := range 10 {
 				// all other keys should still be there
 				key := Key{byte(i)}
 				if _, exists := data.Get(key); !exists {
@@ -333,12 +333,12 @@ func TestMapClearRemovesAllContent(t *testing.T) {
 		data := config.get()
 		t.Run(config.name, func(t *testing.T) {
 			key := Key{}
-			for i := 0; i < N; i++ {
+			for i := range N {
 				key[30] = byte(i >> 8)
 				key[31] = byte(i)
 				data.Put(key, i)
 			}
-			for i := 0; i < N; i++ {
+			for i := range N {
 				key[30] = byte(i >> 8)
 				key[31] = byte(i)
 				if value, exists := data.Get(key); !exists || value != i {
@@ -346,7 +346,7 @@ func TestMapClearRemovesAllContent(t *testing.T) {
 				}
 			}
 			data.Clear()
-			for i := 0; i < N; i++ {
+			for i := range N {
 				key[30] = byte(i >> 8)
 				key[31] = byte(i)
 				if _, exists := data.Get(key); exists {
@@ -439,7 +439,7 @@ func TestMapForEachVisitsAllElements(t *testing.T) {
 		t.Run(config.name, func(t *testing.T) {
 			data := config.get()
 
-			for i := 0; i < 100; i++ {
+			for i := range 100 {
 				elements := map[Key]int{}
 				data.ForEach(func(key Key, value int) {
 					_, exists := elements[key]
@@ -474,7 +474,7 @@ func TestMap_Fill_All_Generations(t *testing.T) {
 
 	// fill in data
 	var k Key
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		m.Put(k, i)
 		k[i%32]++
 	}
@@ -493,7 +493,7 @@ func TestMap_Fill_All_Generations(t *testing.T) {
 	}
 
 	// have to use all generations
-	for i := 0; i < 1<<16; i++ {
+	for range 1 << 16 {
 		m.Clear()
 	}
 
@@ -516,7 +516,7 @@ func TestFastMap_CopyTo(t *testing.T) {
 
 	// fill in data
 	var k Key
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		m.Put(k, i)
 		k[i%32]++
 	}
@@ -640,7 +640,7 @@ func TestFastMap_DeepEqual(t *testing.T) {
 func TestMap_Internal_Negative_Position(t *testing.T) {
 	m := NewFastMap[Key, int](KeyShortHasher{})
 
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		num := uint64(rand.Int63()) | uint64(1<<63) // always negative num
 		if got, want := m.toPtr(int64(num)), num; got != fmPtr(want) {
 			t.Errorf("negative value should be returned unchanged: %d != %d", got, want)
@@ -656,7 +656,7 @@ func BenchmarkMapInsertAndClear(b *testing.B) {
 		b.Run(config.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				key[31] = byte(rand.Intn(256))
-				for j := 0; j < 100; j++ {
+				for j := range 100 {
 					key[31] *= 7
 					data.Put(key, j)
 				}
@@ -792,17 +792,17 @@ func FuzzMapOperations(f *testing.F) {
 
 	// Test a full map
 	cmds := make([]command, 0, 256)
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		cmds = append(cmds, put{byte(i), ^byte(i)})
 	}
 	f.Add(toBytes(cmds))
 
 	// A case where all elements are added and removed.
 	cmds = cmds[0:0]
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		cmds = append(cmds, put{byte(i), ^byte(i)})
 	}
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		cmds = append(cmds, remove{byte(i)})
 	}
 	f.Add(toBytes(cmds))
@@ -824,7 +824,7 @@ func FuzzMapOperations(f *testing.F) {
 				return
 			}
 
-			for i := 0; i < 256; i++ {
+			for i := range 256 {
 				want_value, want_exists := ref[byte(i)]
 				have_value, have_exists := trg.Get(byte(i))
 				if want_exists != have_exists {

--- a/go/common/heap/heap_test.go
+++ b/go/common/heap/heap_test.go
@@ -21,7 +21,7 @@ func TestHeap_ElementsAreSorted(t *testing.T) {
 
 	// Create a shuffled list of entries and add them to the queue.
 	entries := make([]int, N)
-	for i := 0; i < N; i++ {
+	for i := range N {
 		entries[i] = i
 	}
 	rand.Shuffle(len(entries), func(i, j int) {
@@ -65,7 +65,7 @@ func TestHeap_ElementsAreSorted(t *testing.T) {
 func TestHeap_ZeroHeapCanBeUsedToStoreAndRetrieveElements(t *testing.T) {
 	queue := Heap[int]{}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		queue.Add(i)
 	}
 
@@ -89,11 +89,11 @@ func TestHeap_ZeroHeapCanBeUsedToStoreAndRetrieveElements(t *testing.T) {
 func TestHeap_ContainsCanLocateElements(t *testing.T) {
 	queue := Heap[int]{}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		queue.Add(i)
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if !queue.ContainsFunc(func(cur int) bool { return cur == i }) {
 			t.Fatalf("expected to find element %d", i)
 		}

--- a/go/common/keccak_test.go
+++ b/go/common/keccak_test.go
@@ -46,7 +46,7 @@ func TestKeccakC_AddressSpecializationProducesSameHashAsGenericVersion(t *testin
 	}
 
 	// Test each individual bit.
-	for i := 0; i < 20*8; i++ {
+	for i := range 20 * 8 {
 		addr := Address{}
 		addr[i/8] = 1 << i % 8
 		tests = append(tests, addr)
@@ -54,7 +54,7 @@ func TestKeccakC_AddressSpecializationProducesSameHashAsGenericVersion(t *testin
 
 	// Add some random inputs as well.
 	r := rand.New(rand.NewSource(99))
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		addr := Address{}
 		r.Read(addr[:])
 		tests = append(tests, addr)
@@ -96,7 +96,7 @@ func TestKeccakC_KeySpecializationProducesSameHashAsGenericVersion(t *testing.T)
 	}
 
 	// Test each individual bit.
-	for i := 0; i < 32*8; i++ {
+	for i := range 32 * 8 {
 		key := Key{}
 		key[i/8] = 1 << i % 8
 		tests = append(tests, key)
@@ -104,7 +104,7 @@ func TestKeccakC_KeySpecializationProducesSameHashAsGenericVersion(t *testing.T)
 
 	// Add some random inputs as well.
 	r := rand.New(rand.NewSource(99))
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		key := Key{}
 		r.Read(key[:])
 		tests = append(tests, key)

--- a/go/common/lock_file_test.go
+++ b/go/common/lock_file_test.go
@@ -135,10 +135,10 @@ func TestLockFile_GovernsExclusiveAccessForSingleProcess(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(N)
-	for i := 0; i < N; i++ {
+	for i := range N {
 		go func(i int) {
 			defer wg.Done()
-			for j := 0; j < 100; j++ {
+			for range 100 {
 				lock, err := CreateLockFile(path)
 				if err != nil {
 					continue
@@ -176,10 +176,10 @@ func TestLockFile_GovernsExclusiveAccessForMultipleProcesses(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(N)
-	for i := 0; i < N; i++ {
+	for i := range N {
 		go func(i int) {
 			defer wg.Done()
-			for j := 0; j < 100; j++ {
+			for range 100 {
 				execFileLockAcquireInSubProcess(t, path, resource)
 			}
 		}(i)

--- a/go/common/mem_footprint.go
+++ b/go/common/mem_footprint.go
@@ -12,7 +12,7 @@ package common
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -92,7 +92,7 @@ func (mf *MemoryFootprint) toStringBuilder(sb *strings.Builder, path string) {
 	for name := range mf.children {
 		names = append(names, name)
 	}
-	sort.Slice(names, func(i, j int) bool { return names[i] < names[j] })
+	slices.Sort(names)
 
 	for _, name := range names {
 		footprint := mf.children[name]

--- a/go/common/nways_cache_benchmark_test.go
+++ b/go/common/nways_cache_benchmark_test.go
@@ -58,7 +58,7 @@ func BenchmarkNWaysParallelReads(b *testing.B) {
 	for ways := 2; ways <= 32; ways *= 2 {
 		b.StopTimer()
 		c := NewNWaysCache[int, int](N, ways)
-		for i := 0; i < N; i++ {
+		for i := range N {
 			c.Set(keys[i], i)
 		}
 		b.StartTimer()

--- a/go/common/nways_cache_test.go
+++ b/go/common/nways_cache_test.go
@@ -158,13 +158,13 @@ func TestNWaysCacheSetGetVariousConfigurations(t *testing.T) {
 	for ways := 2; ways < capacity; ways *= 2 {
 		t.Run(fmt.Sprintf("ways: %d", ways), func(t *testing.T) {
 			c := NewNWaysCache[int, int](capacity, ways)
-			for i := 0; i < capacity; i++ {
+			for i := range capacity {
 				if evictedKey, evictedVal, evicted := c.Set(i, i); evictedKey != 0 || evictedVal != 0 || evicted {
 					t.Errorf("No value should be evicted when adding: %d", i)
 				}
 			}
 
-			for want := 0; want < capacity; want++ {
+			for want := range capacity {
 				got, exists := c.Get(want)
 				if !exists {
 					t.Errorf("key should exist: %d", want)
@@ -183,7 +183,7 @@ func TestNWaysCacheSetGetMissingValuesVariousConfigurations(t *testing.T) {
 	for ways := 2; ways < capacity; ways *= 2 {
 		t.Run(fmt.Sprintf("ways: %d", ways), func(t *testing.T) {
 			c := NewNWaysCache[int, int](capacity, ways)
-			for i := 0; i < capacity; i++ {
+			for i := range capacity {
 				if evictedKey, evictedVal, evicted := c.Set(i, i); evictedKey != 0 || evictedVal != 0 || evicted {
 					t.Errorf("No value should be evicted when adding: %d", i)
 				}
@@ -255,7 +255,7 @@ func TestNWaysCache_Concurrent_ReadsWrites(t *testing.T) {
 
 	// generate keys
 	keys := make(map[int]bool, loops)
-	for i := 0; i < loops; i++ {
+	for range loops {
 		key := rand.Intn(2048)
 		keys[key] = true
 	}
@@ -298,7 +298,7 @@ func TestNWaysCache_Concurrent_Sequence(t *testing.T) {
 		t.Run(fmt.Sprintf("iter %v", withIter), func(t *testing.T) {
 			c := NewNWaysCache[int, int](1024, 16)
 			var wg sync.WaitGroup
-			for i := 0; i < loops; i++ {
+			for i := range loops {
 				wg.Add(1)
 				go func(key, val int, withIter bool) {
 					defer wg.Done()

--- a/go/common/ticker/ticker_test.go
+++ b/go/common/ticker/ticker_test.go
@@ -21,7 +21,7 @@ func TestTicker_Ticks(t *testing.T) {
 	ticker := NewTimeTicker(10 * time.Millisecond)
 
 	const loops = 100
-	for i := 0; i < loops; i++ {
+	for i := range loops {
 		tick := <-ticker.C()
 		if tick.Before(last) {
 			t.Errorf("tick %d is before last tick: %v < %v", i, last, tick)

--- a/go/common/types_test.go
+++ b/go/common/types_test.go
@@ -209,7 +209,7 @@ func TestTypes_Hash(t *testing.T) {
 
 func testTypesHash[T any](t *testing.T, next func() *T, h Hasher[T]) {
 	var prev uint64
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		hash := h.Hash(next())
 		if hash == 0 {
 			t.Errorf("hash is zero")
@@ -223,7 +223,7 @@ func testTypesHash[T any](t *testing.T, next func() *T, h Hasher[T]) {
 
 func TestTypes_HashToBytes(t *testing.T) {
 	var v Hash
-	for i := 0; i < 32; i++ {
+	for i := range 32 {
 		v[i]++
 	}
 	b := v.ToBytes()
@@ -232,7 +232,7 @@ func TestTypes_HashToBytes(t *testing.T) {
 		t.Errorf("sizes do not match: %d != %d", got, want)
 	}
 
-	for i := 0; i < len(b); i++ {
+	for i := range b {
 		if got, want := b[i], v[i]; got != want {
 			t.Errorf("bytes do not match: %d != %d (pos: %d)", b, v, i)
 		}

--- a/go/common/update_test.go
+++ b/go/common/update_test.go
@@ -347,7 +347,7 @@ func TestUpdateParsingTruncatedDataShouldFailWithError(t *testing.T) {
 	update := getExampleUpdate()
 	data := update.ToBytes()
 	// Test that no panic is triggered.
-	for i := 0; i < len(data); i++ {
+	for i := range data {
 		if _, err := UpdateFromBytes(data[0:i]); err == nil {
 			t.Errorf("parsing of truncated data should fail")
 		}
@@ -382,7 +382,7 @@ func TestUpdate_ApplyTo(t *testing.T) {
 
 func TestUpdate_ApplyTo_Failures(t *testing.T) {
 	const calls = 4
-	for i := 0; i < calls; i++ {
+	for i := range calls {
 		i := i
 		t.Run(fmt.Sprintf("applyTo_failure_at_%d", i), func(t *testing.T) {
 			t.Parallel()

--- a/go/database/mpt/archive_trie_fuzzing_test.go
+++ b/go/database/mpt/archive_trie_fuzzing_test.go
@@ -194,7 +194,7 @@ func fuzzArchiveTrieRandomAccountOps(f *testing.F) {
 		var nonce2 common.Nonce
 		var nonce3 common.Nonce
 
-		for i := 0; i < common.NonceSize; i++ {
+		for i := range common.NonceSize {
 			nonce2[i] = byte(i + 1)
 			nonce3[i] = byte(0xFF)
 		}
@@ -203,7 +203,7 @@ func fuzzArchiveTrieRandomAccountOps(f *testing.F) {
 		var balance2 [amount.BytesLength]byte
 		var balance3 [amount.BytesLength]byte
 
-		for i := 0; i < amount.BytesLength; i++ {
+		for i := range amount.BytesLength {
 			balance2[i] = byte(i + 1)
 			balance3[i] = byte(0xFF)
 		}
@@ -212,7 +212,7 @@ func fuzzArchiveTrieRandomAccountOps(f *testing.F) {
 		var codeHash2 common.Hash
 		var codeHash3 common.Hash
 
-		for i := 0; i < common.HashSize; i++ {
+		for i := range common.HashSize {
 			codeHash2[i] = byte(i + 1)
 			codeHash3[i] = byte(0xFF)
 		}
@@ -588,7 +588,7 @@ func fuzzArchiveTrieRandomAccountStorageOps(f *testing.F) {
 		var value2 common.Value
 		var value3 common.Value
 
-		for i := 0; i < common.ValueSize; i++ {
+		for i := range common.ValueSize {
 			value2[i] = byte(i + 1)
 			value3[i] = byte(0xFF)
 		}

--- a/go/database/mpt/archive_trie_test.go
+++ b/go/database/mpt/archive_trie_test.go
@@ -76,7 +76,7 @@ func TestArchiveTrie_CanOnlyBeOpenedOnce(t *testing.T) {
 
 func TestArchiveTrie_CanBeReOpened(t *testing.T) {
 	dir := t.TempDir()
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 		if err != nil {
 			t.Fatalf("failed to open test archive: %v", err)
@@ -99,7 +99,7 @@ func TestArchiveTrie_Reopen_PreservesAllBlockRootHashes(t *testing.T) {
 			archive, err := OpenArchiveTrie(dir, config, NodeCacheConfig{Capacity: 1024}, ArchiveConfig{})
 			require.NoError(err)
 
-			for i := 0; i < blocks; i++ {
+			for i := range blocks {
 				update := common.Update{
 					Balances: []common.BalanceUpdate{
 						{Account: common.Address{byte(i + 1)}, Balance: amount.New(uint64(i + 1))},
@@ -122,7 +122,7 @@ func TestArchiveTrie_Reopen_PreservesAllBlockRootHashes(t *testing.T) {
 			require.False(empty)
 			require.Equal(uint64(blocks-1), height)
 
-			for i := 0; i < blocks; i++ {
+			for i := range blocks {
 				got, err := archive.GetHash(uint64(i))
 				require.NoError(err)
 				require.Equal(hashes[i], got, "hash mismatch for block %d", i)
@@ -140,7 +140,7 @@ func TestArchiveTrie_Open_LastCheckpointTimeIsSelectedRandomly(t *testing.T) {
 	deltas := []time.Duration{}
 
 	dir := t.TempDir()
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		archive, err := OpenArchiveTrie(dir, S5ArchiveConfig, NodeCacheConfig{Capacity: 1024}, config)
 		if err != nil {
 			t.Fatalf("cannot init archive trie: %v", err)
@@ -597,7 +597,7 @@ func TestArchiveTrie_VisitAccount(t *testing.T) {
 			// insert growing number of keys in several accounts
 			nonces := make([]common.NonceUpdate, 0, Addresses)
 			slotUpdates := make([]common.SlotUpdate, 0, Addresses*Addresses)
-			for i := 0; i < Addresses; i++ {
+			for i := range Addresses {
 				addr := common.AddressFromNumber(i)
 				slots := make([]common.SlotUpdate, 0, i+1)
 				for j := 0; j < i+1; j++ {
@@ -623,7 +623,7 @@ func TestArchiveTrie_VisitAccount(t *testing.T) {
 			}
 
 			// check the keys in the accounts are correct when visiting accounts
-			for i := 0; i < Addresses; i++ {
+			for i := range Addresses {
 				addr := common.AddressFromNumber(i)
 				visited := make(map[common.Key]common.Value)
 				if err := archive.VisitAccountStorage(2, addr, ReadAccess{}, MakeVisitor(func(node Node, _ NodeInfo) VisitResponse {
@@ -650,8 +650,8 @@ func TestArchiveTrie_VisitAccount(t *testing.T) {
 			}
 
 			// check there are no slots in blocks 0 and 1
-			for block := uint64(0); block < 2; block++ {
-				for i := 0; i < Addresses; i++ {
+			for block := range uint64(2) {
+				for i := range Addresses {
 					addr := common.AddressFromNumber(i)
 					if err := archive.VisitAccountStorage(block, addr, ReadAccess{}, MakeVisitor(func(node Node, _ NodeInfo) VisitResponse {
 						t.Errorf("unexpected node: %v", node)
@@ -703,7 +703,7 @@ func TestArchiveTrie_CanHandleEmptyBlocks(t *testing.T) {
 				t.Errorf("failed to add block: %v", err)
 			}
 
-			for i := 0; i < 5; i++ {
+			for i := range 5 {
 				got, err := archive.GetBalance(uint64(i), addr)
 				if err != nil || got != balance {
 					t.Errorf("wrong balance for block %d, got %v, wanted %v, err %v", i, got, balance, err)
@@ -787,7 +787,7 @@ func TestArchiveTrie_CanProcessPrecomputedHashes(t *testing.T) {
 
 			// Block 4 -- larger range of data
 			update = common.Update{}
-			for i := 0; i < 100; i++ {
+			for i := range 100 {
 				addr := common.Address{byte(i + 10)}
 				err = errors.Join(
 					live.SetBalance(addr, blc1),
@@ -961,7 +961,7 @@ func TestArchiveTrie_Add_CreatesCheckpointPeriodically(t *testing.T) {
 				}
 			}()
 
-			for i := 0; i < 20; i++ {
+			for i := range 20 {
 				if err := archive.Add(uint64(i), common.Update{}, nil); err != nil {
 					t.Fatalf("failed to apply update: %v", err)
 				}
@@ -1273,10 +1273,7 @@ func TestArchiveTrie_GettingView_Block_OutOfRange(t *testing.T) {
 
 func TestArchiveTrie_GetCodes(t *testing.T) {
 	collect := func(it iter.Seq2[common.Hash, []byte]) map[common.Hash][]byte {
-		codes := make(map[common.Hash][]byte)
-		for hash, code := range it {
-			codes[hash] = code
-		}
+		codes := maps.Collect(it)
 		return codes
 	}
 
@@ -1900,7 +1897,7 @@ func TestArchiveTrie_StoreLoadRoots(t *testing.T) {
 	if original.length() != 0 {
 		t.Errorf("unexpected number of roots, wanted 0, got %d", original.length())
 	}
-	for i := 0; i < 48; i++ {
+	for i := range 48 {
 		id := NodeId(uint64(1) << i)
 		require.NoError(original.append(Root{NodeRef: NewNodeReference(id)}))
 		id = NodeId((uint64(1) << (i + 1)) - 1)
@@ -1941,9 +1938,7 @@ func TestArchiveTrie_RootListStoreOnlyWritesNewRoots(t *testing.T) {
 	var writtenBatches []map[uint64]Root
 	file.EXPECT().SetBatch(gomock.Any()).DoAndReturn(func(entries map[uint64]Root) error {
 		cp := make(map[uint64]Root, len(entries))
-		for k, v := range entries {
-			cp[k] = v
-		}
+		maps.Copy(cp, entries)
 		writtenBatches = append(writtenBatches, cp)
 		return nil
 	}).AnyTimes()
@@ -2006,8 +2001,8 @@ func TestArchiveTrie_IncrementalRootListUpdates(t *testing.T) {
 	}
 
 	counter := 0
-	for i := 0; i < 5; i++ {
-		for j := 0; j < 10; j++ {
+	for range 5 {
+		for range 10 {
 			id := NodeId(counter)
 			require.NoError(t, list.append(Root{NodeRef: NewNodeReference(id)}))
 			counter++
@@ -2108,10 +2103,7 @@ func TestRootList_Iterate_YieldsAllAppendedRoots(t *testing.T) {
 	seq, err := list.Iterate()
 	require.NoError(err)
 
-	got := map[uint64]Root{}
-	for block, r := range seq {
-		got[block] = r
-	}
+	got := maps.Collect(seq)
 	require.Len(got, len(want))
 	for i, r := range want {
 		require.Equal(r, got[uint64(i)])
@@ -2151,11 +2143,8 @@ func TestRootList_Iterate_CanBeInvokedMultipleTimes(t *testing.T) {
 	seq, err := list.Iterate()
 	require.NoError(err)
 
-	for pass := 0; pass < 2; pass++ {
-		got := map[uint64]Root{}
-		for block, r := range seq {
-			got[block] = r
-		}
+	for pass := range 2 {
+		got := maps.Collect(seq)
 		require.Len(got, len(want), "pass %d", pass)
 		for i, r := range want {
 			require.Equal(r, got[uint64(i)], "pass %d", pass)
@@ -2206,14 +2195,14 @@ func TestArchiveTrie_QueryLoadTest(t *testing.T) {
 
 	// We fill the archive with N blocks, each with N accounts and N slots.
 	const N = 100
-	for b := 0; b < N; b++ {
+	for b := range N {
 		update := common.Update{}
-		for a := 0; a < N; a++ {
+		for a := range N {
 			addr := common.Address{byte(a)}
 			if b == 0 {
 				update.AppendBalanceUpdate(addr, amount.New(10))
 			}
-			for k := 0; k < N; k++ {
+			for k := range N {
 				update.AppendSlotUpdate(addr, common.Key{byte(k)}, common.Value{byte(b), byte(a), byte(k)})
 			}
 		}
@@ -2227,11 +2216,11 @@ func TestArchiveTrie_QueryLoadTest(t *testing.T) {
 	P := runtime.NumCPU()
 	var wg sync.WaitGroup
 	wg.Add(P)
-	for i := 0; i < P; i++ {
+	for i := range P {
 		go func(seed int) {
 			defer wg.Done()
 			r := rand.New(rand.NewSource(int64(seed)))
-			for i := 0; i < Q; i++ {
+			for range Q {
 				block := uint64(r.Intn(N))
 				addr := common.Address{byte(r.Intn(N))}
 				key := common.Key{byte(r.Intn(N))}
@@ -2361,7 +2350,6 @@ func TestArchiveTrie_FailingLiveStateUpdate_InvalidatesArchive(t *testing.T) {
 	}
 
 	for i, liveStateOp := range liveStateOps {
-		i := i
 		t.Run(fmt.Sprintf("liveOp_%s", liveStateOp.name), func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -3049,7 +3037,7 @@ func TestArchiveTrie_RestoredTrieCanBeReused(t *testing.T) {
 
 	counter := 0
 	address := common.Address{}
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		counter++
 		err := archive.Add(uint64(i), common.Update{
 			Nonces: []common.NonceUpdate{
@@ -3064,7 +3052,7 @@ func TestArchiveTrie_RestoredTrieCanBeReused(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		nonce, err := archive.GetNonce(uint64(i), address)
 		if err != nil {
 			t.Fatalf("failed to get nonce: %v", err)
@@ -3111,7 +3099,7 @@ func TestArchiveTrie_RestoredTrieCanBeReused(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < 150; i++ {
+	for i := range 150 {
 		nonce, err := archive.GetNonce(uint64(i), address)
 		if err != nil {
 			t.Fatalf("failed to get nonce: %v", err)
@@ -3228,7 +3216,7 @@ func TestRootList_GuaranteeCheckpoint_CreatedCheckpointsCanBeGuaranteed(t *testi
 		t.Fatalf("failed to load roots: %v", err)
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		cp := checkpoint.Checkpoint(i + 1)
 		err := errors.Join(
 			roots.Prepare(cp),
@@ -3250,7 +3238,7 @@ func TestRootList_GuaranteeCheckpoint_FailsForNonExistingCheckpoint(t *testing.T
 		t.Fatalf("failed to load roots: %v", err)
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		cp := checkpoint.Checkpoint(i + 1)
 		err := errors.Join(
 			roots.Prepare(cp),

--- a/go/database/mpt/benchmark_test.go
+++ b/go/database/mpt/benchmark_test.go
@@ -44,7 +44,7 @@ func Benchmark_Mpt_Hash_BranchNode_All_Leaves_Updated(b *testing.B) {
 	var counter uint64
 	for i := 0; i < b.N; i++ {
 		// modify all values in one leaf
-		for j := 0; j < 16; j++ {
+		for range 16 {
 			key := common.Address{byte(i) << 4} // set first byte to insert at one branch at each iteration, updating all leaves
 			value := AccountInfo{Balance: amount.New(counter + 1)}
 			counter++
@@ -102,7 +102,7 @@ func Benchmark_Mpt_Hash_Key(b *testing.B) {
 }
 
 func createTestNode_One_BranchNode_With_Full_Leaves_Space(live *LiveTrie) error {
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		key := common.Address{byte(i) << 4} // set first byte to insert at different branch at each iteration
 		value := AccountInfo{Nonce: common.Nonce{byte(i + 1)}}
 

--- a/go/database/mpt/codes.go
+++ b/go/database/mpt/codes.go
@@ -252,10 +252,7 @@ func readCodesForTesting(path string) (codes map[common.Hash][]byte, err error) 
 	if err != nil {
 		return nil, err
 	}
-	codes = map[common.Hash][]byte{}
-	for key, code := range seq {
-		codes[key] = code
-	}
+	codes = maps.Collect(seq)
 	return codes, nil
 }
 

--- a/go/database/mpt/decoder_test.go
+++ b/go/database/mpt/decoder_test.go
@@ -56,7 +56,7 @@ func TestDecoder_CanDecodeNodes(t *testing.T) {
 	embeddedChildrenSizes := [16]uint16{}
 
 	childrenRlp := make([]rlp.Item, 17)
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		childrenRlp[i] = rlp.String{Str: childrenHashes[i][:]}
 		if childrenHashes[i] == valueNodeRlpAsHash {
 			childrenRlp[i] = valueNode // inject real size slice, not a 32bit hash
@@ -207,12 +207,12 @@ func TestDecoder_CorruptedRlp(t *testing.T) {
 	codeHashTooLong := rlp.String{Str: rlp.Encode(rlp.List{Items: []rlp.Item{str, str, longStr, strLongerThan32}})}
 
 	childrenTooLongHashes := make([]rlp.Item, 17)
-	for i := 0; i < len(childrenTooLongHashes); i++ {
+	for i := range childrenTooLongHashes {
 		childrenTooLongHashes[i] = strLongerThan32
 	}
 
 	childrenNotStrings := make([]rlp.Item, 17)
-	for i := 0; i < len(childrenNotStrings); i++ {
+	for i := range childrenNotStrings {
 		childrenNotStrings[i] = list
 	}
 
@@ -257,7 +257,7 @@ func Test_isCompactPathLeafNode(t *testing.T) {
 		isLeaf bool
 	}, 0, 0xFF)
 
-	for i := 0; i < 0xFF; i++ {
+	for i := range 0xFF {
 		tests = append(tests, struct {
 			path   []byte
 			isLeaf bool
@@ -307,7 +307,7 @@ func TestDecoder_Decode_Node_Instances(t *testing.T) {
 	ctxt := newNodeContextWithConfig(t, ctrl, S5LiveConfig)
 
 	childHashes := ChildHashes{}
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		if i == 0xA {
 			continue
 		}
@@ -439,7 +439,7 @@ func TestDecoder_Decode_AccountNode_Instances_Above20bytesPaths(t *testing.T) {
 	nibbles := AddressToNibblePath(address, ctxt)
 
 	childHashes := ChildHashes{}
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		if Nibble(i) == nibbles[0] {
 			continue
 		}

--- a/go/database/mpt/diff.go
+++ b/go/database/mpt/diff.go
@@ -195,7 +195,7 @@ func collectDiff(
 		return collectDiffFromLeafs(context, before, after)
 	}
 
-	for i := Nibble(0); i < Nibble(16); i++ {
+	for i := range Nibble(16) {
 		lhs, err := before.getChild(context.source, i)
 		if err != nil {
 			return err

--- a/go/database/mpt/directory_lock_test.go
+++ b/go/database/mpt/directory_lock_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestDirectoryLock_AcquireAndRelease(t *testing.T) {
 	dir := t.TempDir()
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		lock, err := LockDirectory(dir)
 		if err != nil {
 			t.Fatalf("failed to acquire lock: %v", err)

--- a/go/database/mpt/forest.go
+++ b/go/database/mpt/forest.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -578,7 +577,7 @@ func (s *Forest) Flush() error {
 func (s *Forest) flushDirtyIds(ids []NodeId) error {
 	var errs []error
 	// Flush dirty keys in order (to avoid excessive seeking).
-	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	slices.Sort(ids)
 	for _, id := range ids {
 		ref := NewNodeReference(id)
 		node, present := s.nodeCache.Get(&ref)

--- a/go/database/mpt/forest_test.go
+++ b/go/database/mpt/forest_test.go
@@ -588,7 +588,7 @@ func TestForest_getAccess_Fails(t *testing.T) {
 					accounts := stock.NewMockStock[uint64, AccountNode](ctrl)
 					// only the second call must fail - repeats four times for four calls
 					calls := make([]any, 0, 8)
-					for i := 0; i < 4; i++ {
+					for range 4 {
 						calls = append(calls, accounts.EXPECT().Get(gomock.Any()).Return(AccountNode{}, nil))
 						calls = append(calls, accounts.EXPECT().Get(gomock.Any()).Return(AccountNode{}, injectedErr))
 					}
@@ -1303,7 +1303,7 @@ func TestForest_ConcurrentReadsAreRaceFree(t *testing.T) {
 
 					// Fill in some data (sequentially).
 					root := NewNodeReference(EmptyId())
-					for i := 0; i < N; i++ {
+					for i := range N {
 						root, err = forest.SetAccountInfo(&root, common.Address{byte(i)}, AccountInfo{Nonce: common.ToNonce(uint64(i + 1))})
 						if err != nil {
 							t.Fatalf("failed to insert account %d: %v", i, err)
@@ -1314,10 +1314,10 @@ func TestForest_ConcurrentReadsAreRaceFree(t *testing.T) {
 					var errors [N]error
 					var wg sync.WaitGroup
 					wg.Add(N)
-					for i := 0; i < N; i++ {
+					for range N {
 						go func() {
 							defer wg.Done()
-							for i := 0; i < N; i++ {
+							for i := range N {
 								info, _, err := forest.GetAccountInfo(&root, common.Address{byte(i)})
 								if err != nil {
 									errors[i] = err
@@ -1364,7 +1364,7 @@ func TestForest_ConcurrentWritesAreRaceFree(t *testing.T) {
 
 					// Fill in some data (sequentially).
 					root := NewNodeReference(EmptyId())
-					for i := 0; i < N; i++ {
+					for i := range N {
 						root, err = forest.SetAccountInfo(&root, common.Address{byte(i)}, AccountInfo{Nonce: common.ToNonce(uint64(i + 1))})
 						if err != nil {
 							t.Fatalf("failed to insert account %d: %v", i, err)
@@ -1375,10 +1375,10 @@ func TestForest_ConcurrentWritesAreRaceFree(t *testing.T) {
 					var errors [N]error
 					var wg sync.WaitGroup
 					wg.Add(N)
-					for i := 0; i < N; i++ {
+					for range N {
 						go func() {
 							defer wg.Done()
-							for i := 0; i < N; i++ {
+							for i := range N {
 								_, err := forest.SetAccountInfo(&root, common.Address{byte(i)}, AccountInfo{Nonce: common.ToNonce(uint64(i + 2))})
 								if err != nil {
 									errors[i] = err
@@ -1396,7 +1396,7 @@ func TestForest_ConcurrentWritesAreRaceFree(t *testing.T) {
 					}
 
 					// Check that the resulting nonce is i + 2
-					for i := 0; i < N; i++ {
+					for i := range N {
 						info, exits, err := forest.GetAccountInfo(&root, common.Address{byte(i)})
 						if err != nil {
 							t.Fatalf("failed to read account %d: %v", i, err)
@@ -1567,10 +1567,8 @@ func testForest_WriteBufferRecoveryIsThreadSafe(t *testing.T, withConcurrentNode
 	if withConcurrentNodeGeneration {
 		// Optionally new nodes are generated in parallel to the reloading of
 		// the root nodes of the forest.
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for i := 0; i < M; i++ {
+		wg.Go(func() {
+			for range M {
 				_, handle, err := forest.createAccount()
 				if err != nil {
 					t.Errorf("failed to create new node: %v", err)
@@ -1578,13 +1576,13 @@ func testForest_WriteBufferRecoveryIsThreadSafe(t *testing.T, withConcurrentNode
 					handle.Release()
 				}
 			}
-		}()
+		})
 	}
 
-	for i := 0; i < N; i++ {
+	for range N {
 		go func() {
 			defer wg.Done()
-			for i := 0; i < M; i++ {
+			for i := range M {
 				tree := treeA
 				if i%2 > 0 {
 					tree = treeB
@@ -1723,10 +1721,10 @@ func TestForest_NodeHandlingDoesNotDeadlock(t *testing.T) {
 	const N = 10
 	var wg sync.WaitGroup
 	wg.Add(N)
-	for i := 0; i < N; i++ {
+	for range N {
 		go func() {
 			defer wg.Done()
-			for i := 0; i < 1000; i++ {
+			for i := range 1000 {
 				tree := treeA
 				if i%2 > 0 {
 					tree = treeB
@@ -1766,13 +1764,13 @@ func TestForest_CheckPassesAfterReopeningDirectory(t *testing.T) {
 					// Fill the forest with some data.
 					const N = 10
 					root := NewNodeReference(EmptyId())
-					for a := 0; a < N; a++ {
+					for a := range N {
 						addr := common.Address{byte(a)}
 						root, err = forest.SetAccountInfo(&root, addr, AccountInfo{Nonce: common.Nonce{1}})
 						if err != nil {
 							t.Fatalf("failed to create account %v: %v", addr, err)
 						}
-						for k := 0; k < N; k++ {
+						for k := range N {
 							root, err = forest.SetValue(&root, addr, common.Key{byte(k)}, common.Value{byte(k)})
 							if err != nil {
 								t.Fatalf("failed to update value %v: %v", addr, err)
@@ -2271,7 +2269,6 @@ func TestForest_AsyncDelete_CacheIsNotExhausted(t *testing.T) {
 		// test for live configs only as archive configs even write deleted
 		// nodes and cache needs to be allocated for those nodes as well.
 		for _, config := range []MptConfig{S5LiveConfig, S4LiveConfig} {
-			config := config
 			t.Run(config.Name, func(t *testing.T) {
 				t.Parallel()
 

--- a/go/database/mpt/hash_cache_test.go
+++ b/go/database/mpt/hash_cache_test.go
@@ -46,7 +46,7 @@ func TestAddressHasher_AccessesAreRaceConditionFree(t *testing.T) {
 	hasher := NewAddressHasher()
 	var wg sync.WaitGroup
 	wg.Add(10)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
 			defer wg.Done()
 			for _, test := range tests {
@@ -86,7 +86,7 @@ func TestKeyHasher_AccessesAreRaceConditionFree(t *testing.T) {
 	hasher := NewKeyHasher()
 	var wg sync.WaitGroup
 	wg.Add(10)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
 			defer wg.Done()
 			for _, test := range tests {
@@ -125,7 +125,7 @@ func TestNewHitMissTrackingCache_AccessesAreRaceConditionFree(t *testing.T) {
 	hasher := NewHitMissTrackingCache(NewKeyHasher())
 	var wg sync.WaitGroup
 	wg.Add(10)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
 			defer wg.Done()
 			for _, test := range tests {
@@ -192,7 +192,7 @@ func TestNewHitMissTrackingCache_CountsHitsAndMissesCorrectly(t *testing.T) {
 func getRandomAddresses(number int) []common.Address {
 	r := rand.New(rand.NewSource(99))
 	list := []common.Address{}
-	for i := 0; i < number; i++ {
+	for range number {
 		cur := common.Address{}
 		r.Read(cur[:])
 		list = append(list, cur)
@@ -203,7 +203,7 @@ func getRandomAddresses(number int) []common.Address {
 func getRandomKeys(number int) []common.Key {
 	r := rand.New(rand.NewSource(99))
 	list := []common.Key{}
-	for i := 0; i < number; i++ {
+	for range number {
 		cur := common.Key{}
 		r.Read(cur[:])
 		list = append(list, cur)

--- a/go/database/mpt/io/live_test.go
+++ b/go/database/mpt/io/live_test.go
@@ -95,7 +95,7 @@ func TestIO_ExportAndImportAsArchive(t *testing.T) {
 		t.Fatalf("restored DB failed to reproduce same hash\nwanted %x\n   got %x\n   err %v", hash, got, err)
 	}
 
-	for i := uint64(0); i < genesisBlock; i++ {
+	for i := range genesisBlock {
 		if got, err := db.GetHash(i); err != nil || got != mpt.EmptyNodeEthereumHash {
 			t.Fatalf("invalid hash for pre-genesis block %d\nwanted %x\n   got %x\n   err %v", i, mpt.EmptyNodeEthereumHash, got, err)
 		}
@@ -104,7 +104,7 @@ func TestIO_ExportAndImportAsArchive(t *testing.T) {
 
 func TestIO_ExportedDataIsDeterministic(t *testing.T) {
 	reference, _ := exportExampleState(t)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		data, _ := exportExampleState(t)
 		if !bytes.Equal(data, reference) {
 			t.Fatalf("exported data is not deterministic")
@@ -368,11 +368,11 @@ func TestIO_ExportBlockFromArchive(t *testing.T) {
 
 	var expectedHashes []common.Hash
 
-	for i := 0; i < Blocks; i++ {
+	for i := range Blocks {
 		code := []byte{1, 2, 3, byte(i)}
 		u := uint64(i)
 		update := common.Update{}
-		for j := 0; j < Accounts; j++ {
+		for j := range Accounts {
 			newAddr := common.AddressFromNumber(j)
 
 			update.Balances = append(update.Balances, common.BalanceUpdate{Account: newAddr, Balance: amount.New(u + 1)})
@@ -397,7 +397,7 @@ func TestIO_ExportBlockFromArchive(t *testing.T) {
 		t.Fatalf("failed to close archive archive: %v", err)
 	}
 
-	for i := 0; i < Blocks; i++ {
+	for i := range Blocks {
 		// Export live database from archive.
 		buffer := new(bytes.Buffer)
 		if err := ExportBlockFromArchive(context.Background(), NewLog(), sourceDir, buffer, uint64(i), t.TempDir()); err != nil {
@@ -452,11 +452,11 @@ func TestIO_ExportBlockFromOnlineArchive(t *testing.T) {
 		Accounts = 3
 	)
 
-	for i := 0; i < Blocks; i++ {
+	for i := range Blocks {
 		code := []byte{1, 2, 3, byte(i)}
 		u := uint64(i)
 		update := common.Update{}
-		for j := 0; j < Accounts; j++ {
+		for j := range Accounts {
 			newAddr := common.AddressFromNumber(j)
 
 			update.Balances = append(update.Balances, common.BalanceUpdate{Account: newAddr, Balance: amount.New(u + 1)})

--- a/go/database/mpt/io/log_test.go
+++ b/go/database/mpt/io/log_test.go
@@ -62,7 +62,7 @@ func TestLog_CanBeNil(t *testing.T) {
 	logger.Print("Test message")
 	logger.Printf("%d", 1)
 	progress := logger.NewProgressTracker("Progress: %d steps, %.2f steps/sec", 10)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		progress.Step(1)
 	}
 

--- a/go/database/mpt/io/parallel_visit.go
+++ b/go/database/mpt/io/parallel_visit.go
@@ -221,7 +221,7 @@ func visitAllWithConfig(
 				responsesMutex.Unlock()
 
 				// Do the actual prefetching in parallel.
-				for i := 0; i < batchSize; i++ {
+				for range batchSize {
 					prefetchNext(source, false)
 				}
 			}

--- a/go/database/mpt/io/parallel_visit_test.go
+++ b/go/database/mpt/io/parallel_visit_test.go
@@ -102,7 +102,7 @@ func TestPosition_AreOrderedAndWorkWithSharedPrefixes(t *testing.T) {
 	positions := []*position{}
 	var position *position
 	positions = append(positions, position)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		position = position.child(byte(i))
 		positions = append(positions, position)
 	}
@@ -119,7 +119,6 @@ func TestPosition_AreOrderedAndWorkWithSharedPrefixes(t *testing.T) {
 
 func TestNodeSource_CanRead_Nodes(t *testing.T) {
 	for _, config := range allMptConfigs {
-		config := config
 		t.Run(config.Name, func(t *testing.T) {
 			runTestWithArchive(t, config, func(trie *mpt.ArchiveTrie) {
 				t.Parallel()
@@ -179,8 +178,8 @@ func TestVisit_CanHandleSlowConsumer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create account: %v", err)
 	}
-	for i := 0; i < 100; i++ {
-		for j := 0; j < 100; j++ {
+	for i := range 100 {
+		for j := range 100 {
 			key := common.Key{byte(i), byte(j)}
 			err = live.SetStorage(addr, key, common.Value{1})
 			if err != nil {
@@ -249,7 +248,6 @@ func TestVisit_CanHandleSlowConsumer(t *testing.T) {
 
 func TestVisit_Nodes_Failing_CannotOpenDir(t *testing.T) {
 	for _, config := range allMptConfigs {
-		config := config
 		t.Run(config.Name, func(t *testing.T) {
 			t.Parallel()
 
@@ -263,7 +261,6 @@ func TestVisit_Nodes_Failing_CannotOpenDir(t *testing.T) {
 
 func TestVisit_Nodes_Failing_MissingDir(t *testing.T) {
 	for _, config := range allMptConfigs {
-		config := config
 		t.Run(config.Name, func(t *testing.T) {
 			t.Parallel()
 
@@ -292,7 +289,6 @@ func TestVisit_Nodes_Failing_MissingDir(t *testing.T) {
 
 func TestVisit_Nodes_Failing_MissingData(t *testing.T) {
 	for _, config := range allMptConfigs {
-		config := config
 		t.Run(config.Name, func(t *testing.T) {
 			runTestWithArchive(t, config, func(trie *mpt.ArchiveTrie) {
 				t.Parallel()
@@ -360,9 +356,7 @@ func TestVisit_Nodes_CannotCloseSources(t *testing.T) {
 	injectedError := fmt.Errorf("injected error")
 
 	for _, config := range allMptConfigs {
-		config := config
 		for name, factory := range sourceFactories {
-			factory := factory
 			t.Run(fmt.Sprintf("%s_%s", name, config.Name), func(t *testing.T) {
 				t.Parallel()
 
@@ -449,7 +443,7 @@ func TestVisit_Nodes_Iterated_Deterministic(t *testing.T) {
 					// visit all nodes in the trie and compare that the nodes are visited in the same order
 					// as the nodes in the trie
 					// run the experiment N times to ensure that the order is deterministic
-					for i := 0; i < N; i++ {
+					for i := range N {
 						t.Run(fmt.Sprintf("block=%d,iteration=%d", block, i), func(t *testing.T) {
 							t.Parallel()
 							var position int
@@ -487,9 +481,7 @@ func TestOpenSource_Failing_MissingFiles(t *testing.T) {
 	tests := []string{"accounts", "extensions", "branches", "values"}
 
 	for _, config := range allMptConfigs {
-		config := config
 		for _, test := range tests {
-			test := test
 			t.Run(fmt.Sprintf("%s %s", config.Name, test), func(t *testing.T) {
 				t.Parallel()
 
@@ -545,7 +537,6 @@ func TestOpenSource_Failing_MissingFiles(t *testing.T) {
 
 func TestNodeSourceFactoryForLiveDB_CanRead_Nodes(t *testing.T) {
 	for _, config := range allMptConfigs {
-		config := config
 		t.Run(config.Name, func(t *testing.T) {
 			t.Parallel()
 
@@ -612,7 +603,7 @@ func matchNodes(t *testing.T, a, b mpt.Node) {
 			t.Errorf("expected next %v, got %v", want, got)
 		}
 	case *mpt.BranchNode:
-		for i := 0; i < 16; i++ {
+		for i := range 16 {
 			if got, want := n.GetChildren()[i], b.(*mpt.BranchNode).GetChildren()[i]; got.Id() != want.Id() {
 				t.Errorf("expected children %v, got %v", want, got)
 			}
@@ -644,11 +635,11 @@ func createArchive(t *testing.T, dir string, config mpt.MptConfig) *mpt.ArchiveT
 		Accounts = 30
 	)
 
-	for i := 0; i < Blocks; i++ {
+	for i := range Blocks {
 		code := []byte{1, 2, 3, byte(i)}
 		u := uint64(i)
 		update := common.Update{}
-		for j := 0; j < Accounts; j++ {
+		for j := range Accounts {
 			newAddr := common.AddressFromNumber(j)
 
 			update.Balances = append(update.Balances, common.BalanceUpdate{
@@ -682,12 +673,12 @@ func createMptState(t *testing.T, dir string, config mpt.MptConfig) *mpt.MptStat
 	)
 
 	// populate the live db with some data
-	for i := 0; i < Accounts; i++ {
+	for i := range Accounts {
 		addr := common.AddressFromNumber(i)
 		if err := live.SetNonce(addr, common.Nonce{1}); err != nil {
 			t.Fatalf("failed to set account info: %v", err)
 		}
-		for j := 0; j < Key; j++ {
+		for j := range Key {
 			if err := live.SetStorage(addr, common.Key{byte(i), byte(j)}, common.Value{1}); err != nil {
 				t.Fatalf("failed to set value: %v", err)
 			}
@@ -708,10 +699,10 @@ func TestBarrier_SyncsWorkers(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(NumWorker)
 	barrier := newBarrier(NumWorker)
-	for i := 0; i < NumWorker; i++ {
+	for range NumWorker {
 		go func() {
 			defer wg.Done()
-			for j := 0; j < NumIterations; j++ {
+			for j := range NumIterations {
 				barrier.wait()
 				dataLock.Lock()
 				data = append(data, j)
@@ -740,7 +731,7 @@ func TestBarrier_CanBeReleased(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(NumWorker)
 	barrier := newBarrier(NumWorker)
-	for i := 0; i < NumWorker; i++ {
+	for i := range NumWorker {
 		go func(i int) {
 			defer wg.Done()
 			if i != 0 {

--- a/go/database/mpt/live_trie_fuzzing_test.go
+++ b/go/database/mpt/live_trie_fuzzing_test.go
@@ -115,7 +115,7 @@ func fuzzLiveTrieRandomAccountOps(f *testing.F) {
 		var nonce2 common.Nonce
 		var nonce3 common.Nonce
 
-		for i := 0; i < common.NonceSize; i++ {
+		for i := range common.NonceSize {
 			nonce2[i] = byte(i + 1)
 			nonce3[i] = byte(0xFF)
 		}
@@ -124,7 +124,7 @@ func fuzzLiveTrieRandomAccountOps(f *testing.F) {
 		var balance2 [amount.BytesLength]byte
 		var balance3 [amount.BytesLength]byte
 
-		for i := 0; i < amount.BytesLength; i++ {
+		for i := range amount.BytesLength {
 			balance2[i] = byte(i + 1)
 			balance3[i] = byte(0xFF)
 		}
@@ -133,7 +133,7 @@ func fuzzLiveTrieRandomAccountOps(f *testing.F) {
 		var codeHash2 common.Hash
 		var codeHash3 common.Hash
 
-		for i := 0; i < common.HashSize; i++ {
+		for i := range common.HashSize {
 			codeHash2[i] = byte(i + 1)
 			codeHash3[i] = byte(0xFF)
 		}
@@ -386,7 +386,7 @@ func fuzzLiveTrieRandomAccountStorageOps(f *testing.F) {
 		var val2 common.Value
 		var val3 common.Value
 
-		for i := 0; i < common.ValueSize; i++ {
+		for i := range common.ValueSize {
 			val2[i] = byte(i + 1)
 			val3[i] = byte(0xFF)
 		}
@@ -503,7 +503,7 @@ func init() {
 	tinyAddressLookup = make([]common.Address, 256)
 	tinyKeyLookup = make([]common.Key, 256)
 
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		{
 			var addr common.Address
 			hash := common.GetKeccak256Hash([]byte{byte(i)})

--- a/go/database/mpt/live_trie_test.go
+++ b/go/database/mpt/live_trie_test.go
@@ -240,7 +240,7 @@ func TestLiveTrie_VisitAccount(t *testing.T) {
 			)
 
 			// there are no accounts at the beginning
-			for i := 0; i < Addresses; i++ {
+			for i := range Addresses {
 				addr := common.AddressFromNumber(i)
 				if err := trie.VisitAccountStorage(addr, ReadAccess{}, MakeVisitor(func(node Node, _ NodeInfo) VisitResponse {
 					t.Errorf("unexpected node: %v", node)
@@ -251,14 +251,14 @@ func TestLiveTrie_VisitAccount(t *testing.T) {
 			}
 
 			// insert addresses only
-			for i := 0; i < Addresses; i++ {
+			for i := range Addresses {
 				if err := trie.SetAccountInfo(common.AddressFromNumber(i), AccountInfo{Nonce: common.Nonce{1}}); err != nil {
 					t.Fatalf("failed to set account info: %v", err)
 				}
 			}
 
 			// there are no nodes in the accounts
-			for i := 0; i < Addresses; i++ {
+			for i := range Addresses {
 				addr := common.AddressFromNumber(i)
 				if err := trie.VisitAccountStorage(addr, ReadAccess{}, MakeVisitor(func(node Node, _ NodeInfo) VisitResponse {
 					t.Errorf("unexpected node: %v", node)
@@ -269,7 +269,7 @@ func TestLiveTrie_VisitAccount(t *testing.T) {
 			}
 
 			// inset keys
-			for i := 0; i < Addresses; i++ {
+			for i := range Addresses {
 				addr := common.AddressFromNumber(i)
 				for j := 0; j < i+1; j++ {
 					if err := trie.SetValue(addr, common.Key{byte(j)}, common.Value{byte(j)}); err != nil {
@@ -279,7 +279,7 @@ func TestLiveTrie_VisitAccount(t *testing.T) {
 			}
 
 			// check the keys in the accounts are correct when visiting accounts
-			for i := 0; i < Addresses; i++ {
+			for i := range Addresses {
 				addr := common.AddressFromNumber(i)
 				visited := make(map[common.Key]common.Value)
 				if err := trie.VisitAccountStorage(addr, ReadAccess{}, MakeVisitor(func(node Node, _ NodeInfo) VisitResponse {
@@ -655,7 +655,6 @@ func TestLiveTrie_ChangeInTrieSubstructureUpdatesHash(t *testing.T) {
 
 func TestLiveTrie_InsertLotsOfData(t *testing.T) {
 	for _, config := range allMptConfigs {
-		config := config
 		t.Run(config.Name, func(t *testing.T) {
 			t.Parallel()
 			const N = 30
@@ -722,7 +721,6 @@ func TestLiveTrie_InsertLotsOfData(t *testing.T) {
 
 func TestLiveTrie_InsertLotsOfValues(t *testing.T) {
 	for _, config := range allMptConfigs {
-		config := config
 		t.Run(config.Name, func(t *testing.T) {
 			t.Parallel()
 			const N = 500
@@ -814,7 +812,6 @@ func getTestKeys(number int) []common.Key {
 
 func TestLiveTrie_DeleteLargeAccount(t *testing.T) {
 	for _, config := range allMptConfigs {
-		config := config
 		t.Run(config.Name, func(t *testing.T) {
 			t.Parallel()
 			const N = 200000
@@ -834,7 +831,7 @@ func TestLiveTrie_DeleteLargeAccount(t *testing.T) {
 			if err := trie.SetAccountInfo(addr, AccountInfo{Nonce: common.Nonce{1}}); err != nil {
 				t.Fatalf("failed to create account: %v", err)
 			}
-			for i := 0; i < N; i++ {
+			for i := range N {
 				if err := trie.SetValue(addr, common.Key{byte(i), byte(i >> 8), byte(i >> 16)}, common.Value{1}); err != nil {
 					t.Fatalf("failed to insert value: %v", err)
 				}

--- a/go/database/mpt/nibble.go
+++ b/go/database/mpt/nibble.go
@@ -83,7 +83,7 @@ func keyToHashedPathNibbles(key common.Key) []Nibble {
 }
 
 func parseNibbles(dst []Nibble, src []byte) {
-	for i := 0; i < len(src); i++ {
+	for i := range src {
 		dst[2*i] = Nibble(src[i] >> 4)
 		dst[2*i+1] = Nibble(src[i] & 0xF)
 	}
@@ -96,7 +96,7 @@ func GetCommonPrefixLength(a, b []Nibble) int {
 	if lengthA > len(b) {
 		return GetCommonPrefixLength(b, a)
 	}
-	for i := 0; i < lengthA; i++ {
+	for i := range lengthA {
 		if a[i] != b[i] {
 			return i
 		}

--- a/go/database/mpt/nibble_test.go
+++ b/go/database/mpt/nibble_test.go
@@ -163,7 +163,7 @@ func TestNibbles_keyToHashedPath(t *testing.T) {
 func hashAndConvertToNibbles(src []byte) []Nibble {
 	hashed := common.Keccak256(src)
 	res := make([]Nibble, len(hashed)*2)
-	for i := 0; i < len(hashed); i++ {
+	for i := range len(hashed) {
 		res[2*i] = Nibble(hashed[i] >> 4)
 		res[2*i+1] = Nibble(hashed[i] & 0xF)
 	}

--- a/go/database/mpt/node_cache_test.go
+++ b/go/database/mpt/node_cache_test.go
@@ -241,7 +241,7 @@ func TestNodeCache_Release_NoChange(t *testing.T) {
 		t.Errorf("unexpected eviction order, wanted %s, got %s", want, got)
 	}
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		cache.Release(&ref1)
 		if want, got := "[V-3 V-2 V-1]", fmt.Sprintf("%v", cache.getIdsInReverseEvictionOrder()); want != got {
 			t.Errorf("unexpected eviction order, wanted %s, got %s", want, got)
@@ -295,7 +295,7 @@ func TestNodeCache_StressTestLruList(t *testing.T) {
 
 	// fill cache with elements
 	refs := []NodeReference{}
-	for i := 0; i < Capacity; i++ {
+	for i := range Capacity {
 		id := ValueId(uint64(i))
 		ref := NewNodeReference(id)
 		cache.GetOrSet(&ref, nil)
@@ -304,7 +304,7 @@ func TestNodeCache_StressTestLruList(t *testing.T) {
 
 	// touch elements in cache and check LRU consistency
 	r := rand.New(rand.NewSource(123))
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		pos := int(r.Int31n(Capacity))
 		ref := refs[pos]
 		cache.Touch(&ref)
@@ -388,7 +388,7 @@ func TestNodeCache_ForEachEnumeratesAllEntries(t *testing.T) {
 		t.Errorf("invalid content, wanted %v, got %v", want, got)
 	}
 
-	for i := 0; i < 2*Capacity; i++ {
+	for i := range 2 * Capacity {
 		ref := NewNodeReference(ValueId(uint64(i)))
 		node := shared.MakeShared[Node](&ValueNode{})
 
@@ -408,12 +408,12 @@ func TestNodeCache_GetAndSetThreadSafety(t *testing.T) {
 	N := 100
 	var wg sync.WaitGroup
 	wg.Add(N)
-	for i := 0; i < N; i++ {
+	for i := range N {
 		go func(i int) {
 			defer wg.Done()
 			id := ValueId(uint64(i))
 			node := shared.MakeShared[Node](EmptyNode{})
-			for j := 0; j < 1000; j++ {
+			for range 1000 {
 				ref := NewNodeReference(id)
 				got, _, _, _, _ := cache.GetOrSet(&ref, node)
 				if got != node {
@@ -428,11 +428,11 @@ func TestNodeCache_GetAndSetThreadSafety(t *testing.T) {
 
 func TestNodeCache_GetAndSetIsThreadSafe(t *testing.T) {
 	nodes := []*shared.Shared[Node]{}
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		nodes = append(nodes, shared.MakeShared[Node](&ValueNode{pathLength: byte(i)}))
 	}
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		t.Run(fmt.Sprintf("iteration-%d", i), func(t *testing.T) {
 			t.Parallel()
 			cache := newNodeCache(128)
@@ -444,7 +444,7 @@ func TestNodeCache_GetAndSetIsThreadSafe(t *testing.T) {
 			done := sync.WaitGroup{}
 			done.Add(10)
 			stop := make(chan struct{})
-			for i := 0; i < 10; i++ {
+			for range 10 {
 				go func() {
 					ready.Done()
 					defer done.Done()
@@ -487,7 +487,7 @@ func TestNodeCache_GetAndSetIsThreadSafe(t *testing.T) {
 }
 
 func TestTagPair_ProducesValidPairOfTags(t *testing.T) {
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		transition, stable := getUpdateTagPair(uint64(i))
 		if !isTransitionTag(transition) {
 			t.Errorf("invalid transition tag %x", transition)

--- a/go/database/mpt/node_flusher_test.go
+++ b/go/database/mpt/node_flusher_test.go
@@ -55,7 +55,7 @@ func TestNodeFlusher_UsesTickerToTriggerFlushes(t *testing.T) {
 	}).Return()
 
 	tickerC := make(chan time.Time, loops)
-	for i := 0; i < loops; i++ {
+	for range loops {
 		tickerC <- time.Now()
 	}
 
@@ -70,7 +70,7 @@ func TestNodeFlusher_UsesTickerToTriggerFlushes(t *testing.T) {
 	})
 
 	var numTicks int
-	for i := 0; i < loops; i++ {
+	for range loops {
 		select {
 		case <-flushSignal:
 			numTicks++

--- a/go/database/mpt/node_hash_test.go
+++ b/go/database/mpt/node_hash_test.go
@@ -52,7 +52,7 @@ func TestNodeHashes_ContainsAddedElements(t *testing.T) {
 }
 
 func TestNodeHashes_RecycledListsAreEmpty(t *testing.T) {
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		list := NewNodeHashes()
 		if size := len(list.GetHashes()); size != 0 {
 			t.Errorf("new node list is not empty, size: %d", size)

--- a/go/database/mpt/node_id_test.go
+++ b/go/database/mpt/node_id_test.go
@@ -133,7 +133,7 @@ func TestNodeID_ValueIDOfZeroNodeIsNotEmptyId(t *testing.T) {
 func TestNodeID_EncodingAndDecoding(t *testing.T) {
 	var buffer [6]byte
 	encoder := NodeIdEncoder{}
-	for i := uint64(0); i < 100; i++ {
+	for i := range uint64(100) {
 		for _, id := range []NodeId{NodeId(0), ValueId(i), AccountId(i), BranchId(i), ExtensionId(i)} {
 			encoder.Store(buffer[:], &id)
 			restored := NodeId(12345)
@@ -147,7 +147,7 @@ func TestNodeID_EncodingAndDecoding(t *testing.T) {
 func TestNodeID_EncodingAndDecodingPowerOfTwos(t *testing.T) {
 	var buffer [6]byte
 	encoder := NodeIdEncoder{}
-	for i := 0; i < 6*8; i++ {
+	for i := range 6 * 8 {
 		id := NodeId(uint64(1) << i)
 		encoder.Store(buffer[:], &id)
 		restored := NodeId(12345)

--- a/go/database/mpt/nodes.go
+++ b/go/database/mpt/nodes.go
@@ -558,7 +558,7 @@ func CheckForest(source NodeSource, roots iter.Seq[*NodeReference]) error {
 				err = scheduleNode(&storage, context.root, true, nil)
 			}
 		case *BranchNode:
-			for i := 0; i < 16; i++ {
+			for i := range 16 {
 				child := &cur.children[i]
 				if !child.id.IsEmpty() {
 					path := make([]Nibble, len(context.path)+1)
@@ -2295,7 +2295,7 @@ func (BranchNodeEncoderWithNodeHash) Store(dst []byte, node *BranchNode) error {
 	}
 	encoder := NodeIdEncoder{}
 	step := encoder.GetEncodedSize()
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		encoder.Store(dst[i*step:], &node.children[i].id)
 	}
 	dst = dst[step*16:]
@@ -2306,7 +2306,7 @@ func (BranchNodeEncoderWithNodeHash) Store(dst []byte, node *BranchNode) error {
 func (BranchNodeEncoderWithNodeHash) Load(src []byte, node *BranchNode) error {
 	encoder := NodeIdEncoder{}
 	step := encoder.GetEncodedSize()
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		var id NodeId
 		encoder.Load(src[i*step:], &id)
 		node.children[i] = NewNodeReference(id)
@@ -2317,7 +2317,7 @@ func (BranchNodeEncoderWithNodeHash) Load(src []byte, node *BranchNode) error {
 
 	// The hashes of the child nodes are not stored with the node, so they are
 	// marked as dirty to trigger a re-computation the next time they are used.
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		if !node.children[i].Id().IsEmpty() {
 			node.markChildHashDirty(byte(i))
 		}
@@ -2339,11 +2339,11 @@ func (BranchNodeEncoderWithChildHashes) Store(dst []byte, node *BranchNode) erro
 	}
 	encoder := NodeIdEncoder{}
 	step := encoder.GetEncodedSize()
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		encoder.Store(dst[i*step:], &node.children[i].id)
 	}
 	dst = dst[step*16:]
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		copy(dst, node.hashes[i][:])
 		dst = dst[common.HashSize:]
 	}
@@ -2354,13 +2354,13 @@ func (BranchNodeEncoderWithChildHashes) Store(dst []byte, node *BranchNode) erro
 func (BranchNodeEncoderWithChildHashes) Load(src []byte, node *BranchNode) error {
 	encoder := NodeIdEncoder{}
 	step := encoder.GetEncodedSize()
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		var id NodeId
 		encoder.Load(src[i*step:], &id)
 		node.children[i] = NewNodeReference(id)
 	}
 	src = src[step*16:]
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		copy(node.hashes[i][:], src)
 		src = src[common.HashSize:]
 	}

--- a/go/database/mpt/nodes_test.go
+++ b/go/database/mpt/nodes_test.go
@@ -6356,7 +6356,6 @@ func TestTransitions_TestForMissingTransitions(t *testing.T) {
 
 func TestTransitions_TestStatesAreValid(t *testing.T) {
 	for _, transition := range getTestTransitions() {
-		transition := transition
 		t.Run(transition.getLabel(), func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -6373,7 +6372,6 @@ func TestTransitions_TestStatesAreValid(t *testing.T) {
 
 func TestTransitions_BeforeAndAfterStatesCanBeFrozen(t *testing.T) {
 	for _, transition := range getTestTransitions() {
-		transition := transition
 		t.Run(transition.getLabel(), func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -6479,7 +6477,6 @@ func TestTransitions_MutableTransitionHaveExpectedEffectWithEthereumHashing(t *t
 
 func testTransitions_MutableTransitionHaveExpectedEffect(t *testing.T, config MptConfig) {
 	for _, transition := range getTestTransitions() {
-		transition := transition
 		t.Run(transition.getLabel(), func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -6574,7 +6571,7 @@ func markModifiedAsDirty(t *testing.T, ctxt *nodeContext, before, after NodeRefe
 		// Also update the dirty child-hash markers in the nodes.
 		if branch, ok := n.(*BranchNode); ok {
 			branch.dirtyHashes = 0
-			for i := byte(0); i < 16; i++ {
+			for i := range byte(16) {
 				if branch.children[i].Id().IsEmpty() {
 					continue
 				}
@@ -7044,7 +7041,6 @@ func TestTransitions_ImmutableTransitionHaveExpectedEffectWithEthereumHashing(t 
 
 func testTransitions_ImmutableTransitionHaveExpectedEffect(t *testing.T, config MptConfig) {
 	for _, transition := range getTestTransitions() {
-		transition := transition
 		t.Run(transition.getLabel(), func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -7111,7 +7107,7 @@ func markReusedAsFrozen(t *testing.T, ctxt *nodeContext, before, after NodeRefer
 		// Also update the frozen hints in branch nodes.
 		if branch, ok := n.(*BranchNode); ok {
 			branch.frozenChildren = 0
-			for i := byte(0); i < 16; i++ {
+			for i := range byte(16) {
 				if branch.children[i].Id().IsEmpty() {
 					continue
 				}
@@ -7168,7 +7164,6 @@ func getTestActions() []action {
 
 	// Make all transitions actions.
 	for _, transition := range getTestTransitions() {
-		transition := transition
 		res = append(res, action{
 			description: fmt.Sprintf("transition/%s", transition.getLabel()),
 			input:       transition.before,
@@ -7701,7 +7696,6 @@ func TestActions_PassOnFrozenNode(t *testing.T) {
 
 func testActions_Pass(t *testing.T, frozen bool) {
 	for _, action := range getTestActions() {
-		action := action
 		t.Run(action.description, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -8476,7 +8470,7 @@ func (c *nodeContext) diff(prefix string, nodeA, nodeB Node) []string {
 
 			diffs = append(diffs, c.diffTries(prefix+"/storage", a.storage, b.storage)...)
 		} else {
-			diffs = append(diffs, fmt.Sprintf("%s: different node types, got %v and %v", prefix, reflect.TypeOf(a), reflect.TypeOf(nodeB)))
+			diffs = append(diffs, fmt.Sprintf("%s: different node types, got %v and %v", prefix, reflect.TypeFor[*AccountNode](), reflect.TypeOf(nodeB)))
 		}
 	}
 
@@ -8496,7 +8490,7 @@ func (c *nodeContext) diff(prefix string, nodeA, nodeB Node) []string {
 			}
 			diffs = append(diffs, c.diffTries(prefix+"/next", a.next, b.next)...)
 		} else {
-			diffs = append(diffs, fmt.Sprintf("%s: different node types, got %v and %v", prefix, reflect.TypeOf(a), reflect.TypeOf(nodeB)))
+			diffs = append(diffs, fmt.Sprintf("%s: different node types, got %v and %v", prefix, reflect.TypeFor[*ExtensionNode](), reflect.TypeOf(nodeB)))
 		}
 	}
 
@@ -8519,7 +8513,7 @@ func (c *nodeContext) diff(prefix string, nodeA, nodeB Node) []string {
 				diffs = append(diffs, c.diffTries(fmt.Sprintf("%s/0x%X", prefix, i), next, b.children[i])...)
 			}
 		} else {
-			diffs = append(diffs, fmt.Sprintf("%s: different node types, got %v and %v", prefix, reflect.TypeOf(a), reflect.TypeOf(nodeB)))
+			diffs = append(diffs, fmt.Sprintf("%s: different node types, got %v and %v", prefix, reflect.TypeFor[*BranchNode](), reflect.TypeOf(nodeB)))
 		}
 	}
 
@@ -8543,7 +8537,7 @@ func (c *nodeContext) diff(prefix string, nodeA, nodeB Node) []string {
 				}
 			}
 		} else {
-			diffs = append(diffs, fmt.Sprintf("%s: different node types, got %v and %v", prefix, reflect.TypeOf(a), reflect.TypeOf(b)))
+			diffs = append(diffs, fmt.Sprintf("%s: different node types, got %v and %v", prefix, reflect.TypeFor[*ValueNode](), reflect.TypeFor[*ValueNode]()))
 		}
 	}
 

--- a/go/database/mpt/path.go
+++ b/go/database/mpt/path.go
@@ -108,10 +108,7 @@ func (p *Path) IsEqualTo(list []Nibble) bool {
 // GetCommonPrefixLength determines the common prefix of the given Nibble
 // slice and this path.
 func (p *Path) GetCommonPrefixLength(list []Nibble) int {
-	max := int(p.length)
-	if max > len(list) {
-		max = len(list)
-	}
+	max := min(int(p.length), len(list))
 	for i := 0; i < max; i++ {
 		if p.Get(i) != list[i] {
 			return i
@@ -181,7 +178,7 @@ func (p *Path) ShiftLeft(steps int) *Path {
 			p.Set(j, p.Get(i+steps))
 			j++
 		}
-		for i := 0; i < steps; i++ {
+		for range steps {
 			p.Set(j, 0)
 			j++
 		}

--- a/go/database/mpt/proof.go
+++ b/go/database/mpt/proof.go
@@ -104,9 +104,7 @@ func MergeProofs(others ...WitnessProof) WitnessProof {
 
 // Add merges the input witness proof into the current witness proof.
 func (p WitnessProof) Add(other WitnessProof) {
-	for k, v := range other.proofDb {
-		p.proofDb[k] = v
-	}
+	maps.Copy(p.proofDb, other.proofDb)
 }
 
 // Extract extracts a sub-proof for a given account and selected storage locations from this proof.
@@ -343,7 +341,7 @@ func (p *proofExtractionVisitor) Visit(node Node, info NodeInfo) VisitResponse {
 	case *BranchNode:
 		if n.dirtyHashes != 0 {
 			embeddedChildren := make(map[NodeId]bool, 16)
-			for i := 0; i < 16; i++ {
+			for i := range 16 {
 				if n.isChildHashDirty(byte(i)) {
 					childHandle, err := p.nodeSource.getViewAccess(&n.children[i])
 					if err != nil {

--- a/go/database/mpt/proof/verification_test.go
+++ b/go/database/mpt/proof/verification_test.go
@@ -41,7 +41,7 @@ func TestVerification_VerifyProofArchiveTrie(t *testing.T) {
 			addr := common.Address{1}
 			for i := 0; i <= blocks; i++ {
 				slotUpdates := make([]common.SlotUpdate, 0, slots)
-				for j := 0; j < slots; j++ {
+				for j := range slots {
 					slotUpdates = append(slotUpdates, common.SlotUpdate{Account: addr, Key: common.Key{byte(i), byte(j)}, Value: common.Value{byte(j)}})
 				}
 
@@ -175,13 +175,13 @@ func TestVerification_VerifyProofLiveTrie(t *testing.T) {
 				t.Fatalf("failed to create live trie, err %v", err)
 			}
 
-			for i := 0; i < accounts; i++ {
+			for i := range accounts {
 				addr := common.Address{byte(i)}
 				if err := live.SetAccountInfo(addr, mpt.AccountInfo{Nonce: common.Nonce{byte(i)}, Balance: amount.New(uint64(i))}); err != nil {
 					t.Errorf("failed to add account %d; %s", i, err)
 				}
 
-				for j := 0; j < keys; j++ {
+				for j := range keys {
 					if err := live.SetValue(addr, common.Key{byte(j), byte(i)}, common.Value{byte(i)}); err != nil {
 						t.Errorf("failed to add account %d; %s", i, err)
 					}
@@ -295,7 +295,7 @@ func TestVerification_FailingArchiveTrie(t *testing.T) {
 
 	// exercise the mock based on the number of executions
 	loops := count
-	for i := 0; i < loops; i++ {
+	for i := range loops {
 		count = 0     // reset the counter
 		threshold = i // update the threshold every loop
 		if err := verifyArchiveTrie(context.Background(), errorInjectingArchiveVerifiableTrieMock, 0, 10, observer, 10); !errors.Is(err, injectedError) {
@@ -324,7 +324,7 @@ func TestVerification_FailingLiveTrie(t *testing.T) {
 		t.Fatalf("failed to set nonce: %v", err)
 	}
 
-	for i := 0; i < 11; i++ {
+	for i := range 11 {
 		if err := trie.SetValue(common.Address{1}, common.Key{byte(i)}, common.Value{1}); err != nil {
 			t.Fatalf("failed to set storage: %v", err)
 		}
@@ -419,7 +419,7 @@ func TestVerification_FailingLiveTrie(t *testing.T) {
 
 	// exercise the mock based on the number of executions
 	loops := count
-	for i := 0; i < loops; i++ {
+	for i := range loops {
 		count = 0     // reset the counter
 		threshold = i // update the threshold every loop
 		if err := verifyTrie(context.Background(), errorInjectingVerifiableTrieMock, observer, 10); !errors.Is(err, injectedError) {
@@ -448,7 +448,7 @@ func TestVerification_FailingInvalidProofs(t *testing.T) {
 		t.Fatalf("failed to set nonce: %v", err)
 	}
 
-	for i := 0; i < 11; i++ {
+	for i := range 11 {
 		if err := trie.SetValue(common.Address{1}, common.Key{byte(i)}, common.Value{1}); err != nil {
 			t.Fatalf("failed to set storage: %v", err)
 		}
@@ -486,7 +486,7 @@ func TestVerification_FailingInvalidProofs(t *testing.T) {
 
 	// exercise the mock based on the number of executions
 	loops := counter
-	for i := 0; i < loops; i++ {
+	for i := range loops {
 		counter = 0   // reset the counter
 		threshold = i // update the threshold every loop
 		if err := verifyTrie(context.Background(), errorInjectingTrieMock, observer, 10); !errors.Is(err, ErrInvalidProof) {
@@ -550,7 +550,7 @@ func TestVerification_VerifyProof_Incomplete_Or_Empty(t *testing.T) {
 
 			// exercise the mock based on the number of executions
 			loops := count
-			for i := 0; i < loops; i++ {
+			for i := range loops {
 				count = 0     // reset the counter
 				threshold = i // update the threshold every loop
 				if err := verifyAccount(common.Hash{}, errorInjectingProofMock, address, data); err == nil {
@@ -605,7 +605,7 @@ func TestVerification_VerifyProof_Can_Cancel(t *testing.T) {
 
 	const numNodes = 100
 	nodes := make([]mpt.Node, 0, numNodes)
-	for i := 0; i < numNodes; i++ {
+	for range numNodes {
 		nodes = append(nodes, &mpt.ValueNode{})
 		nodes = append(nodes, &mpt.BranchNode{})
 		nodes = append(nodes, &mpt.ExtensionNode{})
@@ -702,7 +702,7 @@ func TestVerification_Log_Processed_Accounts(t *testing.T) {
 	visitor := accountVerifyingVisitor{trie: trie, observer: observer, logWindow: LogWindow,
 		ctx: context.Background()}
 
-	for i := 0; i < LogWindow+1; i++ {
+	for range LogWindow + 1 {
 		visitor.Visit(accountNode, mpt.NodeInfo{})
 	}
 }

--- a/go/database/mpt/rlp/rlp.go
+++ b/go/database/mpt/rlp/rlp.go
@@ -263,7 +263,7 @@ func encodeLength(length int, offset byte, writer writer) writer {
 	}
 	numBytesForLength := getNumBytes(uint64(length))
 	writer = writer.Put(offset + 55 + numBytesForLength)
-	for i := byte(0); i < numBytesForLength; i++ {
+	for i := range numBytesForLength {
 		writer = writer.Put(byte(length >> (8 * (numBytesForLength - i - 1))))
 	}
 	return writer
@@ -392,7 +392,7 @@ func readNumber(b []byte, slen byte) (uint64, error) {
 		return 0, fmt.Errorf("expected %d bytes, got: %d", slen, len(b))
 	}
 	var s uint64
-	for i := byte(0); i < slen; i++ {
+	for i := range slen {
 		s = s<<8 | uint64(b[i])
 	}
 	return s, nil

--- a/go/database/mpt/rlp/rlp_test.go
+++ b/go/database/mpt/rlp/rlp_test.go
@@ -380,7 +380,7 @@ func forEachRlpHashTest(t *testing.T, action func(t *testing.T, rlp []byte, item
 	const size = 32
 	tests := make([]test, 0, size)
 	var hash common.Hash
-	for i := 0; i < size; i++ {
+	for i := range size {
 		hash[i] = byte(i)
 		tests = append(tests, test{hash, append([]byte{0xA0}, hash[:]...)})
 	}

--- a/go/database/mpt/shared/shared_test.go
+++ b/go/database/mpt/shared/shared_test.go
@@ -252,7 +252,7 @@ func TestShared_ConcurrentRead(t *testing.T) {
 	shared := MakeShared(10)
 	var wg sync.WaitGroup
 	wg.Add(10)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
 			defer wg.Done()
 			read := shared.GetReadHandle()
@@ -269,7 +269,7 @@ func TestShared_ConcurrentWrite(t *testing.T) {
 	shared := MakeShared(10)
 	var wg sync.WaitGroup
 	wg.Add(10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		i := i
 		go func() {
 			defer wg.Done()
@@ -289,10 +289,10 @@ func TestShared_WriteHandleSynchronizesAccess(t *testing.T) {
 	shared := MakeShared(0)
 	var wg sync.WaitGroup
 	wg.Add(N)
-	for i := 0; i < N; i++ {
+	for range N {
 		go func() {
 			defer wg.Done()
-			for i := 0; i < M; i++ {
+			for range M {
 				write := shared.GetWriteHandle()
 				cur := write.Get()
 				write.Set(cur + 1)

--- a/go/database/mpt/state_test.go
+++ b/go/database/mpt/state_test.go
@@ -85,7 +85,7 @@ func TestState_CanBeReOpened(t *testing.T) {
 	for name, open := range stateFactories {
 		t.Run(name, func(t *testing.T) {
 			dir := t.TempDir()
-			for i := 0; i < 5; i++ {
+			for range 5 {
 				state, err := open(dir)
 				if err != nil {
 					t.Fatalf("failed to open test state: %v", err)
@@ -739,7 +739,7 @@ func runFlushBenchmark(b *testing.B, config MptConfig, forceDirtyNodes bool) {
 	}
 
 	// Add some codes to be flushed.
-	for i := 0; i < numAccounts; i++ {
+	for i := range numAccounts {
 		if err := state.codes.codes.Set(common.Hash{byte(i >> 8), byte(i)}, make([]byte, 100)); err != nil {
 			b.Fatalf("failed to set code: %v", err)
 		}

--- a/go/database/mpt/tool/stress.go
+++ b/go/database/mpt/tool/stress.go
@@ -234,7 +234,7 @@ func (s *stressTestState) AddBlock(rand *rand.Rand) error {
 	)
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	for j := 0; j < changesPerBlock; j++ {
+	for range changesPerBlock {
 		// Select between insert, update, and delete operations.
 		// The proportions have been adjusted to produce a slow
 		// growth of the database and to have good chances of

--- a/go/database/mpt/verification.go
+++ b/go/database/mpt/verification.go
@@ -17,7 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
-	"sort"
+	"slices"
 
 	"github.com/0xsoniclabs/carmen/go/backend/stock"
 	"github.com/0xsoniclabs/carmen/go/backend/stock/file"
@@ -254,7 +254,7 @@ func verifyForest(directory string, config MptConfig, roots iter.Seq2[uint64, Ro
 		func(node Node) (bool, error) { return hasher.isEmbedded(node, source) },
 		func(id NodeId) bool { return id.IsBranch() },
 		func(node *BranchNode, hashes map[NodeId]common.Hash, embedded map[NodeId]bool) {
-			for i := 0; i < 16; i++ {
+			for i := range 16 {
 				child := &node.children[i]
 				if !child.Id().IsEmpty() && embedded[child.Id()] {
 					node.setEmbedded(byte(i), true)
@@ -270,7 +270,7 @@ func verifyForest(directory string, config MptConfig, roots iter.Seq2[uint64, Ro
 			node.dirtyHashes = 0
 		},
 		func(node *BranchNode, ids *nodeIdCollection) {
-			for i := 0; i < 16; i++ {
+			for i := range 16 {
 				// ID may be an embedded child, it will be determined later while hashing
 				ids.Put(node.children[i].Id())
 			}
@@ -383,9 +383,7 @@ func (n *nodeIdCollection) DrainToOrderedKeys() []NodeId {
 	n.nodeIds = make(map[NodeId]struct{}) // remove items to save space
 
 	// ... and sort
-	sort.Slice(n.nodeIdsKeys, func(i, j int) bool {
-		return n.nodeIdsKeys[i] < n.nodeIdsKeys[j]
-	})
+	slices.Sort(n.nodeIdsKeys)
 
 	return n.nodeIdsKeys
 }

--- a/go/database/mpt/verification_test.go
+++ b/go/database/mpt/verification_test.go
@@ -133,7 +133,7 @@ func TestVerification_ModifiedRootIsDetected(t *testing.T) {
 		_, encoder, _, _ := config.GetEncoders()
 
 		root := NewNodeReference(EmptyId())
-		for i := 0; i < len(roots); i++ {
+		for i := range roots {
 			if roots[i].NodeRef.Id().IsBranch() {
 				root = roots[i].NodeRef
 				break
@@ -762,7 +762,6 @@ func (c *countingWhenDoneContext) Done() <-chan struct{} {
 func runVerificationTest(t *testing.T, verify func(t *testing.T, dir string, config MptConfig, roots []Root)) {
 	t.Helper()
 	for _, config := range allMptConfigs {
-		config := config
 		t.Run(config.Name, func(t *testing.T) {
 			t.Parallel()
 			t.Helper()
@@ -830,13 +829,13 @@ func fillTestForest(dir string, config MptConfig) (roots []Root, err error) {
 	}
 
 	root := NewNodeReference(EmptyId())
-	for i := 0; i < N; i++ {
+	for i := range N {
 		addr := common.Address{byte(i)}
 		root, err = forest.SetAccountInfo(&root, addr, AccountInfo{Nonce: common.ToNonce(1), CodeHash: common.Keccak256([]byte{1})})
 		if err != nil {
 			return nil, err
 		}
-		for j := 0; j < N; j++ {
+		for j := range N {
 			root, err = forest.SetValue(&root, addr, common.Key{byte(j)}, common.Value{byte(i + j + 1)})
 			if err != nil {
 				return nil, err

--- a/go/database/mpt/write_buffer.go
+++ b/go/database/mpt/write_buffer.go
@@ -15,7 +15,7 @@ package mpt
 import (
 	"errors"
 	"runtime"
-	"sort"
+	"slices"
 	"sync"
 
 	"github.com/0xsoniclabs/carmen/go/database/mpt/shared"
@@ -208,7 +208,7 @@ func (b *writeBuffer) tryEmptyBuffer() {
 	b.bufferMutex.Unlock()
 
 	// Sort IDs to minimize disk seeks.
-	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	slices.Sort(ids)
 
 	// Flush all nodes of current patch.
 	for i := 0; i < len(ids); i++ {

--- a/go/database/mpt/write_buffer_test.go
+++ b/go/database/mpt/write_buffer_test.go
@@ -94,7 +94,7 @@ func TestWriteBuffer_CanFlushLargeNumberOfElements(t *testing.T) {
 	N := 1000
 
 	// Setup expectations
-	for i := 0; i < N; i++ {
+	for i := range N {
 		sink.EXPECT().Write(ValueId(uint64(i)), gomock.Any())
 	}
 
@@ -102,7 +102,7 @@ func TestWriteBuffer_CanFlushLargeNumberOfElements(t *testing.T) {
 	defer func() { require.NoError(t, buffer.Close()) }()
 
 	// Send in N nodes to be written to the sink.
-	for i := 0; i < N; i++ {
+	for i := range N {
 		buffer.Add(ValueId(uint64(i)), shared.MakeShared[Node](&ValueNode{}))
 	}
 
@@ -139,7 +139,7 @@ func TestWriteBuffer_AllQueuedEntriesArePresentUntilWritten(t *testing.T) {
 	})
 
 	node := shared.MakeShared[Node](EmptyNode{})
-	for i := 0; i < N; i++ {
+	for i := range N {
 		id := ValueId(uint64(i))
 		buffer.Add(id, node)
 		enqueuedLock.Lock()
@@ -219,7 +219,7 @@ func TestWriteBuffer_ElementsCanBeAddedInParallel(t *testing.T) {
 	N := 1000
 
 	// Setup expectations
-	for i := 0; i < N; i++ {
+	for i := range N {
 		sink.EXPECT().Write(ValueId(uint64(i)), gomock.Any())
 	}
 
@@ -232,7 +232,7 @@ func TestWriteBuffer_ElementsCanBeAddedInParallel(t *testing.T) {
 	for j := 0; j < N/100; j++ {
 		go func(j int) {
 			defer wg.Done()
-			for i := 0; i < 100; i++ {
+			for i := range 100 {
 				buffer.Add(ValueId(uint64(j*100+i)), shared.MakeShared[Node](&ValueNode{}))
 			}
 		}(j)
@@ -262,10 +262,10 @@ func TestWriteBuffer_ElementsCanBeAddedAndCanceledInParallel(t *testing.T) {
 	for j := 0; j < N/100; j++ {
 		go func(j int) {
 			defer wg.Done()
-			for i := 0; i < 100; i++ {
+			for i := range 100 {
 				buffer.Add(ValueId(uint64(j*100+i)), shared.MakeShared[Node](&ValueNode{}))
 			}
-			for i := 0; i < 100; i++ {
+			for i := range 100 {
 				buffer.Cancel(ValueId(uint64(j*100 + i)))
 			}
 		}(j)
@@ -420,7 +420,7 @@ func TestWriteBuffer_Add_Cancel_Empty_DoesNotLock(t *testing.T) {
 
 	started.Wait()
 	const loops = 10_000_000
-	for i := 0; i < loops; i++ {
+	for range loops {
 		buffer.Add(id, node)
 	}
 

--- a/go/database/vt/benchmark_test.go
+++ b/go/database/vt/benchmark_test.go
@@ -34,7 +34,7 @@ func Benchmark_VerkleTrie_Commit_To_InnerNode_All_Leaves_Updated(b *testing.B) {
 	var counter int
 	for i := 0; i < b.N; i++ {
 		// modify all values in one leaf
-		for j := 0; j < verkle.NodeWidth; j++ {
+		for j := range verkle.NodeWidth {
 			var key common.Key
 			key[0] = byte(j) // set first byte to insert at one branch at each iteration, updating all leaves
 			value := common.Value{byte(counter), byte(counter >> 8), byte(counter >> 16), byte(counter >> 24), 0x1}
@@ -83,7 +83,7 @@ func Benchmark_VerkleTrie_Commit_To_LeafNode_Update_All_Values(b *testing.B) {
 
 	var counter int
 	for i := 0; i < b.N; i++ {
-		for j := 0; j < verkle.NodeWidth; j++ {
+		for j := range verkle.NodeWidth {
 			var key common.Key
 			key[31] = byte(j) // set the last byte to insert at one value of the first leaf
 			value := common.Value{byte(counter), byte(counter >> 8), byte(counter >> 16), byte(counter >> 24), 0x1}
@@ -133,7 +133,7 @@ func Benchmark_VerkleTrie_Hash_Key_No_Cache(b *testing.B) {
 
 func createTestNode_One_Inner_Node_With_Full_Leaves_Space() (*verkle.InternalNode, error) {
 	root := verkle.New().(*verkle.InternalNode)
-	for i := 0; i < verkle.NodeWidth; i++ {
+	for i := range verkle.NodeWidth {
 		key := common.Key{byte(i)} // set the first byte to insert at different branch at each iteration
 		value := common.Value{byte(i)}
 

--- a/go/database/vt/commit/benchmarks_test.go
+++ b/go/database/vt/commit/benchmarks_test.go
@@ -79,7 +79,7 @@ func Benchmark_PolyMultiCommit(b *testing.B) {
 	for _, i := range []int{64, 256} {
 		b.Run(fmt.Sprintf("values=%d", i), func(b *testing.B) {
 			poly := make([]banderwagon.Fr, VectorSize)
-			for j := 0; j < i; j++ {
+			for j := range i {
 				poly[j] = random
 			}
 			for b.Loop() {
@@ -95,14 +95,14 @@ func Benchmark_CommitAdd(b *testing.B) {
 	config := getConfig() // < the polynomial commit "engine"
 
 	poly := make([]banderwagon.Fr, VectorSize)
-	for i := 0; i < VectorSize; i++ {
+	for i := range VectorSize {
 		poly[i] = random
 	}
 	c1 := config.Commit(poly)
 
 	var c1v banderwagon.Fr
 	c1.MapToScalarField(&c1v)
-	for i := 0; i < VectorSize; i++ {
+	for i := range VectorSize {
 		poly[i] = c1v
 	}
 	c2 := config.Commit(poly)

--- a/go/database/vt/geth/state.go
+++ b/go/database/vt/geth/state.go
@@ -532,10 +532,7 @@ func ChunkifyCode(code []byte) ChunkedCode {
 	chunks := make([]byte, chunkCount*32)
 	for i := 0; i < chunkCount; i++ {
 		// number of bytes to copy, 31 unless the end of the code has been reached.
-		end := 31 * (i + 1)
-		if len(code) < end {
-			end = len(code)
-		}
+		end := min(len(code), 31*(i+1))
 		copy(chunks[i*32+1:], code[31*i:end]) // copy the code itself
 
 		// chunk offset = taken from the last chunk.

--- a/go/database/vt/state_test.go
+++ b/go/database/vt/state_test.go
@@ -92,9 +92,9 @@ func TestState_CreateAccounts_In_Blocks_Accounts_Updated(t *testing.T) {
 
 			const numBlocks = 10
 			const numInsertsPerBlock = 10
-			for i := 0; i < numBlocks; i++ {
+			for i := range numBlocks {
 				update := common.Update{}
-				for j := 0; j < numInsertsPerBlock; j++ {
+				for j := range numInsertsPerBlock {
 					addr := common.Address{byte(j), byte(j >> 8)}
 					update.Nonces = append(update.Nonces, common.NonceUpdate{Account: addr, Nonce: common.ToNonce(uint64(i * j))})
 					update.Balances = append(update.Balances, common.BalanceUpdate{Account: addr, Balance: amount.New(uint64(i * j))})
@@ -109,7 +109,7 @@ func TestState_CreateAccounts_In_Blocks_Accounts_Updated(t *testing.T) {
 				require.NotEmpty(t, hash, "hash should not be empty for block %d", i)
 
 				// check basic properties of accounts
-				for j := 0; j < numInsertsPerBlock; j++ {
+				for j := range numInsertsPerBlock {
 					addr := common.Address{byte(j), byte(j >> 8)}
 
 					nonce, err := state.GetNonce(addr)
@@ -143,9 +143,9 @@ func TestState_Storage_Can_Set_And_Receive(t *testing.T) {
 			const numAddresses = 10
 			const numKeysPerAddress = 10
 			update := common.Update{}
-			for i := 0; i < numAddresses; i++ {
+			for i := range numAddresses {
 				addr := common.Address{byte(i), byte(i >> 8)}
-				for j := 0; j < numKeysPerAddress; j++ {
+				for j := range numKeysPerAddress {
 					key := common.Key{byte(i), byte(i >> 8), byte(j), byte(j >> 8)}
 					value := common.Value{byte(i), byte(i >> 8), byte(j), byte(j >> 8)}
 					update.Codes = append(update.Codes, common.CodeUpdate{Account: addr, Code: []byte{}})
@@ -161,9 +161,9 @@ func TestState_Storage_Can_Set_And_Receive(t *testing.T) {
 			require.NotEmpty(t, hash, "hash should not be empty for block")
 
 			// check storage properties
-			for i := 0; i < numAddresses; i++ {
+			for i := range numAddresses {
 				addr := common.Address{byte(i), byte(i >> 8)}
-				for j := 0; j < numKeysPerAddress; j++ {
+				for j := range numKeysPerAddress {
 					key := common.Key{byte(i), byte(i >> 8), byte(j), byte(j >> 8)}
 					expectedValue := common.Value{byte(i), byte(i >> 8), byte(j), byte(j >> 8)}
 
@@ -209,7 +209,7 @@ func TestState_Code_Can_Set_And_Receive(t *testing.T) {
 				const numOfCodes = 10
 				expectedCodes := [numOfCodes][]byte{}
 				update := common.Update{}
-				for i := 0; i < numOfCodes; i++ {
+				for i := range numOfCodes {
 					addr := common.Address{byte(i), byte(i >> 8)}
 					update.Codes = append(update.Codes, common.CodeUpdate{
 						Account: addr,
@@ -228,7 +228,7 @@ func TestState_Code_Can_Set_And_Receive(t *testing.T) {
 				require.NoError(t, err, "failed to get hash for block")
 				require.NotEmpty(t, hash, "hash should not be empty for block")
 
-				for i := 0; i < numOfCodes; i++ {
+				for i := range numOfCodes {
 					addr := common.Address{byte(i), byte(i >> 8)}
 
 					code, err := state.GetCode(addr)

--- a/go/database/vt/utils/verkle.go
+++ b/go/database/vt/utils/verkle.go
@@ -159,7 +159,7 @@ func GetTreeKeyWithEvaluatedAddress(evaluated *verkle.Point, treeIndex *uint256.
 
 	// little-endian, 32-byte aligned treeIndex
 	var index [32]byte
-	for i := 0; i < len(treeIndex); i++ {
+	for i := range len(treeIndex) {
 		binary.LittleEndian.PutUint64(index[i*8:(i+1)*8], treeIndex[i])
 	}
 	// FromLEBytes cannot fail: 16-byte inputs are always smaller than the 256-bit field modulus.

--- a/go/state/configurations_test.go
+++ b/go/state/configurations_test.go
@@ -36,8 +36,6 @@ func TestStateConfigs_AllSetupsCreateDataInCorrectDirectories(t *testing.T) {
 	// in the correct sub-directories (live/ and archive/) and do not store
 	// any data in the root directory.
 	for config, factory := range state.GetAllRegisteredStateFactories() {
-		config := config
-		factory := factory
 		t.Run(config.String(), func(t *testing.T) {
 			if config.Schema == 0 || config.Schema == 6 {
 				switch strings.TrimSuffix(string(config.Variant), "-flat") {

--- a/go/state/flush_benchmark_test.go
+++ b/go/state/flush_benchmark_test.go
@@ -38,7 +38,7 @@ func BenchmarkFlushGoState(b *testing.B) {
 
 	for n := uint64(0); n < uint64(b.N); n++ {
 		update := common.Update{}
-		for i := 0; i < 10_000; i++ {
+		for i := range 10_000 {
 			update.AppendBalanceUpdate(common.Address{
 				byte(n >> 24), byte(n >> 16), byte(n >> 8), byte(n),
 				byte(i >> 24), byte(i >> 16), byte(i >> 8), byte(i),

--- a/go/state/gostate/go_schema5_test.go
+++ b/go/state/gostate/go_schema5_test.go
@@ -49,7 +49,7 @@ func TestScheme5_Archive_And_Live_Must_Be_InSync(t *testing.T) {
 		t.Fatalf("failed to open database: %v", err)
 	}
 	const blocks = 10
-	for i := 0; i < blocks; i++ {
+	for i := range blocks {
 		addBlock(uint64(i), db)
 	}
 
@@ -77,7 +77,7 @@ func TestScheme5_Archive_And_Live_Must_Be_InSync(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open database: %v", err)
 	}
-	for i := 0; i < blocks; i++ {
+	for i := range blocks {
 		addBlock(uint64(i+blocks), db)
 	}
 
@@ -122,7 +122,7 @@ func TestCarmen_Empty_Archive_And_Live_Must_Be_InSync(t *testing.T) {
 		t.Fatalf("failed to open database: %v", err)
 	}
 	const blocks = 10
-	for i := 0; i < blocks; i++ {
+	for i := range blocks {
 		block := uint64(i)
 		update := common.Update{
 			Balances: []common.BalanceUpdate{{Account: common.Address{byte(block)}, Balance: amount.New(100)}},

--- a/go/state/gostate/go_state_test.go
+++ b/go/state/gostate/go_state_test.go
@@ -274,7 +274,7 @@ func TestHashing(t *testing.T) {
 	}
 
 	// check all final hashes for each schema are the same
-	for schema := 0; schema < len(hashes); schema++ {
+	for schema := range hashes {
 		for i := 0; i < len(hashes[schema])-1; i++ {
 			if hashes[schema][i] != hashes[schema][i+1] {
 				t.Errorf("hashes differ in schema %d", schema)
@@ -433,7 +433,7 @@ func TestStateDB_AddBlock_CannotCallRepeatedly_OnError(t *testing.T) {
 	db := newGoState(liveDB, nil, []func(){})
 
 	stateDB := state.CreateStateDBUsing(db)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		runAddBlock(uint64(i), stateDB)
 		if err := stateDB.Check(); !errors.Is(err, injectedErr) {
 			t.Errorf("each operation should fail: %v", err)
@@ -460,7 +460,7 @@ func TestState_Flush_Or_Close_Corrupted_State_Detected(t *testing.T) {
 	}
 
 	// the same result many times
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if _, err := db.Apply(uint64(i), update); !errors.Is(err, injectedErr) {
 			t.Errorf("operation should fail: %v", err)
 		}
@@ -490,7 +490,7 @@ func TestState_Flush_Or_Close_Corrupted_Archive_Detected(t *testing.T) {
 	db := newGoState(liveDB, archiveDB, []func(){})
 
 	// the same result many times
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		if err := db.Close(); !errors.Is(err, injectedErr) {
 			t.Errorf("operation should fail: %v", err)
 		}
@@ -514,7 +514,7 @@ func TestState_Apply_CannotCallRepeatedly_OnError(t *testing.T) {
 
 	db := newGoState(liveDB, nil, []func(){})
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		update := common.Update{
 			Balances: []common.BalanceUpdate{{Account: common.Address{0xA}, Balance: amount.New(10)}},
 		}
@@ -694,7 +694,7 @@ func TestState_All_Live_Operations_May_Cause_Failure(t *testing.T) {
 	injectedErr := fmt.Errorf("injectedError")
 
 	const loops = 10
-	for i := 0; i < loops; i++ {
+	for i := range loops {
 		i := i
 		t.Run(fmt.Sprintf("operation_%d", i), func(t *testing.T) {
 			t.Parallel()
@@ -718,7 +718,7 @@ func TestState_All_Live_Operations_May_Cause_Failure(t *testing.T) {
 			// calls must succeed until the first failure,
 			// repeated calls must all fail
 			var shouldFail bool
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				shouldFail = shouldFail || errors.Is(results[0], injectedErr)
 				if _, err := db.GetBalance(addr); shouldFail && !errors.Is(err, injectedErr) {
 					t.Errorf("operation should fail")
@@ -779,7 +779,7 @@ func TestState_All_Archive_Operations_May_Cause_Failure(t *testing.T) {
 
 	db := newGoState(liveDB, archiveDB, []func(){})
 	// repeated calls must all fail
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		if _, err := db.GetArchiveState(0); !errors.Is(err, injectedErr) {
 			t.Errorf("calling archive should fail")
 		}
@@ -789,7 +789,7 @@ func TestState_All_Archive_Operations_May_Cause_Failure(t *testing.T) {
 	}
 	// swap calls
 	db = newGoState(liveDB, archiveDB, []func(){})
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		if _, _, err := db.GetArchiveBlockHeight(); !errors.Is(err, injectedErr) {
 			t.Errorf("calling archive should fail")
 		}

--- a/go/state/state_db_and_state_test.go
+++ b/go/state/state_db_and_state_test.go
@@ -38,7 +38,6 @@ func TestCarmen_CanHandleMaximumBalance(t *testing.T) {
 	maxBalance := amount.New(0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF) // Balance is max 16bytes
 
 	for _, config := range initStates() {
-		config := config
 		t.Run(config.name(), func(t *testing.T) {
 			t.Parallel()
 			dir := t.TempDir()
@@ -183,7 +182,7 @@ func TestCarmenThereCanBeMultipleBulkLoadPhasesOnRealState(t *testing.T) {
 				}
 			}()
 
-			for i := 0; i < 10; i++ {
+			for i := range 10 {
 				load := db.StartBulkLoad(uint64(i))
 				load.CreateAccount(address1)
 				load.SetNonce(address1, uint64(i))
@@ -215,7 +214,7 @@ func TestCarmenBulkLoadsCanBeInterleavedWithRegularUpdates(t *testing.T) {
 				}
 			}()
 
-			for i := 0; i < 5; i++ {
+			for i := range 5 {
 				// Run a bulk-load update (creates one block)
 				load := db.StartBulkLoad(uint64(i * 2))
 				address := common.Address{byte(i + 1)}
@@ -261,9 +260,8 @@ func testCarmenStateDbHashAfterModification(t *testing.T, mod func(s state.State
 		ref.EndBlock(0)
 		want[s] = ref.GetHash()
 	}
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		for _, config := range initStates() {
-			config := config
 			if strings.Contains(config.name(), "geth-leveldb") {
 				// This is the only implementation that sets the empty code hash by default.
 				// Therefore tests not modifying the code will fail.
@@ -406,7 +404,7 @@ func TestPersistentStateDB(t *testing.T) {
 			stateDb.SetCode(address1, []byte{1, 2, 3})
 
 			// insert number of slots to address 1
-			for i := 0; i < numSlots; i++ {
+			for i := range numSlots {
 				val := toVal(uint64(i))
 				stateDb.SetState(address1, toKey(uint64(i)), val)
 			}
@@ -422,7 +420,7 @@ func TestPersistentStateDB(t *testing.T) {
 			stateDb.SetCode(address2, []byte{3, 2, 1})
 
 			// insert number of slots to address 2
-			for i := 0; i < numSlots; i++ {
+			for i := range numSlots {
 				val := toVal(uint64(i + numSlots))
 				stateDb.SetState(address2, toKey(uint64(i)), val)
 			}
@@ -487,7 +485,7 @@ func TestStateDBRead(t *testing.T) {
 	}
 
 	// slots in address 1
-	for i := 0; i < numSlots; i++ {
+	for i := range numSlots {
 		val := toVal(uint64(i))
 		key := toKey(uint64(i))
 		if storage := stateDb.GetState(address1, key); storage != val {
@@ -496,7 +494,7 @@ func TestStateDBRead(t *testing.T) {
 	}
 
 	// slots in address 2
-	for i := 0; i < numSlots; i++ {
+	for i := range numSlots {
 		val := toVal(uint64(i + numSlots))
 		key := toKey(uint64(i))
 		if storage := stateDb.GetState(address2, key); storage != val {
@@ -630,7 +628,6 @@ func TestStateDBSupportsConcurrentAccesses(t *testing.T) {
 	const N = 10  // number of concurrent goroutines
 	const M = 100 // number of updates per goroutine
 	for _, config := range initStates() {
-		config := config
 		t.Run(config.name(), func(t *testing.T) {
 			t.Parallel()
 			dir := t.TempDir()
@@ -649,7 +646,7 @@ func TestStateDBSupportsConcurrentAccesses(t *testing.T) {
 			ready.Add(N)
 			done := sync.WaitGroup{}
 			done.Add(N)
-			for i := 0; i < N; i++ {
+			for i := range N {
 				isPrimary := i == 0
 				go func() {
 					defer done.Done()
@@ -665,7 +662,7 @@ func TestStateDBSupportsConcurrentAccesses(t *testing.T) {
 
 					// Perform concurrent accesses.
 					block := 0
-					for j := 0; j < M; j++ {
+					for range M {
 						if isPrimary {
 							stateDb.(state.StateDB).BeginBlock()
 						}

--- a/go/state/state_db_test.go
+++ b/go/state/state_db_test.go
@@ -2404,7 +2404,7 @@ func TestStateDB_CodeCanBeUpdated_In_Each_Block(t *testing.T) {
 	gomock.InOrder(getCodeCalls...)
 	gomock.InOrder(getCodeHashCalls...)
 
-	for i := 0; i < len(codes); i++ {
+	for i := range codes {
 		db.BeginBlock()
 		db.BeginTransaction()
 		db.SetCode(address1, codes[i])
@@ -2438,7 +2438,7 @@ func TestStateDB_CodeCanBeUpdated_In_One_Block(t *testing.T) {
 	mock.EXPECT().GetCode(address1).Return(codes[len(codes)-1], nil)
 
 	db.BeginBlock()
-	for i := 0; i < len(codes); i++ {
+	for i := range codes {
 		db.BeginTransaction()
 		db.SetCode(address1, codes[i])
 		checkCode(t, db, address1, codes[i], hashes[i]) // available in the same transaction
@@ -2473,7 +2473,7 @@ func TestStateDB_CodeCanBeUpdated_In_One_Transaction(t *testing.T) {
 
 	db.BeginBlock()
 	db.BeginTransaction()
-	for i := 0; i < len(codes); i++ {
+	for i := range codes {
 		db.SetCode(address1, codes[i])
 		checkCode(t, db, address1, codes[i], hashes[i]) // available in the same transaction
 	}
@@ -3809,7 +3809,7 @@ func TestStateDB_GetArchiveStateDbRecyclesNonCommittableStateDbInstances(t *test
 	// This test aims to verify that a released StateDB is recycled.
 	reuseSeen := false
 	seen := map[*stateDB]struct{}{}
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		history, err := db.GetArchiveStateDB(12)
 		if err != nil {
 			t.Fatalf("Unexpected error during archive lookup: %v", err)
@@ -4067,7 +4067,7 @@ func TestStateDB_ThereCanBeMultipleBulkLoadPhases(t *testing.T) {
 		return future.Immediate(result.Ok(common.Hash{}))
 	})
 
-	for i := 0; i < N; i++ {
+	for i := range N {
 		load := db.StartBulkLoad(uint64(i))
 		load.CreateAccount(address1)
 		load.SetNonce(address1, uint64(i))
@@ -4606,7 +4606,7 @@ func TestStateDB_resetReincarnationWhenExceeds_DoesNotResetBelowLimit(t *testing
 		storedDataCache: common.NewLruCache[slotId, storedDataCacheValue](limit),
 	}
 
-	for i := 0; i < limit; i++ {
+	for i := range limit {
 		s.reincarnation[common.Address{byte(i)}] = uint64(i)
 		s.storedDataCache.Set(
 			slotId{common.Address{byte(i)}, common.Key{byte(i)}},
@@ -4645,7 +4645,7 @@ func TestStateDB_resetReincarnationWhenExceeds_ResetAboveLimit(t *testing.T) {
 				storedDataCache: common.NewLruCache[slotId, storedDataCacheValue](limit),
 			}
 
-			for i := 0; i < limit; i++ {
+			for i := range limit {
 				s.reincarnation[common.Address{byte(i)}] = uint64(i)
 				s.storedDataCache.Set(
 					slotId{common.Address{byte(i)}, common.Key{byte(i)}},

--- a/go/state/state_test.go
+++ b/go/state/state_test.go
@@ -279,9 +279,9 @@ func TestMultipleCodeUpdateHashes(t *testing.T) {
 func TestLargeStateHashes(t *testing.T) {
 	testHashAfterModification(t, func(t *testing.T, schema state.Schema, s state.State) {
 		update := common.Update{}
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			address := common.Address{byte(i)}
-			for j := 0; j < 100; j++ {
+			for j := range 100 {
 				key := common.Key{byte(j)}
 				update.Slots = append(update.Slots, common.SlotUpdate{Account: address, Key: key, Value: common.Value{byte(i), 0, 0, byte(j)}})
 			}

--- a/go/state/tool/benchmark.go
+++ b/go/state/tool/benchmark.go
@@ -253,8 +253,8 @@ func runBenchmarkState(
 		"Simulating %d blocks with %d reads and %d inserts each",
 		numBlocks, numReadsPerBlock, numInsertsPerBlock,
 	)
-	for i := 0; i < numBlocks; i++ {
-		for j := 0; j < numReadsPerBlock; j++ {
+	for i := range numBlocks {
+		for range numReadsPerBlock {
 			addr := common.Address{byte(counter), byte(counter >> 8), byte(counter >> 16), byte(counter >> 24), byte(counter >> 32)}
 			if _, err := state.GetBalance(addr); err != nil {
 				return res, fmt.Errorf("error reading balance for account %x at block %d: %v", addr, i, err)
@@ -262,7 +262,7 @@ func runBenchmarkState(
 			counter++
 		}
 		update := common.Update{}
-		for j := 0; j < numInsertsPerBlock; j++ {
+		for range numInsertsPerBlock {
 			addr := common.Address{byte(counter), byte(counter >> 8), byte(counter >> 16), byte(counter >> 24), byte(counter >> 32)}
 			update.Nonces = append(update.Nonces, common.NonceUpdate{Account: addr, Nonce: common.ToNonce(1)})
 			counter++


### PR DESCRIPTION
This PR modernizes the code by using the `go fix` command.

This was run with `go 1.27rc`, as the one included in `go 1.26.3` includes a bug which does not declare variables after substituing a map loop copy with `maps.Collect`